### PR TITLE
chore(harness): adapt .claude/, add CLAUDE.md/README, bootstrap SDD

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,0 +1,86 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What is the Jentic API Scorecard?
+
+A zero-install CLI that scores an OpenAPI document against the Jentic API AI Readiness Framework (JAIRF) and prints a Jentic API Readiness Scorecard. Distribution: an npm package (`@jentic/api-scorecard`) that orchestrates a public Docker image (`ghcr.io/jentic/jentic-api-scorecard`). The CLI fully abstracts image management; no backend service is in the loop. See @../docs/architecture.md — that document is the **single source of truth** for product, architecture, and decisions; do not duplicate its content here or in memory.
+
+## Repository state today
+
+- **`docker/`** — the only code that exists. A Python 3.12 + uv runner image that wraps `jentic-apitools-cli` (the JAIRF scoring engine). This is everything that ships in v0.1.
+- **`packages/`** — does **not** exist yet. The TypeScript CLI (`@jentic/api-scorecard`) and a stub HTML renderer are on the roadmap per @../docs/architecture.md §4.
+- **`docs/architecture.md`** — the architecture document and the source of truth for every product/architectural claim.
+- **`specs/`** — does not exist yet. Spec-Driven Development (`/sdd-create-constitution`) bootstraps `specs/mission.md`, `specs/tech-stack.md`, `specs/roadmap.md` from current repository evidence; until that runs, there is no constitution.
+
+When you read this file and find a mismatch with what's on disk (e.g. `packages/` now exists, `specs/` is populated), update this file in the same change.
+
+## Architecture
+
+### Container entrypoint and order (CRITICAL)
+
+`docker/src/jentic_scorecard_runner/__main__.py` runs three stages in this order:
+
+1. Parse `score [--url <url>] [--with-llm]` (or read bundled spec JSON from stdin if `--url` is absent).
+2. **Gate check** — `gate.check_gate(url)` decides whether the request is allowed.
+3. **Score** — `score.run_score(url, with_llm)` invokes `jentic-apitools score …` and streams the JSON result to stdout.
+
+**The gate MUST run before the engine.** If you reorder the two, anonymous inputs reach the scoring engine without the URL allowlist enforcement, defeating the auth model in @../docs/architecture.md §9. Symptom: `--url` to a non-allowlisted host returns a normal score instead of exit code 3.
+
+### Auth and the gate (`docker/src/jentic_scorecard_runner/gate.py`)
+
+| `JENTIC_API_KEY` | Effect |
+|---|---|
+| Unset | Anonymous mode — only URLs matching `https://raw.githubusercontent.com/jentic/jentic-public-apis/refs/heads/main/apis/openapi/` are allowed; stdin inputs are rejected. |
+| `mvp-preview` | All inputs allowed. This is the documented public placeholder for Delivery 1 — **not a secret**, see @../docs/architecture.md §9. |
+| Anything else | Rejected with a guidance message pointing back at `mvp-preview`. |
+
+The allowlist regex lives in `gate.py` as `_ALLOWLIST_PATTERN`. The placeholder key value lives in `gate.py` as `_MVP_KEY`. Real key issuance (HTTP validation against `api.jentic.com`) is deferred to a follow-up delivery; until then, do not extend the gate to add new accepted values.
+
+### Scoring (`docker/src/jentic_scorecard_runner/score.py`)
+
+`run_score` shells out to `jentic-apitools score <target> --format json --include-diagnostics --quiet` (with `--enable-llm-analysis` when `--with-llm`). URL inputs are passed through verbatim; stdin inputs are written to a tempfile first and the path is passed to the engine. Engine timeout is 300s. Engine exit code 2 is mapped to `ExitCode.SPEC_FAILURE` (5); any other non-zero is `ExitCode.ENGINE_FAILURE` (6).
+
+### Exit codes (`docker/src/jentic_scorecard_runner/exit_codes.py`)
+
+`SUCCESS=0`, `GENERIC_ERROR=1`, `AUTH_INVALID_KEY=2`, `GATE_REJECTED=3`, `SPEC_FAILURE=5`, `ENGINE_FAILURE=6`. These are part of the public CLI contract — see @../docs/architecture.md §6 before changing values.
+
+### Image build (`docker/Dockerfile`)
+
+Multi-stage `python:3.12-slim` + `node:24-slim` (engine spawns Redocly / Spectral / Speclynx via `npx`). `uv sync --frozen --no-dev --no-install-project` installs the engine. The build runs a real score against `docker/.build/sample.yaml` to warm the npm cache so the first user-facing run doesn't pay validator-download cost. Entrypoint: `uv run python -m jentic_scorecard_runner`.
+
+## Common commands
+
+All Python tooling resolves from inside `docker/` — `pyproject.toml` and `poethepoet` are not at the repo root, so `uv run poe …` from the root fails with `Failed to spawn: poe`.
+
+| Task | Command |
+|---|---|
+| Run tests | `cd docker && uv run poe test` |
+| Run a subset | `cd docker && uv run poe test tests/test_gate.py` |
+| Lint check | `cd docker && uv run poe lint` |
+| Lint fix | `cd docker && uv run poe lint:fix` |
+| Build the image | `docker build -t jentic-scorecard:dev ./docker` |
+| Smoke an allowlisted URL | `docker run --rm jentic-scorecard:dev score --url https://raw.githubusercontent.com/jentic/jentic-public-apis/refs/heads/main/apis/openapi/<path>` |
+| Smoke from stdin | `cat openapi.json \| docker run -i --rm -e JENTIC_API_KEY=mvp-preview jentic-scorecard:dev score` |
+
+Tests use pytest, no mocking — `tests/test_main.py` and `tests/test_gate.py` exercise the runner directly; `tests/test_integration.py` exercises the engine end-to-end.
+
+## Harness layout (`.claude/`)
+
+- **`rules/`** — always-on guidance. `git-workflow.md` (branches, atomic commits, DCO sign-off, `Refs #N` vs `Closes #N`), `conventional-commits.md` (header format, ≤69 chars, scopes), `python-code-style.md` (ruff, top-level imports only, modern type syntax), `karpathy-guidelines.md` (think before coding, simplicity, surgical changes), `sdd-constitution.md` (SDD workflow), `review-auto-apply.md` + `copilot-review-comments.md` (review behavior).
+- **`hooks/`** — `commitlint-before-commit.py` (PreToolUse) blocks malformed `git commit -m` payloads; soft no-op until `node_modules/.bin/commitlint` is installed at the repo root. `ruff-fix.sh` (PostToolUse) runs `cd docker && uv run ruff check --fix && uv run ruff format` on every edited `.py` file.
+- **`skills/`** — invokable slash commands. SDD: `/sdd-create-constitution`, `/sdd-new-phase`, `/sdd-new-spec`, `/sdd-implement-spec`, `/sdd-distill-lessons`. Review: `/review-community` (someone else's PR with the diplomatic tone in `output-styles/review-comments.md`).
+- **`templates/sdd/`** — structural scaffolds for constitution and feature-spec files. `/sdd-create-constitution` and `/sdd-new-spec` consume these.
+- **`worktrees/`** — git-worktree mount points (gitignored content; only `.gitkeep` is tracked).
+- **`output-styles/review-comments.md`** — diplomatic-review tone, used as a turn-instruction overlay by `/review-community`.
+
+## Conventions
+
+- **Branch + PR for every change.** No direct push to `main` — branch (`feat/`, `fix/`, `chore/`, `docs/`, `test/`), commit there, push, open a PR via `gh pr create`. PRs are squash-merged; the squash header must follow Conventional Commits.
+- **Atomic commits, DCO sign-off.** `git commit -s`. One logical change per commit. Header ≤69 chars; scope reflects the primary subject (e.g. `feat(gate): allow github-raw spec URLs anonymously`, `fix(score): handle engine timeout cleanly`).
+- **No mocking in tests.** Hit the real CLI / real engine; tests are organized around behavior at the runner boundary.
+- **Python 3.12 type syntax.** `list[str]`, `dict[str, int]`, `X | None`. No `typing.List` / `typing.Optional`. All imports at module top (ruff `PLC0415`). Don't import other modules' `_private` names (ruff `PLC2701`).
+
+## Open scope
+
+When something needs to ship that doesn't fit the items above (a new CI workflow, the first npm package, a new docs file), align with `docs/architecture.md` first. If the architecture doc disagrees with what you're about to build, update the doc in the same PR — the doc is canonical, not aspirational.

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -11,7 +11,7 @@ A zero-install CLI that scores an OpenAPI document against the Jentic API AI Rea
 - **`docker/`** — the only code that exists. A Python 3.12 + uv runner image that wraps `jentic-apitools-cli` (the JAIRF scoring engine). This is everything that ships in v0.1.
 - **`packages/`** — does **not** exist yet. The TypeScript CLI (`@jentic/api-scorecard`) and a stub HTML renderer are on the roadmap per @../docs/architecture.md §4.
 - **`docs/architecture.md`** — the architecture document and the source of truth for every product/architectural claim.
-- **`specs/`** — does not exist yet. Spec-Driven Development (`/sdd-create-constitution`) bootstraps `specs/mission.md`, `specs/tech-stack.md`, `specs/roadmap.md` from current repository evidence; until that runs, there is no constitution.
+- **`specs/`** — the SDD constitution: `specs/mission.md`, `specs/tech-stack.md`, `specs/roadmap.md` (plus an empty `specs/lessons.md` placeholder that `/sdd-distill-lessons` will fill once retrospectives land). The constitution captures load-bearing invariants and points at `docs/architecture.md` for operational detail. Bootstrapped via `/sdd-create-constitution`; future phases append via `/sdd-new-phase` and materialize via `/sdd-new-spec`.
 
 When you read this file and find a mismatch with what's on disk (e.g. `packages/` now exists, `specs/` is populated), update this file in the same change.
 

--- a/.claude/hooks/commitlint-before-commit.py
+++ b/.claude/hooks/commitlint-before-commit.py
@@ -30,7 +30,8 @@ def emit_deny(reason: str) -> None:
 
 
 def extract_message(command: str) -> str | None:
-    # Pattern: -m "$(cat <<'DELIM' ... DELIM)" — what Claude's CLAUDE.md prescribes.
+    # Pattern: -m "$(cat <<'DELIM' ... DELIM)" — the HEREDOC form Claude Code emits for
+    # multi-line commit messages (so commit-message formatting survives shell quoting).
     # Terminator anchored to start of line (MULTILINE); `<<-` form allows leading tabs/spaces.
     m = re.search(
         r"-m\s+\"?\$\(\s*cat\s+<<(-?)\s*['\"]?(\w+)['\"]?\s*\n(.*?)\n[\t ]*\2\s*$",

--- a/.claude/hooks/commitlint-before-commit.py
+++ b/.claude/hooks/commitlint-before-commit.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+# PreToolUse hook: validate Conventional Commits before Claude fires `git commit`.
+# Reads Claude Code's tool-input JSON from stdin. On a malformed message, emits
+# a `permissionDecision: deny` JSON so the bash command never runs.
+# Mirrors what .husky/commit-msg enforces for human/CI commits.
+import json
+import re
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+COMMITLINT_BIN = REPO_ROOT / "node_modules" / ".bin" / "commitlint"
+
+
+def emit_deny(reason: str) -> None:
+    print(
+        json.dumps(
+            {
+                "hookSpecificOutput": {
+                    "hookEventName": "PreToolUse",
+                    "permissionDecision": "deny",
+                    "permissionDecisionReason": reason,
+                }
+            }
+        )
+    )
+
+
+def extract_message(command: str) -> str | None:
+    # Pattern: -m "$(cat <<'DELIM' ... DELIM)" — what Claude's CLAUDE.md prescribes.
+    # Terminator anchored to start of line (MULTILINE); `<<-` form allows leading tabs/spaces.
+    m = re.search(
+        r"-m\s+\"?\$\(\s*cat\s+<<(-?)\s*['\"]?(\w+)['\"]?\s*\n(.*?)\n[\t ]*\2\s*$",
+        command,
+        re.DOTALL | re.MULTILINE,
+    )
+    if m:
+        body = m.group(3)
+        return textwrap.dedent(body) if m.group(1) == "-" else body
+    # Pattern: -m "..." — bash double-quotes only escape \$ \" \\ \` (NOT \n, \t, \uNNNN).
+    m = re.search(r'-m\s+"((?:[^"\\]|\\.)*)"', command)
+    if m:
+        return re.sub(r'\\([$"\\`])', r"\1", m.group(1))
+    # Pattern: -m '...' (single quotes — no escapes in shell)
+    m = re.search(r"-m\s+'([^']*)'", command)
+    if m:
+        return m.group(1)
+    return None
+
+
+def main() -> int:
+    try:
+        data = json.loads(sys.stdin.read())
+    except Exception:
+        return 0
+
+    command = data.get("tool_input", {}).get("command", "") or ""
+
+    # Match `git commit` allowing flags between (e.g., `git -C /path commit`, `git -c k=v commit`).
+    if not re.search(r"(^|[\s&;|])git(\s+\S+)*?\s+commit(\s|$)", command):
+        return 0
+    # Check for `--no-edit` only in the args before -m / --message — avoid false-matching
+    # the literal string inside a message body.
+    args_prefix = re.split(r"\s-m\b|\s--message\b", command, maxsplit=1)[0]
+    if "--no-edit" in args_prefix:
+        return 0
+    if not COMMITLINT_BIN.exists():
+        # Fresh checkout before `npm install` — defer to husky.
+        return 0
+
+    msg = extract_message(command)
+    if not msg:
+        # Couldn't extract (e.g., -F file or interactive editor); husky covers it.
+        return 0
+
+    try:
+        proc = subprocess.run(
+            [str(COMMITLINT_BIN)],
+            input=msg,
+            capture_output=True,
+            text=True,
+            cwd=str(REPO_ROOT),
+            timeout=30,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return 0
+
+    if proc.returncode == 0:
+        return 0
+
+    output = (proc.stdout + proc.stderr).strip() or "commitlint reported errors."
+    emit_deny(
+        "Commit message fails Conventional Commits validation "
+        "(see .claude/rules/conventional-commits.md):\n\n" + output
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/hooks/ruff-fix.sh
+++ b/.claude/hooks/ruff-fix.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# PostToolUse hook: run ruff check --fix and ruff format on an edited .py file.
+# Reads Claude Code's hook JSON from stdin and no-ops for non-Python paths.
+# ruff lives inside docker/.venv (the only Python project tree), so we cd
+# there and invoke it via uv.
+set -u
+f=$(jq -r '.tool_input.file_path // .tool_response.filePath // empty')
+[ -n "$f" ] && [ "${f##*.}" = "py" ] || exit 0
+cd "$CLAUDE_PROJECT_DIR/docker" && uv run ruff check --fix "$f" && uv run ruff format "$f"

--- a/.claude/output-styles/review-comments.md
+++ b/.claude/output-styles/review-comments.md
@@ -1,0 +1,67 @@
+---
+name: review-comments
+description: Diplomatic, constructive tone for reviewing PRs authored by other people. This file is consumed by the /review-community skill, which inlines it as turn instructions on top of Claude Code's default system prompt. Activating it as a session-level output style (via /config → Output style) replaces the default software-engineering prompt — prefer the skill unless you want a review-only session.
+---
+
+You are an expert code reviewer. The pull request under review was
+authored by someone other than the current user. Give honest, useful
+feedback about correctness, design, and risk in a tone that respects the
+author's effort and invites discussion.
+
+If activated as a session-level output style, this file replaces Claude
+Code's default software-engineering instructions. Lean on your own
+engineering judgement: read the diff, trace the change through the
+codebase, verify claims against the code, and surface real risks.
+
+## Voice
+
+- Open the first review of a PR with a brief, sincere thank-you for the
+  contribution. One sentence, no flowery language. On re-reviews after
+  the author pushes changes, skip the thanks and any opening pleasantries
+  — jump straight to feedback. The thank-you is for the contribution,
+  not for each iteration.
+- Lead with what works before flagging issues. One genuine sentence, not
+  flattery — if there's nothing notable, skip it. Same re-review rule:
+  don't repeat the "what works" callout on subsequent passes.
+- Frame concerns as questions or observations, not verdicts: "Did you
+  consider X?" / "I'd expect this to fail when Y" — not "this is wrong."
+- Use "we" and "the code" instead of "you." Critique the change, not
+  the author.
+- Say "I" when stating a preference or uncertainty: "I'd lean toward X
+  because…" / "I'm not sure this handles Y."
+- No hedging stacks ("maybe perhaps possibly"). Be direct about the
+  substance, diplomatic about the framing.
+- No emoji, no exclamation marks, no "great work!" filler.
+- Don't restate what the diff does — the author wrote it, they know.
+- Don't recommend changes outside the PR's scope. If something adjacent
+  is broken, mention it once at the end as a follow-up, not as a review
+  item.
+- Don't demand tests for trivial changes. Ask whether existing coverage
+  exercises the new path; if not, suggest one specific test.
+- Don't speculate about intent ("I assume you meant…"). Ask.
+- Don't pile on. If you've raised the same concern in two places, link
+  the second to the first instead of repeating the argument.
+
+## Structure
+
+Group feedback by severity, in this order. Skip any group that's empty —
+don't write "no issues found" headers.
+
+1. **Blocking** — correctness bugs, security issues, broken contracts,
+   regressions. State the problem, the failure mode, and (if obvious)
+   the fix. These are the only items the author MUST address.
+2. **Worth discussing** — design choices, trade-offs, alternative
+   approaches. Frame as questions. The author can push back; you may
+   be missing context.
+3. **Nits / optional** — naming, style, minor refactors. Prefix each
+   with "nit:" so the author knows they're optional.
+
+For each item, include the file path and line number in `path:line`
+format so the author can navigate to it.
+
+## When uncertain
+
+If you're not sure whether something is a real issue, say so explicitly:
+"I might be missing context here, but…" — and then state the concern.
+The author can confirm or correct. Don't suppress real concerns just
+because you're unsure; don't assert them as facts either.

--- a/.claude/rules/conventional-commits.md
+++ b/.claude/rules/conventional-commits.md
@@ -1,0 +1,19 @@
+Commit messages MUST follow Conventional Commits (https://www.conventionalcommits.org/en/v1.0.0/).
+
+*Enforced today only by a Claude PreToolUse hook (`.claude/hooks/commitlint-before-commit.py`) that validates `git commit -m` payloads before the command fires. The hook soft-no-ops until commitlint is installed at the repo root (`node_modules/.bin/commitlint`); plug it in once the npm workspaces root in `packages/` exists.*
+
+Format: `type(scope): description` — max 69 characters in the header.
+
+- Types: `feat`, `fix`, `chore`, `refactor`, `test`, `docs`, `perf`, `build`, `ci`, `style`, `revert`
+- If a change ships to users, it's `feat` (new capability) or `fix`
+  (bug). Internal developer tooling (agent harness configs, editor
+  configs, dev scripts, dependency bumps) uses `chore`. The other
+  types (`refactor`, `test`, `docs`, `perf`, `build`, `ci`, `style`,
+  `revert`) take precedence over `chore` when they fit.
+- Scope: always include a scope. Use the primary subject of the change:
+  - For `docs`: the doc file name without extension (e.g. `docs(DEVELOPMENT)`, `docs(README)`, `docs(TESTING)`)
+  - For `ci`: the workflow/config file name without extension (e.g. `ci(ci-backend)`, `ci(docker-publish)`, `ci(release)`). When the change IS the CI config, use type `ci` — not `chore(ci)`.
+  - For code: the module, router, or component name (e.g. `fix(broker)`, `feat(search)`, `refactor(ui)`)
+  - For `chore`: prefer harness-agnostic scopes — `chore(harness)`
+    covers anything under `.claude/`, `.cursor/`, `.codex/`, etc.
+- Description: lowercase, imperative mood, no trailing period

--- a/.claude/rules/conventional-commits.md
+++ b/.claude/rules/conventional-commits.md
@@ -11,9 +11,9 @@ Format: `type(scope): description` — max 69 characters in the header.
   types (`refactor`, `test`, `docs`, `perf`, `build`, `ci`, `style`,
   `revert`) take precedence over `chore` when they fit.
 - Scope: always include a scope. Use the primary subject of the change:
-  - For `docs`: the doc file name without extension (e.g. `docs(DEVELOPMENT)`, `docs(README)`, `docs(TESTING)`)
-  - For `ci`: the workflow/config file name without extension (e.g. `ci(ci-backend)`, `ci(docker-publish)`, `ci(release)`). When the change IS the CI config, use type `ci` — not `chore(ci)`.
-  - For code: the module, router, or component name (e.g. `fix(broker)`, `feat(search)`, `refactor(ui)`)
+  - For `docs`: the doc file name without extension (e.g. `docs(README)`, `docs(architecture)`)
+  - For `ci`: the workflow/config file name without extension (e.g. `ci(docker-image)`, `ci(npm-publish)`). When the change IS the CI config, use type `ci` — not `chore(ci)`.
+  - For code: the module, package, or component name (e.g. `fix(gate)`, `feat(score)`, `refactor(cli)`)
   - For `chore`: prefer harness-agnostic scopes — `chore(harness)`
     covers anything under `.claude/`, `.cursor/`, `.codex/`, etc.
 - Description: lowercase, imperative mood, no trailing period

--- a/.claude/rules/copilot-review-comments.md
+++ b/.claude/rules/copilot-review-comments.md
@@ -1,0 +1,11 @@
+After pushing fixes for Copilot review comments, resolve the threads automatically — don't wait to be asked. Only resolve threads whose feedback the pushed commit actually addresses; skip the rest.
+
+Flow (via `gh api graphql`):
+
+1. Query `reviewThreads` on the PR.
+2. Filter to `isResolved=false` where the first comment's author is `copilot-pull-request-reviewer`.
+3. For each thread, decide whether the pushed commit addresses it. If not, skip.
+4. Reply with `addPullRequestReviewThreadReply` — `Addressed by <pushed-sha>`.
+5. Call `resolveReviewThread`.
+
+The reply is the audit trail, so the resolution isn't mistaken for a dismissal.

--- a/.claude/rules/git-workflow.md
+++ b/.claude/rules/git-workflow.md
@@ -1,0 +1,27 @@
+## Branches
+
+- Prefix branches by change type: `feature/`, `fix/`, `chore/`, `docs/`, `test/`.
+- After the slash, use a short kebab-case description: `fix/fix-everything-that-was-broken`.
+- If an issue exists for the work, put the issue number right after the slash: `fix/1234-fix-all-the-other-things`.
+
+## Commits
+
+- Break work into **atomic** logical units — each commit should stand on its own and be reviewable in isolation.
+- Reference related issues with `Refs #<issue>` in the commit body.
+- Do NOT use GitHub magic close-keywords (`Closes`, `Fixes`, `Resolves`) in commit messages — those belong in the PR body so they close issues on merge, not on every push.
+- Sign off every commit per the Developer Certificate of Origin: `git commit -s` (adds a `Signed-off-by:` trailer).
+
+## Issues
+
+If you spot something worth tracking outside the current task, surface it and offer to file a GitHub issue — don't let findings get buried in chat. Never create one yourself unless the user explicitly asks. Before creating any issue:
+
+- Verify the claim (re-read the code, run the relevant test, reproduce if possible).
+- Search existing issues (`gh issue list --search "..."`) to avoid duplicates. If a match exists, comment on it with new findings instead of opening a new one.
+
+## Pull requests
+
+- Keep PRs **small and focused**. Split unrelated changes into separate PRs.
+- Before opening a PR, search existing issues (`gh issue list --search "..."`) and link the ones the change touches in the PR **body** (never the title).
+- Use `Closes #N` / `Fixes #N` for issues the PR fully resolves — they auto-close on merge. Use `Refs #N` for partial relation.
+- PRs are **squash-merged**. The squash commit message must follow Conventional Commits (see `conventional-commits.md`).
+- When a PR adds or changes a feature, update the relevant documentation in the same PR.

--- a/.claude/rules/karpathy-guidelines.md
+++ b/.claude/rules/karpathy-guidelines.md
@@ -1,0 +1,9 @@
+Behavioral guidelines to reduce common LLM coding mistakes.
+
+1. **Think before coding** — state assumptions explicitly. If uncertain, ask. If multiple interpretations exist, present them. Push back when a simpler approach exists.
+
+2. **Simplicity first** — minimum code that solves the problem. No speculative features, no abstractions for single-use code, no error handling for impossible scenarios.
+
+3. **Surgical changes** — touch only what you must. Don't "improve" adjacent code, comments, or formatting. Match existing style. Remove only imports/variables that YOUR changes made unused.
+
+4. **Goal-driven execution** — define verifiable success criteria before implementing. For multi-step tasks, state a brief plan with verification checks.

--- a/.claude/rules/python-code-style.md
+++ b/.claude/rules/python-code-style.md
@@ -12,4 +12,4 @@ Formatting is `ruff format` — [PEP 8](https://peps.python.org/pep-0008/)-align
 
 - **Don't import other modules' private names.** Symbols prefixed with `_` are module-private. If another module needs one, promote it to public (rename without the leading underscore) rather than cross-importing `_foo`. Enforced by ruff `PLC2701`.
 
-- **Modern type syntax for Python 3.11.** Prefer `list[str]`, `dict[str, int]` ([PEP 585](https://peps.python.org/pep-0585/)) and `X | None` ([PEP 604](https://peps.python.org/pep-0604/)) over `typing.List` / `typing.Optional`.
+- **Modern type syntax for Python 3.12.** Prefer `list[str]`, `dict[str, int]` ([PEP 585](https://peps.python.org/pep-0585/)) and `X | None` ([PEP 604](https://peps.python.org/pep-0604/)) over `typing.List` / `typing.Optional`.

--- a/.claude/rules/python-code-style.md
+++ b/.claude/rules/python-code-style.md
@@ -1,0 +1,15 @@
+---
+paths:
+  - "**/*.py"
+---
+
+## Python code style
+
+Formatting is `ruff format` — [PEP 8](https://peps.python.org/pep-0008/)-aligned, line length 100 (project standard; PEP 8 recommends 79). `ruff check` enforces our selected rule subset (`E4`, `E7`, `E9`, `F`, `I`, `PLC0415`, `PLC2701`) — see `[tool.ruff.lint]` in `docker/pyproject.toml`. Run `cd docker && uv run poe lint:fix` on files you touched before handing off.
+
+- **Top-level imports only.** Every `import` belongs at the module top, above the first definition. No function-local imports for lazy-loading or startup-cost reasons. Enforced by ruff `PLC0415`.
+  - **Exception: breaking an import cycle.** When you must inline an import to avoid a circular dependency, leave a one-line comment explaining why the cycle can't be untangled.
+
+- **Don't import other modules' private names.** Symbols prefixed with `_` are module-private. If another module needs one, promote it to public (rename without the leading underscore) rather than cross-importing `_foo`. Enforced by ruff `PLC2701`.
+
+- **Modern type syntax for Python 3.11.** Prefer `list[str]`, `dict[str, int]` ([PEP 585](https://peps.python.org/pep-0585/)) and `X | None` ([PEP 604](https://peps.python.org/pep-0604/)) over `typing.List` / `typing.Optional`.

--- a/.claude/rules/review-auto-apply.md
+++ b/.claude/rules/review-auto-apply.md
@@ -1,0 +1,14 @@
+`/review` and `/security-review` always produce comments — that's the audit trail. For findings that pass the re-check (below), push a follow-up commit on the same PR (per `git-workflow.md` / `conventional-commits.md`) and append an `## Auto-applied fixes` section to the PR review comment (or post a new comment if none exists), listing every auto-applied finding. If the finding lived in a PR review thread, resolve it per `copilot-review-comments.md`.
+
+The re-check is per-finding: re-open the file(s) the finding points at, confirm the issue still applies against current code, and confirm the fix fits the categories below. If uncertain, leave it as a comment directed to the PR author.
+
+If the follow-up commit breaks tests or hooks, revert it and convert the finding back to a comment — don't fix forward with more commits.
+
+### Follow-up commit when *all* hold
+
+- PR author is a jentic org member — verify with `gh api orgs/jentic/members/<author_login>` (204 = member, 404 = not). Non-member PRs are review-only; use `review-community`, which never pushes to a contributor's branch. All findings on non-member PRs are comments only, regardless of category.
+- The finding is one of:
+  - **Mechanical**: lint, typo, dead import, missing type, formatting, narrow null-check.
+  - **Bug introduced by this PR**: a regression the PR's own diff caused, identifiable against the base branch.
+- No architectural or design change — those go to the PR author as a comment regardless of authorship.
+- Single-concern, small enough to verify at a glance.

--- a/.claude/rules/sdd-constitution.md
+++ b/.claude/rules/sdd-constitution.md
@@ -1,0 +1,29 @@
+**Spec-Driven Development** (SDD) is a workflow where feature specs, tasks, and implementation all derive from a stable project foundation — the **constitution**. Work is grounded in the constitution rather than re-invented each time.
+
+In this repo the constitution is one document split across three files in `specs/` — each a section, load-bearing together. None stands alone.
+
+- `specs/mission.md` — why the project exists, who it serves, what success looks like
+- `specs/tech-stack.md` — the stack that exists (not what is ideal), plus system-wide constraints and conventions
+- `specs/roadmap.md` — the next shippable phases, ordered and scoped small
+
+Each file is YAML-frontmatter-tagged with `type: constitution` and its `section:`. Do not add a `sources:` list — nothing consumes it and it rots as files move. Where a doc is load-bearing for a specific claim, cross-reference it inline in the body instead.
+
+The constitution captures **load-bearing invariants**, not operational detail. Endpoint catalogs, schemas, threat models, and similar reference material live in `docs/` — the constitution cross-references them from `tech-stack.md`. Mission / tech-stack / roadmap is the whole set; there is no fourth section.
+
+Once the constitution exists, individual roadmap phases are materialized into **feature specs** — dated directories under `specs/` (`specs/YYYY-MM-DD-<slug>/`) containing `requirements.md` (what + why), `plan.md` (how), and `validation.md` (done). Unlike constitution files, feature-spec files are plain markdown with **no YAML frontmatter** — the H1 (`# Phase N <Requirements|Plan|Validation|Retrospective> — <Title>`) carries identity. When a phase ships, append ` ✅` (a single space followed by the U+2705 checkmark) to its `## Phase N — Title` heading in `specs/roadmap.md` and leave the rest of the block in place (do not delete or renumber); the feature-spec directory stays as history. The leading space is load-bearing — verify steps `grep -F` for the exact ` ✅` suffix.
+
+Implementation feedback flows back into the spec process via two artifacts that sit alongside the constitution without becoming a fourth section:
+
+- `specs/<date>-<slug>/retrospective.md` — optional, written **manually** after the implementation PR (only when the spec genuinely missed something worth remembering). `/sdd-implement-spec` surfaces a `## Spec deviations` section in the PR body as raw material; a human curates it into the retrospective.
+- `specs/lessons.md` — aggregated checklist of recurring lessons; loaded by `/sdd-new-spec` and `/sdd-new-phase` before scaffolding so future specs absorb the learning. Refreshed manually by `/sdd-distill-lessons`, which reads `specs/*/retrospective.md`, proposes additions via `AskUserQuestion`, and writes on confirmation. When a lesson recurs across multiple retrospectives **and** names a load-bearing invariant (rather than an empirical reminder), hand-promote it into `specs/tech-stack.md` — `/sdd-distill-lessons` flags promotion candidates; the promotion itself is a manual edit.
+
+Supporting infrastructure:
+
+- `.claude/templates/sdd/constitution/*.example.md` — structural templates for each constitution section
+- `.claude/skills/sdd-create-constitution/SKILL.md` — `/sdd-create-constitution` skill that bootstraps the constitution from repository evidence (refuses to overwrite an existing constitution without explicit user confirmation)
+- `.claude/templates/sdd/feature-spec/*.example.md` — structural templates for each feature-spec file
+- `.claude/skills/sdd-new-phase/SKILL.md` — `/sdd-new-phase` skill that appends a new active phase to `specs/roadmap.md`
+- `.claude/skills/sdd-new-spec/SKILL.md` — `/sdd-new-spec` skill that scaffolds a feature spec from a roadmap phase
+- `.claude/skills/sdd-implement-spec/SKILL.md` — `/sdd-implement-spec` skill that implements an existing feature spec end-to-end (branch, commits per `plan.md` group, verification per `validation.md`, pre-push review pairing built-in `/review` with three deep-review subagents, PR)
+- `.claude/templates/sdd/feature-spec/retrospective.example.md` — structural template for per-spec retrospectives
+- `.claude/skills/sdd-distill-lessons/SKILL.md` — `/sdd-distill-lessons` skill that distils retrospectives into `specs/lessons.md`

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,31 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/commitlint-before-commit.py",
+            "statusMessage": "Validating Conventional Commit format"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/ruff-fix.sh",
+            "statusMessage": "Running ruff on edited file"
+          }
+        ]
+      }
+    ]
+  },
+  "enabledPlugins": {
+    "skill-creator@claude-plugins-official": true
+  }
+}

--- a/.claude/skills/review-community/SKILL.md
+++ b/.claude/skills/review-community/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: review-community
+description: Review a pull request authored by someone other than the current GitHub user, applying the team's diplomatic review-comments tone. Use when the PR author's GitHub login differs from the current user's `gh api user` login. For own PRs, use the built-in /review directly. Detects authorship automatically and refuses on self-authored PRs.
+argument-hint: "[pr-number | pr-url] (optional — defaults to the PR for the current branch)"
+---
+
+# /review-community — review someone else's PR with the community tone
+
+This skill wraps the built-in `/review` command with two additions:
+
+1. **Authorship guard** — refuses to run if the PR author's GitHub login matches the current user's. For self-reviews, use `/review` directly with its default voice.
+2. **Tone injection** — inlines the diplomatic review-comments style into this turn so the tone applies without flipping the session output style. Activating the style via `/config` → Output style would replace Claude Code's default software-engineering system prompt; this skill avoids that by overlaying the tone on top of the default.
+
+## Tone for this review
+
+The tone, structure, and constraints below are the source of truth for
+voice and feedback structure. Follow them for every comment drafted in
+this review.
+
+!`cat .claude/output-styles/review-comments.md`
+
+## Phase 0 — Resolve PR and verify authorship
+
+Run this once and use the values for the rest of the skill. `set -e`
+ensures any failed command stops the block; if it stops, surface the
+error to the user and do not proceed.
+
+```bash
+set -e
+
+if [ -n "$ARGUMENTS" ]; then
+  PR="$ARGUMENTS"
+else
+  PR=$(gh pr view --json number -q .number)
+fi
+
+PR_AUTHOR=$(gh pr view "$PR" --json author -q .author.login)
+GH_USER=$(gh api user -q .login)
+
+echo "PR=$PR"
+echo "PR_AUTHOR=$PR_AUTHOR"
+echo "GH_USER=$GH_USER"
+```
+
+Expected outcomes:
+
+- **`gh pr view` with no argument fails** (no PR for current branch) →
+  stop and ask the user for a PR number or URL. Don't guess.
+- **`gh api user` fails or returns empty `$GH_USER`** → stop. The
+  authorship guard cannot run without a confirmed login. Tell the user
+  to authenticate (`gh auth status`) and try again.
+- **`$PR_AUTHOR` equals `$GH_USER`** → stop. Tell the user this is
+  their own PR and to use `/review` directly. Do not proceed.
+- **`$PR_AUTHOR` differs from `$GH_USER`** → continue. State who
+  authored the PR before starting the review, so the user has
+  confirmation the guard saw the right author.
+
+## Phase 1 — Run the review
+
+Invoke the built-in `/review` skill against `$PR` via the Skill tool.
+The tone instructions inlined in "Tone for this review" above apply to
+all comments drafted in this turn.
+
+If the user asks follow-up questions in subsequent turns ("expand
+point 3," "draft the GitHub comment for line 42"), the inlined tone
+instructions will not carry over automatically. Re-read the style file
+when needed. A session-level voice lock is possible via `/config` →
+Output style → review-comments, but it replaces Claude Code's default
+software-engineering system prompt — not recommended unless the whole
+session is review work.
+
+## Out of scope
+
+Severity grouping, technical depth, and what gets flagged remain
+whatever the built-in `/review` does — this skill only adds the
+authorship guard and the tone overlay.

--- a/.claude/skills/sdd-create-constitution/SKILL.md
+++ b/.claude/skills/sdd-create-constitution/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sdd-create-constitution
-description: Bootstrap the SDD constitution (specs/mission.md, specs/tech-stack.md, specs/roadmap.md) from current repository evidence. Refuses by default if any of the three files already exists — overwriting requires explicit confirmation via AskUserQuestion. Loads the constitution templates, runs parallel Explore subagents over src/, ui/, docs/, and top-level config to ground claims in evidence, synthesizes findings, then issues a single grouped AskUserQuestion call (Mission / Tech Stack / Roadmap) before writing the three files. Edits files in place and stops — committing, branching, and opening a PR are user actions.
+description: Bootstrap the SDD constitution (specs/mission.md, specs/tech-stack.md, specs/roadmap.md) from current repository evidence. Refuses by default if any of the three files already exists — overwriting requires explicit confirmation via AskUserQuestion. Loads the constitution templates, runs parallel Explore subagents over the code trees that exist (e.g. `docker/`, `packages/`), `docs/`, and top-level config to ground claims in evidence, synthesizes findings, then issues a single grouped AskUserQuestion call (Mission / Tech Stack / Roadmap) before writing the three files. Edits files in place and stops — committing, branching, and opening a PR are user actions.
 argument-hint: "(no arguments)"
 ---
 
@@ -14,7 +14,7 @@ The **constitution** is the project foundation that every later SDD action (feat
 
 - **Refuse to overwrite without explicit user confirmation.** If `specs/mission.md`, `specs/tech-stack.md`, or `specs/roadmap.md` already exists, the skill stops at Phase 0 and asks the user via `AskUserQuestion` whether to overwrite. Default-deny: anything other than an explicit "overwrite all three files" selection aborts the run. Do not auto-backup, rename, or move existing files — the user owns them.
 - **Do not write to disk before the Phase 4 AskUserQuestion completes.** The grouped clarifying questions lock in decisions that shape file content; writing earlier wastes the call.
-- **Ground every claim in repository evidence.** Prefer facts from `src/`, `ui/`, `docs/`, `pyproject.toml`, `package.json`, `Dockerfile`, and similar over assumptions. Use `Explore` subagents for parallel research; do not invent capabilities, libraries, or constraints the repo does not support.
+- **Ground every claim in repository evidence.** Prefer facts from the code trees that exist (e.g. `docker/`, `packages/`, `src/`), `docs/`, `pyproject.toml`, `package.json`, `Dockerfile`, and similar over assumptions. Use `Explore` subagents for parallel research; do not invent capabilities, libraries, or constraints the repo does not support.
 - **Distinguish confirmed facts from inferred conclusions and unknowns.** Mark uncertainty inline; do not present inferences as facts.
 - **No git actions, no commits, no branching.** This skill writes files and stops. Branching, committing, and PR creation are user actions per `.claude/rules/git-workflow.md`.
 - **Templates are structural scaffolds, not content.** Replace every `[PLACEHOLDER]`; do not copy template prose verbatim.
@@ -60,34 +60,34 @@ Launch four `Explore` subagents in parallel — a single message with multiple `
 - **Thoroughness:** `very thorough` on every subagent. The constitution is load-bearing; shallow grounding produces a shallow constitution that future agents will misuse.
 - **Briefs are self-contained.** Each subagent does not see this conversation. Include the goal (constitution bootstrapping) and the specific area to inspect.
 
-**Subagent A — Backend research** (`src/`):
-- What does the system do (routes, request flow, core modules)?
-- Implemented capabilities (search, broker, workflows, credentials, etc.)
-- Architecture invariants and constraints (e.g. router registration order, middleware chain, DB access patterns)
-- Tech-stack signals (dependencies, runtime/server choice)
+**Subagent A — Primary code research** (the main code tree — pick what exists, e.g. `src/`, `docker/`, `packages/`):
+- What does the system do (entry points, request/CLI flow, core modules)?
+- Implemented capabilities (the user-facing verbs the system exposes today)
+- Architecture invariants and constraints (e.g. registration order, middleware chain, gate / allowlist enforcement, DB access patterns — whichever apply)
+- Tech-stack signals (dependencies, runtime/server/CLI choice)
 - Return: confirmed capabilities, architectural invariants, uncertainty markers.
 
-**Subagent B — UI research** (`ui/`):
-- What admin/user interface ships (pages, primary flows)
-- UI tech stack (framework, styling system, build tool, generated API client)
-- Design conventions (theming approach, component library, where generated code lives)
-- Return: capabilities visible in the UI, UI stack facts, conventions worth preserving.
+**Subagent B — Secondary code research** (skip when not applicable — e.g. UI tree at `ui/`, a sibling package tree at `packages/`, a separate runner tree):
+- What additional surface ships (pages, commands, sibling deliverables)
+- Stack signals specific to this tree (framework, styling, build tool, generated client)
+- Design conventions (where generated code lives, theming/layout approach, component conventions)
+- Return: capabilities visible in this tree, stack facts, conventions worth preserving. If the tree does not exist, say so explicitly and return early — do not invent content.
 
-**Subagent C — Documentation research** (`docs/`, `README.md`, `AGENTS.md`, `CLAUDE.md`):
+**Subagent C — Documentation research** (`docs/`, `README.md`, `CLAUDE.md`):
 - Stated mission and product purpose
 - Documented architecture and constraints
 - User personas / target audiences mentioned
 - Threat models, design decisions, load-bearing invariants
 - Return: stated facts about why the project exists, who it serves, what is load-bearing.
 
-**Subagent D — Top-level config research** (`pyproject.toml`, `package.json`, `Dockerfile`, `compose.yml`, CI workflows under `.github/`, `.editorconfig`, `.tool-versions`):
+**Subagent D — Top-level config research** (`docker/pyproject.toml`, `Dockerfile`, CI workflows under `.github/`, `.editorconfig`, `.tool-versions`):
 - Languages, runtimes, build tools, deployment shape
 - Test frameworks and CI gates
 - Linting / formatting / type-checking choices
 - Return: tech-stack evidence with file references.
 
 **Rules:**
-- Every brief must instruct the subagent to lead its summary with a `## Blockers` section (write `_none_` when there are none). Examples of blockers: the repo is empty (nothing to ground a constitution); critical files referenced from `CLAUDE.md` or `AGENTS.md` are missing; the repo contains multiple disjoint projects with unclear scope.
+- Every brief must instruct the subagent to lead its summary with a `## Blockers` section (write `_none_` when there are none). Examples of blockers: the repo is empty (nothing to ground a constitution); critical files referenced from `CLAUDE.md` are missing; the repo contains multiple disjoint projects with unclear scope.
 - Subagents are read-only (`Explore` type; cannot edit, write, or commit).
 - If any subagent returns a non-empty `## Blockers` section, stop and report to the user before Phase 3.
 

--- a/.claude/skills/sdd-create-constitution/SKILL.md
+++ b/.claude/skills/sdd-create-constitution/SKILL.md
@@ -1,0 +1,167 @@
+---
+name: sdd-create-constitution
+description: Bootstrap the SDD constitution (specs/mission.md, specs/tech-stack.md, specs/roadmap.md) from current repository evidence. Refuses by default if any of the three files already exists — overwriting requires explicit confirmation via AskUserQuestion. Loads the constitution templates, runs parallel Explore subagents over src/, ui/, docs/, and top-level config to ground claims in evidence, synthesizes findings, then issues a single grouped AskUserQuestion call (Mission / Tech Stack / Roadmap) before writing the three files. Edits files in place and stops — committing, branching, and opening a PR are user actions.
+argument-hint: "(no arguments)"
+---
+
+# /sdd-create-constitution — bootstrap the SDD constitution
+
+You are operating within a Spec-Driven Development (SDD) workflow. See `.claude/rules/sdd-constitution.md`.
+
+The **constitution** is the project foundation that every later SDD action (feature specs, tasks, implementation) derives from. It lives in `specs/` as three files: `mission.md` (why and who), `tech-stack.md` (what exists), `roadmap.md` (what comes next, in small phases). This skill bootstraps those three files from current repository evidence — code, configs, dependencies, docs — rather than aspiration. Once the constitution exists, future phases are appended via `/sdd-new-phase` and materialized into feature specs via `/sdd-new-spec`. This skill is the cold-start; it is not for incremental updates.
+
+## Hard constraints
+
+- **Refuse to overwrite without explicit user confirmation.** If `specs/mission.md`, `specs/tech-stack.md`, or `specs/roadmap.md` already exists, the skill stops at Phase 0 and asks the user via `AskUserQuestion` whether to overwrite. Default-deny: anything other than an explicit "overwrite all three files" selection aborts the run. Do not auto-backup, rename, or move existing files — the user owns them.
+- **Do not write to disk before the Phase 4 AskUserQuestion completes.** The grouped clarifying questions lock in decisions that shape file content; writing earlier wastes the call.
+- **Ground every claim in repository evidence.** Prefer facts from `src/`, `ui/`, `docs/`, `pyproject.toml`, `package.json`, `Dockerfile`, and similar over assumptions. Use `Explore` subagents for parallel research; do not invent capabilities, libraries, or constraints the repo does not support.
+- **Distinguish confirmed facts from inferred conclusions and unknowns.** Mark uncertainty inline; do not present inferences as facts.
+- **No git actions, no commits, no branching.** This skill writes files and stops. Branching, committing, and PR creation are user actions per `.claude/rules/git-workflow.md`.
+- **Templates are structural scaffolds, not content.** Replace every `[PLACEHOLDER]`; do not copy template prose verbatim.
+- **Front matter shape is fixed.** Each file starts with YAML frontmatter: `type: constitution`, `section: mission|tech-stack|roadmap`, `generated_by: spec-driven-agent`, `generated_at: <ISO 8601 UTC timestamp>`, `confidence: low|medium|high`. Do **not** add a `sources:` list — nothing consumes it and it rots; cross-reference load-bearing docs inline in the body instead.
+- **If the repo is empty (no code, no configs)**, stop and tell the user — there is nothing to ground a constitution against. The skill documents and structures what exists; it does not design from scratch.
+
+## Phase 0 — Existence guard (MANDATORY, before any work)
+
+Check for the three constitution files in parallel:
+
+- `specs/mission.md`
+- `specs/tech-stack.md`
+- `specs/roadmap.md`
+
+**If none exist** — proceed silently to Phase 1.
+
+**If any exist** — stop and surface the situation. List which of the three files exist with their last-modified date and byte size so the user can judge what would be overwritten. Then issue a single `AskUserQuestion` call:
+
+  - Prompt: "A constitution already exists in `specs/`. The files listed above will be overwritten if you continue. Proceed?"
+  - Options:
+    - `Cancel — keep existing constitution` (recommended; first option)
+    - `Overwrite all three files`
+  - The freeform write-in is provided automatically. Treat **every** freeform write-in as cancel — only the explicit `Overwrite all three files` option-button selection proceeds.
+
+Only proceed past this gate if the user explicitly selects the `Overwrite all three files` option button. Anything else — including silence, cancel, or any freeform write-in regardless of its content — aborts the run with a one-line summary ("Aborted; existing constitution preserved.").
+
+If only one or two of the three files exist (a partial constitution), the same rule applies: any existing file means the guard fires. The skill regenerates all three together; it does not patch individual sections.
+
+## Phase 1 — Load constitution templates
+
+Load the three structural templates in parallel:
+
+- @.claude/templates/sdd/constitution/mission.example.md
+- @.claude/templates/sdd/constitution/tech-stack.example.md
+- @.claude/templates/sdd/constitution/roadmap.example.md
+
+Extract structure, section organization, formatting conventions, frontmatter shape, and level of detail. Use the templates as scaffolds for the files you generate — do not copy their prose verbatim.
+
+## Phase 2 — Parallel research (MANDATORY)
+
+Launch four `Explore` subagents in parallel — a single message with multiple `Agent` tool calls, `subagent_type: Explore`, one per research area. Do not proceed to Phase 3 until all four return.
+
+- **Thoroughness:** `very thorough` on every subagent. The constitution is load-bearing; shallow grounding produces a shallow constitution that future agents will misuse.
+- **Briefs are self-contained.** Each subagent does not see this conversation. Include the goal (constitution bootstrapping) and the specific area to inspect.
+
+**Subagent A — Backend research** (`src/`):
+- What does the system do (routes, request flow, core modules)?
+- Implemented capabilities (search, broker, workflows, credentials, etc.)
+- Architecture invariants and constraints (e.g. router registration order, middleware chain, DB access patterns)
+- Tech-stack signals (dependencies, runtime/server choice)
+- Return: confirmed capabilities, architectural invariants, uncertainty markers.
+
+**Subagent B — UI research** (`ui/`):
+- What admin/user interface ships (pages, primary flows)
+- UI tech stack (framework, styling system, build tool, generated API client)
+- Design conventions (theming approach, component library, where generated code lives)
+- Return: capabilities visible in the UI, UI stack facts, conventions worth preserving.
+
+**Subagent C — Documentation research** (`docs/`, `README.md`, `AGENTS.md`, `CLAUDE.md`):
+- Stated mission and product purpose
+- Documented architecture and constraints
+- User personas / target audiences mentioned
+- Threat models, design decisions, load-bearing invariants
+- Return: stated facts about why the project exists, who it serves, what is load-bearing.
+
+**Subagent D — Top-level config research** (`pyproject.toml`, `package.json`, `Dockerfile`, `compose.yml`, CI workflows under `.github/`, `.editorconfig`, `.tool-versions`):
+- Languages, runtimes, build tools, deployment shape
+- Test frameworks and CI gates
+- Linting / formatting / type-checking choices
+- Return: tech-stack evidence with file references.
+
+**Rules:**
+- Every brief must instruct the subagent to lead its summary with a `## Blockers` section (write `_none_` when there are none). Examples of blockers: the repo is empty (nothing to ground a constitution); critical files referenced from `CLAUDE.md` or `AGENTS.md` are missing; the repo contains multiple disjoint projects with unclear scope.
+- Subagents are read-only (`Explore` type; cannot edit, write, or commit).
+- If any subagent returns a non-empty `## Blockers` section, stop and report to the user before Phase 3.
+
+## Phase 3 — Synthesis
+
+Combine the four research summaries into a single understanding:
+
+- Real product purpose (mission)
+- Actual tech stack from evidence (not aspirational)
+- Current maturity (prototype / early-stage / production)
+- Gaps and missing pieces relevant to the roadmap
+- Conflicts between sources (e.g. `README.md` claims X but `src/` shows Y) — surface these explicitly; do not paper over them
+
+Track three categories explicitly: **confirmed facts**, **inferred conclusions**, **unknowns requiring clarification**. Carry these into Phase 4 — they determine which questions are worth asking and which are answered by evidence already.
+
+If synthesis surfaced material conflicts, raise them to the user as a freeform note before issuing the Phase 4 AskUserQuestion call. Do not silently pick a side.
+
+## Phase 4 — AskUserQuestion (MANDATORY, before any disk write)
+
+Issue a single `AskUserQuestion` call containing exactly three questions, one per output file. Each question offers 3–4 concrete options derived from the synthesis. Ask only **high-leverage unanswered questions** — do not ask what the repo already answers.
+
+**Question 1 — Mission** (shapes `specs/mission.md`):
+  - Prompt: a one-sentence question resolving the largest mission unknown surfaced in synthesis (typically: who the primary stakeholder is, or what the core problem framing is).
+  - Options: 3–4 framings derived from synthesis; if synthesis already resolves this, offer "the synthesis framing already fits — proceed as drafted" as a recommended option.
+
+**Question 2 — Tech Stack** (shapes `specs/tech-stack.md`):
+  - Prompt: a one-sentence question resolving the largest tech-stack uncertainty surfaced in synthesis (typically: current maturity level, or whether a partially-evident technology is actually load-bearing).
+  - Options: 3–4 evidence-grounded options; if synthesis already resolves this, offer the proceed-as-drafted option.
+
+**Question 3 — Roadmap** (shapes `specs/roadmap.md`):
+  - Prompt: a one-sentence question resolving the next-priority direction or scope (typically: which gap from synthesis to address first, or what the immediate next phase looks like).
+  - Options: 3–4 plausible next-phase directions derived from gaps; if synthesis already implies a clear sequence, offer the proceed-as-drafted option.
+
+Only after the user answers all three do you proceed to Phase 5.
+
+## Phase 5 — Write the three files
+
+Write `specs/mission.md`, `specs/tech-stack.md`, `specs/roadmap.md` using the templates from Phase 1 as structural scaffolds and the synthesis + user answers as content. Each file MUST start with the YAML frontmatter from Hard constraints — fill `generated_at` with the current ISO 8601 UTC timestamp and `confidence` per how well grounded the section is in evidence.
+
+### mission.md
+
+- Purpose of the project — why it exists, in real-world terms
+- Target users / stakeholders
+- Problem being solved
+- Success criteria — measurable outcomes, observable behavior, concrete capabilities
+- Align with repo reality; surface assumptions explicitly when uncertain
+
+### tech-stack.md
+
+- Describe the **actual current** stack (not the ideal stack)
+- Cover: language, frameworks, libraries, UI approach, data/storage, testing, tooling, runtime/deployment
+- Separate confirmed vs inferred — do not present recommendations as facts
+- Include "What We Are Not Using" entries only when supported by evidence
+- Cross-reference load-bearing docs from `docs/` inline (e.g. "see `docs/architecture.md`") rather than enumerating them in frontmatter
+
+### roadmap.md
+
+- Define small, incremental phases — each one shippable, independently reviewable, testable
+- Prefer vertical slices (a phase touches whatever layers it needs to deliver an end-to-end capability) over technical-layer splits ("build the backend", "build the frontend")
+- Include `Depends on:` between phases when ordering matters
+- Keep phases small (hours to days, not weeks); split if a phase feels too large
+- Use `Priority:` values per the template — `High`, `Medium–High` (with the en-dash U+2013, not a hyphen), `Medium`. Apply `(blocker)` only when the phase fixes a current trust/security gap that makes the system unsafe for its intended use **today**; forward-looking production work uses normal priority and states the rationale in the phase body.
+- Include a **Lifecycle** paragraph near the top of the file describing the completion-marker convention: when a phase ships, append ` ✅` (a single space followed by the U+2705 checkmark) to its `## Phase N — Title` heading and leave the rest of the block in place (do not delete or renumber). The leading space is load-bearing — completion-verify steps `grep -F` for the exact ` ✅` suffix. Phase numbers are stable identifiers; completed phases stay in the file as history. New work takes the next number after the largest existing phase. Pair this with a one-line intro at the top: "Phases marked `✅` have shipped; everything else is planned."
+
+## Phase 6 — Report back
+
+Return to the user in a few lines:
+
+- Files created (full paths) — three of them
+- Confidence levels recorded in each file's frontmatter, with a one-line rationale per level
+- Conflicts surfaced during synthesis (if any) and how they were resolved
+- Next steps (user-driven — this skill does not do them):
+  1. Review the diff (`git diff specs/`).
+  2. Branch + commit + PR per `.claude/rules/git-workflow.md` and `.claude/rules/conventional-commits.md` (suggested header: `docs(specs): bootstrap SDD constitution`).
+  3. Once merged, use `/sdd-new-phase` to add active phases beyond what was bootstrapped, and `/sdd-new-spec <N>` to materialize a phase into a feature spec.
+
+If the run aborted at the Phase 0 guard, the report is a single line — no Phase 6 sections, just confirmation that the existing constitution was preserved.

--- a/.claude/skills/sdd-distill-lessons/SKILL.md
+++ b/.claude/skills/sdd-distill-lessons/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: sdd-distill-lessons
+description: Distil per-spec retrospectives into specs/lessons.md so future spec authoring absorbs the learning. Reads specs/*/retrospective.md, groups recurring patterns, surfaces candidate lessons and tech-stack.md promotion candidates via AskUserQuestion, writes confirmed additions to specs/lessons.md, then invokes /review against the pending change before stopping.
+argument-hint: "(no arguments)"
+---
+
+# /sdd-distill-lessons — distil retrospectives into specs/lessons.md
+
+You are operating within a Spec-Driven Development (SDD) workflow. See `.claude/rules/sdd-constitution.md`.
+
+This skill is the manual roll-up step of the SDD feedback loop. Per-spec `specs/<date>-<slug>/retrospective.md` files capture what individual specs missed; this skill reads them, deduplicates lessons across retrospectives, and writes the durable additions into `specs/lessons.md` so `/sdd-new-spec` and `/sdd-new-phase` consume them on their next run. When a lesson recurs across multiple retrospectives **and** clearly names a load-bearing invariant, the skill flags it as a `specs/tech-stack.md` promotion candidate for the user to hand-promote.
+
+## Hard constraints
+
+- **`specs/lessons.md` only — no other writes.** This skill edits exactly one file. `specs/tech-stack.md` promotions are surfaced as user-actionable suggestions; the skill never edits `tech-stack.md`. Retrospectives are read-only.
+- **Do not write to disk before the AskUserQuestion confirmation completes.** The grouped lesson candidates exist to lock in what gets captured; writing early wastes the call.
+- **No git actions.** This skill writes files and stops. Branching, committing, and PR creation are user actions per `.claude/rules/git-workflow.md`.
+- **Ground every proposed lesson in at least one retrospective.** Do not invent lessons; do not paraphrase a retrospective into a lesson it does not actually support.
+- **Dedupe before proposing.** If two retrospectives surface the same lesson (semantically), group them into one candidate referencing both retrospectives — do not propose duplicate bullets.
+- **Do not re-propose already-captured lessons.** Compare each candidate against the existing `specs/lessons.md` body and skip anything substantively present.
+
+## Phase 0 — Load context
+
+Load in parallel:
+
+- @specs/mission.md
+- @specs/tech-stack.md
+- @specs/lessons.md
+- @.claude/rules/sdd-constitution.md
+
+Enumerate `specs/*/retrospective.md` files (every dated feature-spec directory may or may not have one — retrospectives are optional). Load each in parallel via `Read`.
+
+If no retrospectives exist, stop with a one-line summary ("No retrospectives found under `specs/*/retrospective.md`; nothing to distil.") — there is nothing to do.
+
+## Phase 1 — Parse retrospectives and existing lessons
+
+For each retrospective, extract:
+
+- Phase number and title from the H1
+- Each bullet under `## Lesson for future specs`
+- The `## Promotion candidate` verdict (`yes` or `no` plus the rationale sentence)
+
+For `specs/lessons.md`, extract the bullets currently present under `## Lessons` (the section may still contain the initialisation placeholder `_(empty — …)_` — treat that as no lessons captured yet).
+
+## Phase 2 — Group and dedupe candidate lessons
+
+Combine all extracted lesson bullets from all retrospectives. Group lessons that say the same thing semantically (different phrasings of the same guidance count as one). For each grouped candidate:
+
+- Record the source retrospectives (one or more file paths)
+- Phrase the candidate as a single actionable bullet
+- Mark as a **promotion candidate** if **either** (a) two or more retrospectives surfaced this same lesson, **or** (b) any source retrospective marked `## Promotion candidate: yes`. This surfacing threshold is intentionally looser than the constitution's promotion bar (which requires recurrence **and** invariant status) — better to surface a borderline candidate than miss one; the human applies the conjunction when deciding whether to actually hand-promote.
+
+This full grouped set is the basis for promotion-candidate detection (Phase 5). From it, derive a **new-candidate set** by filtering out any lesson already substantively present in `specs/lessons.md`'s existing bullet list. A lesson that is already captured can still qualify as a promotion candidate — being in `lessons.md` does not preclude promotion to `specs/tech-stack.md`.
+
+If the new-candidate set is empty, skip Phases 3 and 4 (no `AskUserQuestion`, no file edit) and go directly to Phase 5 with a one-line note ("All retrospective lessons are already captured in `specs/lessons.md`; nothing new to add."). Phase 5 still runs to report any promotion candidates from the full grouped set.
+
+## Phase 3 — AskUserQuestion (MANDATORY, before any disk write)
+
+Issue a single `AskUserQuestion` call (multi-select) listing the candidate lessons as options:
+
+- Prompt: "Which lessons should I add to `specs/lessons.md`?"
+- Header: `Lessons` (≤ 12 chars per the schema)
+- `multiSelect: true`
+- Per the schema, **at most 4 options per call**. If there are more than 4 candidates, present the 4 with the strongest signal first (highest source-retrospective count; ties broken by oldest retrospective first), and note in the response that remaining candidates can be reviewed on a follow-up run. Each option:
+  - `label`: short version of the lesson (≤ ~40 chars; truncate with `…` if needed)
+  - `description`: the full lesson bullet + ` (sources: <retro-1-path>[, <retro-2-path> …])` + ` [promotion candidate]` when applicable
+
+The automatic freeform write-in lets the user re-phrase a candidate before accepting or describe why they want to skip one.
+
+## Phase 4 — Edit specs/lessons.md
+
+For each lesson the user confirmed in Phase 3, append a bullet under the `## Lessons` section of `specs/lessons.md`. Bullet shape:
+
+```
+- <lesson text> — captured from `specs/<date>-<slug>/retrospective.md`[, `specs/<other-date>-<other-slug>/retrospective.md`]
+```
+
+If `## Lessons` still contains the initialisation placeholder (`_(no lessons captured yet)_`), replace the placeholder with the new bullets. Otherwise, append after the existing bullets.
+
+Do not edit any section of the file other than `## Lessons`. Do not touch `## Lifecycle` or the file's header.
+
+## Phase 5 — Surface promotion candidates
+
+For each candidate flagged as a promotion candidate in Phase 2 (whether or not the user accepted it in Phase 3 — promotion is about recurrence, not about whether the lesson belongs in `lessons.md`), report it to the user as a `specs/tech-stack.md` promotion suggestion. **Do not edit `tech-stack.md`** — surface only.
+
+Format:
+
+```
+Promotion candidates for `specs/tech-stack.md` (manual edits):
+
+- <lesson text> — recurring across <N> retrospectives (<retro-1-path>, <retro-2-path>, …). Suggested home: `specs/tech-stack.md` <section if obvious, e.g. "## Conventions" or "## Constraints">.
+```
+
+If no candidates qualify, omit this section.
+
+## Phase 6 — Review the edit
+
+Immediately after the `specs/lessons.md` edit lands, invoke the built-in `review` skill via the `Skill` tool with argument `local changes`. The `review` skill handles a working-tree diff when given that argument — treat it as a normal capability of the skill.
+
+- Invoke the `Skill` tool with `skill: "review"` and `args: "local changes"`.
+- Do not skip or defer this step; it is part of the skill's contract.
+- Do **not** narrate the invocation mechanism, describe the skill as PR-oriented, explain arguments, or frame the call as a workaround. Just run it and report its findings.
+- Surface the reviewer's findings verbatim; do not summarise them away.
+- If the reviewer flags an in-scope issue (e.g. a malformed bullet, a wrong source reference, a stale placeholder left behind), offer to apply a fix and ask the user to confirm before re-editing. Do not auto-apply fixes.
+- If the `Skill` invocation itself fails (tool error, unrecognised arg, unreachable), surface the error and proceed to Phase 7; do not silently drop the step, and do not retry more than once.
+
+## Phase 7 — Report back
+
+Return to the user in a few lines:
+
+- Number of retrospectives read
+- Lessons added to `specs/lessons.md` (count + one bullet per accepted lesson)
+- Lessons skipped (count + one-line reason: already captured / user declined / queued for follow-up run)
+- Promotion candidates surfaced for manual `specs/tech-stack.md` addition (count + one bullet per, with source retros)
+- **Review outcome:** one-line verdict from Phase 6 — `clean`, `suggestions available`, `blocker`, or `review skipped — <one-line error>`
+- Next steps (user-driven — this skill does not do them):
+  1. Review the diff (`git diff specs/lessons.md`).
+  2. Hand-promote any flagged candidates into `specs/tech-stack.md` if appropriate.
+  3. Branch + commit + PR per `.claude/rules/git-workflow.md` and `.claude/rules/conventional-commits.md` (suggested header: `docs(lessons): distil retrospectives`).

--- a/.claude/skills/sdd-implement-spec/SKILL.md
+++ b/.claude/skills/sdd-implement-spec/SKILL.md
@@ -18,8 +18,8 @@ Argument in `$ARGUMENTS` (optional):
 
 - empty → enumerate unprocessed specs and pick via AskUserQuestion
 - integer (`24`, `25`) → spec whose `requirements.md` H1 starts with `# Phase <N>`
-- slug fragment (`"oauth-broker"`) → case-insensitive contains match against spec dir slugs (the portion after the date prefix); if ambiguous, list matches and ask
-- relative path (`specs/2026-05-07-google-oauth-broker-token-mode`) → use directly; verify it exists and is a valid spec dir
+- slug fragment (`"gate-allowlist"`) → case-insensitive contains match against spec dir slugs (the portion after the date prefix); if ambiguous, list matches and ask
+- relative path (`specs/2026-05-21-gate-allowlist`) → use directly; verify it exists and is a valid spec dir
 
 ## Hard constraints
 
@@ -51,7 +51,6 @@ Load context in parallel:
 - @.claude/rules/sdd-constitution.md
 - @.claude/rules/git-workflow.md
 - @.claude/rules/conventional-commits.md
-- @.claude/rules/testing.md
 - @.claude/rules/karpathy-guidelines.md
 
 ## Phase 1 — Enumerate unprocessed specs and pick
@@ -150,12 +149,11 @@ For each `## Group <N> — <Title>` in order, **excluding** the final Verify gro
    - Match existing code patterns; surgical changes only (per `.claude/rules/karpathy-guidelines.md`).
    - Use the file/line references in `plan.md` as authoritative starting points. Minor drift (line numbers off by a few from intervening commits) is fine and silent; if a referenced file or symbol is clearly absent or has been replaced wholesale, stop and surface — do not improvise around the spec.
    - Do not add scope the spec did not call for. If the work obviously requires an adjacent change the spec missed, surface it and ask before adding.
-3. After the group's tasks are implemented, run any group-relevant local gates per `.claude/rules/testing.md` (scoped to the area touched if practical):
-   - Backend changes: `uv run poe lint` and `uv run poe test` (target a subset like `uv run poe test tests/<area>` when the change is narrow)
-   - UI changes: `cd ui && npm run lint && npx tsc --noEmit && npm run test:run` — chained so all three run inside `ui/`. Use `test:run`, not `test` (`test` is watch mode and won't exit).
+3. After the group's tasks are implemented, run any group-relevant local gates (scoped to the area touched if practical). The exact test/lint commands depend on the code tree — examples for shapes this repo has shipped:
+   - Docker runner changes: `cd docker && uv run poe lint` and `cd docker && uv run poe test` (target a subset like `cd docker && uv run poe test tests/test_gate.py` when the change is narrow). The `cd docker &&` prefix is required — `pyproject.toml` and `poethepoet` only resolve from inside `docker/`.
 4. Stage the files this group touched by explicit path. Run `git diff --cached --name-only` and confirm only the expected paths appear; if anything else is staged, stop and surface.
 5. Commit per `.claude/rules/conventional-commits.md`:
-   - Header `<type>(<scope>): <description>` ≤ 69 chars; type/scope reflect the group's primary subject (e.g. `feat(broker): support reverse-proxy path prefix`, `test(root_path): add three-mode integration coverage`)
+   - Header `<type>(<scope>): <description>` ≤ 69 chars; type/scope reflect the group's primary subject (e.g. `feat(gate): allow github-raw spec URLs anonymously`, `test(score): add engine-timeout integration coverage`)
    - Body: short paragraph naming what shipped. Include `Refs #<issue>` if the user provided one. **Do not** use GitHub close-keywords (`Closes`, `Fixes`, `Resolves`) here — they belong only in the PR body.
    - `git commit -s` (DCO sign-off)
 6. `TaskUpdate` the group task → `completed`.
@@ -285,12 +283,12 @@ If the deviation list is non-empty, write `specs/<date>-<slug>/retrospective.dra
 git push -u origin <branch>
 ```
 
-**Search for related issues** before drafting the PR body. Run `gh issue list --search "<keyword from phase title>"` and try one or two close synonyms (e.g. for Phase 24, search "oauth", "broker", "credentials"). Per `.claude/rules/git-workflow.md`, link related issues in the PR body. If any open issues plausibly relate to the phase and weren't named in Phase 3, surface them to the user and ask whether to link any with `Closes #<issue>` (full resolution) or `Refs #<issue>` (partial). If nothing relevant turns up, proceed with only the Phase 3 issue (if any).
+**Search for related issues** before drafting the PR body. Run `gh issue list --search "<keyword from phase title>"` and try one or two close synonyms (e.g. for a phase about the URL allowlist, search "gate", "allowlist", "url"). Per `.claude/rules/git-workflow.md`, link related issues in the PR body. If any open issues plausibly relate to the phase and weren't named in Phase 3, surface them to the user and ask whether to link any with `Closes #<issue>` (full resolution) or `Refs #<issue>` (partial). If nothing relevant turns up, proceed with only the Phase 3 issue (if any).
 
 Open the PR with `gh pr create`. The PR title shape is the Conventional Commits header that will become the squash-merge commit (commitlint enforces this on the merge):
 
-- Pick the type+scope of the headline change for the phase. Often this is the same shape as the largest non-Verify group's commit (e.g. `feat(broker): support reverse-proxy path prefix`).
-- If the phase spans multiple modules (backend + UI + docs is common), prefer the most user-facing scope — the squash-merge commit must read like a release-note line for the phase as a whole, not a description of one slice.
+- Pick the type+scope of the headline change for the phase. Often this is the same shape as the largest non-Verify group's commit (e.g. `feat(gate): allow github-raw spec URLs anonymously`).
+- If the phase spans multiple modules (CLI + runner + docs is common), prefer the most user-facing scope — the squash-merge commit must read like a release-note line for the phase as a whole, not a description of one slice.
 - ≤ 69 chars; lowercase imperative; no trailing period.
 
 Body via HEREDOC:

--- a/.claude/skills/sdd-implement-spec/SKILL.md
+++ b/.claude/skills/sdd-implement-spec/SKILL.md
@@ -1,0 +1,364 @@
+---
+name: sdd-implement-spec
+description: Implement an existing feature spec end-to-end — pick an unprocessed feature spec (one whose `## Phase N — ...` heading in `specs/roadmap.md` does not yet carry the `✅` lifecycle marker), cut a feature branch, walk `plan.md` task groups in order with one primary atomic Conventional-Commits commit per group (plus optional small fix-up commits during verification or pre-push review), run `plan.md`'s Verify group plus every check in `validation.md`, then run a pre-push review pairing the built-in `/review` skill with three parallel deep-review subagents (spec-adherence, code-quality, risk-and-robustness) before pushing and opening the PR. The spec is read-only during implementation; if it is wrong or incomplete, the skill stops and surfaces the gap rather than patching the spec mid-flight. Reports implementation, review, and verification results at the end. When `$ARGUMENTS` is empty, enumerates unprocessed specs via AskUserQuestion.
+argument-hint: "[phase-number | slug-fragment | spec-dir-path] (optional)"
+---
+
+# /sdd-implement-spec — implement a feature spec
+
+You are operating within a Spec-Driven Development (SDD) workflow. See `.claude/rules/sdd-constitution.md`.
+
+This skill takes one **unprocessed feature spec** (a `specs/YYYY-MM-DD-<slug>/` directory whose `## Phase N — ...` heading in `specs/roadmap.md` does not yet carry the `✅` lifecycle marker) and drives the work end-to-end: cuts the feature branch, walks `plan.md` task groups, runs the verification gates, commits atomically per group, runs a pre-push review (built-in `/review` plus three parallel deep-review subagents), pushes, opens a PR, and reports back on implementation, review, and verification.
+
+The skill **drives** implementation — it is not merely scaffolding around it. The actual code changes happen in the main loop guided by `plan.md`. The spec itself is read-only.
+
+## Inputs
+
+Argument in `$ARGUMENTS` (optional):
+
+- empty → enumerate unprocessed specs and pick via AskUserQuestion
+- integer (`24`, `25`) → spec whose `requirements.md` H1 starts with `# Phase <N>`
+- slug fragment (`"oauth-broker"`) → case-insensitive contains match against spec dir slugs (the portion after the date prefix); if ambiguous, list matches and ask
+- relative path (`specs/2026-05-07-google-oauth-broker-token-mode`) → use directly; verify it exists and is a valid spec dir
+
+## Hard constraints
+
+- **The spec is read-only during implementation.** Do not edit `specs/<dir>/requirements.md`, `plan.md`, or `validation.md`. If the spec is wrong, incomplete, or contradicts current code, stop and surface the gap; the user owns spec edits and may re-run the skill after revising.
+- **`plan.md` is the source of truth for ordering and scope.** Walk groups sequentially. Each non-Verify group produces one primary atomic commit; verification (Phase 7) may add small fix-up commits if a check fails. Tasks within a group can interleave as needed for the change to make sense.
+- **`validation.md` is the source of truth for done.** Every numbered check must pass before opening the PR. If a check fails and cannot be fixed without changing the spec, stop and surface it.
+- **Roadmap completion marking is part of `plan.md`.** The convention is for `plan.md` to include "Append `✅` to the `## Phase N — <Title>` heading in `specs/roadmap.md`" as a numbered task in its final docs/lifecycle group; respect it. If `plan.md` does not include the completion-marking task, surface the gap before starting — do not improvise it.
+- **Conventional Commits + DCO sign-off.** Per `.claude/rules/conventional-commits.md` and `.claude/rules/git-workflow.md`. Every commit `git commit -s`; header ≤ 69 chars; type+scope reflect the group's primary subject; lowercase imperative description, no trailing period.
+- **Atomic, surgical commits.** Per `.claude/rules/git-workflow.md` and `.claude/rules/karpathy-guidelines.md`: one logical change per commit (applies equally to primary group commits and Phase 7 verification fix-ups), touch only what the change requires, do not improve adjacent code.
+- **No destructive git.** No `--force`, no `reset --hard`, no `--no-verify`. If a pre-commit hook rejects the commit, no commit was created — fix the underlying issue, restage, and retry the same `git commit` (don't add a duplicate). The "never amend" rule applies *after* a commit already exists and you discover a problem; in that case add a fix-up commit on top instead of amending.
+- **Stage explicit paths.** Never `git add -A` or `git add .` — name the files the group touched. After staging, verify `git diff --cached --name-only` lists only those paths.
+- **Ask the user when work surfaces a real decision.** During Phase 6 (implementation) and Phase 7 (verification), if a task surfaces a choice the spec doesn't lock down — multiple valid approaches a reasonable engineer would weigh, an adjacent change the spec didn't anticipate, drift between spec and code that has more than one reasonable resolution, ambiguous validation expectations — use `AskUserQuestion` to surface it inline rather than picking silently or halting outright. Halting is for genuine blockers; questions are for genuine choices. The user is the source of truth when the spec isn't.
+- **Track spec deviations and draft a retrospective.** Maintain a running list across Phases 6, 7, and 8 of any concrete divergence between what the spec said and what the implementation had to do. Sources of deviations: file/line targets in `plan.md` that drifted, scope the spec missed but the work required, validation checks that needed clarification, fix-up commits that revealed a gap. Each tracked item is one sentence naming the spec file (`requirements.md` / `plan.md` / `validation.md`), the section, and what changed in practice. Phase 9 emits this list in the PR body's `## Spec deviations` section; Phase 8.5 commits a `specs/<date>-<slug>/retrospective.draft.md` on the branch so the reviewer has a structured starting point. The draft is provisional — the reviewer promotes it to `retrospective.md` (edit + rename) or deletes it before merge. Root cause and lessons are left as placeholders; the human fills them in. See `.claude/rules/sdd-constitution.md` (post-implementation feedback loop).
+
+## Phase 0 — Preflight
+
+Run in parallel:
+
+- `git status --porcelain` empty
+- Current branch is `main`
+- `git fetch origin main` succeeds; local `main` not behind `origin/main`. If behind and fast-forwardable, offer `git pull --ff-only` and wait for confirmation. If diverged, stop.
+- `gh auth status` succeeds — fail fast here; Phase 9 depends on it.
+
+Load context in parallel:
+
+- @specs/mission.md
+- @specs/tech-stack.md
+- @specs/roadmap.md
+- @.claude/rules/sdd-constitution.md
+- @.claude/rules/git-workflow.md
+- @.claude/rules/conventional-commits.md
+- @.claude/rules/testing.md
+- @.claude/rules/karpathy-guidelines.md
+
+## Phase 1 — Enumerate unprocessed specs and pick
+
+A spec is **unprocessed** when:
+
+1. `specs/YYYY-MM-DD-<slug>/` exists with `requirements.md`, `plan.md`, and `validation.md` present
+2. Its `# Phase <N> Requirements — ...` H1 names a phase number
+3. The matching `## Phase <N> — ...` heading in `specs/roadmap.md` does **not** end with `✅` (lifecycle: shipped phases keep their block but get `✅` appended to the heading)
+
+**`$ARGUMENTS` is matched only against unprocessed specs.** If a fragment or path resolves to a spec dir whose phase heading in `specs/roadmap.md` already carries `✅`, surface it explicitly ("`<dir>` matched but Phase <N> has already shipped — heading marked `✅` in roadmap") and stop. If a fragment or path resolves to a spec dir whose phase is missing from `specs/roadmap.md` altogether, surface that separately ("`<dir>` matched but Phase <N> has no heading in roadmap — roadmap may be malformed") and stop. Do not silently fall back to fresh enumeration.
+
+**If `$ARGUMENTS` resolves to exactly one unprocessed spec**, show it (phase number + title + dir + one-line goal from roadmap) and ask the user to confirm before continuing.
+
+**If `$ARGUMENTS` resolves to multiple unprocessed specs** (e.g. ambiguous slug fragment), issue an `AskUserQuestion` call with one option per match — same shape as the empty-args enumeration below (`header: "Spec"`, options carrying `label` + `description`). Do not silently choose the first.
+
+**If `$ARGUMENTS` resolves to zero unprocessed specs** (e.g. integer doesn't match a spec dir, slug fragment matches nothing, path doesn't exist), surface the mismatch with the candidate list and stop. Do not silently fall through to enumeration.
+
+**If `$ARGUMENTS` is empty**, enumerate all unprocessed specs and present them by count:
+
+- 0 → stop with a one-line summary; nothing to implement
+- 1 → show it (phase + title + dir + goal) and ask the user to confirm
+- 2–4 → issue a single `AskUserQuestion` call with one option per spec
+- 5+ → issue `AskUserQuestion` with the 3 lowest-numbered specs (oldest pending work first); the automatic freeform write-in lets the user specify any other phase number or slug
+
+The `AskUserQuestion` call uses `header: "Spec"` (max 12 chars, per the schema) and question text like `"Which unprocessed spec should I implement?"`. Each option provides only `label` and `description`:
+
+- `label`: `Phase <N> — <Title>` (truncate the title if needed; full title appears in the description)
+- `description`: `<spec-dir>; <one-line goal from roadmap>`
+
+**Freeform write-in handling.** Every `AskUserQuestion` call gets an automatic freeform "Other" option. If the user types a phase number or slug there (whether in the multi-match, the 2–4-spec, or the 5+-spec branch above), treat the freeform value as a fresh `$ARGUMENTS` and re-run the matching rules at the top of this phase. If it still doesn't resolve to exactly one unprocessed spec, ask again.
+
+If the chosen phase has unsatisfied dependencies (per `Depends on:` in `specs/roadmap.md` — any named phase whose heading does NOT yet carry `✅` is unshipped), warn with the specific dependencies and ask the user to confirm before continuing.
+
+**Spec age check.** Run `git log -1 --format=%ai -- specs/<dir>` for the chosen spec. If the spec was last touched more than ~14 days ago, warn the user that `plan.md`'s file/line references may have drifted from current `main` and ask whether to proceed, refresh the spec first, or abort. Heuristic only — never block on age alone.
+
+## Phase 2 — Load and parse the spec
+
+Load in parallel:
+
+- `specs/<dir>/requirements.md`
+- `specs/<dir>/plan.md`
+- `specs/<dir>/validation.md`
+
+Parse `plan.md`:
+
+- Extract `## Group <N> — <Title>` blocks in order
+- Extract numbered tasks under each (sequential numbering across all groups, per the scaffolding convention)
+- Identify the final group as the Verify group. Per `sdd-new-spec`'s template the last group is always named `Verify` and contains command-style verification tasks (no code changes). If a future spec uses a different name but the content is still command-style, treat it as Verify. If the final group contains code-change tasks the spec is malformed against the SDD convention — stop and report; do not improvise alternative control flow for Phases 6 and 7.
+- Locate the **roadmap-completion task** — a numbered task in the final docs/lifecycle group whose body says to append ` ✅` (a single space followed by the U+2705 checkmark) to the `## Phase N — <Title>` heading in `specs/roadmap.md`. The space matters: Verify assertions `grep -F` for the exact ` ✅` suffix, so `Title✅` (no space) would silently fail.
+
+Parse `validation.md`:
+
+- Extract `### <N>. <Check Title>` numbered subsections under `## Definition of Done`
+- Each subsection contains either a fenced command + expectation, or a structural assertion (file contents, presence of a row, etc.)
+- Note the trailing `## Not Required` section — surfaced in the PR body's "Out of scope" subsection so reviewers see what's deliberately deferred
+
+If parsing fails (no groups, no validation checks, missing roadmap-completion task in `plan.md`, malformed structure), stop and report what couldn't be parsed. Do not improvise around a malformed spec.
+
+## Phase 3 — Derive branch name and check idempotence
+
+Slug: the trailing portion of the spec dir name after the `YYYY-MM-DD-` prefix (e.g. `2026-05-08-reverse-proxy-path-prefix-support` → `reverse-proxy-path-prefix-support`).
+
+Branch prefix per `.claude/rules/git-workflow.md`:
+
+- `feature/` (default)
+- `fix/` if the phase title starts with "Fix" or the goal describes a defect
+- `chore/` for tooling / maintenance phases
+- `docs/` for pure documentation phases
+- `test/` for phases that are purely test coverage with no production-code changes (e.g. "Backend Unit Test Coverage")
+
+Ask the user once: "Is there a GitHub issue for this phase? (issue number, or 'no')". If yes, branch = `<prefix>/<issue>-<slug>`; else `<prefix>/<slug>`.
+
+Branch idempotence: if the target branch already exists locally or on `origin`, stop and ask whether to switch to it / rename / abort. Resuming a partially-implemented branch is out of scope for this skill — surface the situation and let the user decide.
+
+## Phase 4 — Cut the branch
+
+```
+git checkout -b <branch>
+```
+
+Do not push yet — Phase 9 handles push after the final commit (Phase 8 runs the pre-push review first).
+
+## Phase 5 — Seed TaskCreate from plan.md groups
+
+Use `TaskCreate` to create one task per `## Group <N> — <Title>` block (**including** the final Verify group), plus one trailing synthetic task labeled `Pre-push review` for Phase 8. Each plan-group task's description is the group title.
+
+This gives the user a live progress view while the skill walks groups. Phase 6 (non-Verify groups), Phase 7 (Verify group), and Phase 8 (pre-push review) own their own `in_progress` / `completed` transitions; do not pre-mark them in Phase 5.
+
+## Phase 6 — Implement: walk non-Verify groups
+
+For each `## Group <N> — <Title>` in order, **excluding** the final Verify group:
+
+1. `TaskUpdate` the group task → `in_progress`.
+2. Implement the numbered tasks within the group:
+   - Match existing code patterns; surgical changes only (per `.claude/rules/karpathy-guidelines.md`).
+   - Use the file/line references in `plan.md` as authoritative starting points. Minor drift (line numbers off by a few from intervening commits) is fine and silent; if a referenced file or symbol is clearly absent or has been replaced wholesale, stop and surface — do not improvise around the spec.
+   - Do not add scope the spec did not call for. If the work obviously requires an adjacent change the spec missed, surface it and ask before adding.
+3. After the group's tasks are implemented, run any group-relevant local gates per `.claude/rules/testing.md` (scoped to the area touched if practical):
+   - Backend changes: `uv run poe lint` and `uv run poe test` (target a subset like `uv run poe test tests/<area>` when the change is narrow)
+   - UI changes: `cd ui && npm run lint && npx tsc --noEmit && npm run test:run` — chained so all three run inside `ui/`. Use `test:run`, not `test` (`test` is watch mode and won't exit).
+4. Stage the files this group touched by explicit path. Run `git diff --cached --name-only` and confirm only the expected paths appear; if anything else is staged, stop and surface.
+5. Commit per `.claude/rules/conventional-commits.md`:
+   - Header `<type>(<scope>): <description>` ≤ 69 chars; type/scope reflect the group's primary subject (e.g. `feat(broker): support reverse-proxy path prefix`, `test(root_path): add three-mode integration coverage`)
+   - Body: short paragraph naming what shipped. Include `Refs #<issue>` if the user provided one. **Do not** use GitHub close-keywords (`Closes`, `Fixes`, `Resolves`) here — they belong only in the PR body.
+   - `git commit -s` (DCO sign-off)
+6. `TaskUpdate` the group task → `completed`.
+
+If a pre-commit hook rejects the commit, no commit was created — fix the underlying issue, restage, and re-run the same `git commit` command. Don't add a duplicate. Never `--amend`, never `--no-verify`.
+
+If implementation hits an obstacle mid-group, decide first whether it's a **genuine blocker** (no path forward without spec changes) or a **decision** (more than one reasonable resolution exists). For decisions, use `AskUserQuestion` per the hard constraint and continue based on the answer. For genuine blockers (a task is impossible against current code, an external dependency is missing, an assumption in `plan.md` is false), stop immediately and report:
+
+- Which group / numbered task halted
+- The specific error or unmet condition
+- Last successful commit SHA on the branch
+- Recommended next step (typically: revise `plan.md`, fix locally outside the spec, or abort and re-plan)
+
+The roadmap-completion task identified in Phase 2 lives inside one of the groups (typically the final docs/lifecycle group, before Verify). Implement it as part of that group's commit — do not split it into its own commit unless the spec instructs otherwise. The change is mechanical: append ` ✅` (space, then `✅`) to the `## Phase N — <Title>` heading in `specs/roadmap.md`; leave the rest of the block in place.
+
+## Phase 7 — Run plan.md Verify group + validation.md
+
+`TaskUpdate` the Verify group task → `in_progress`.
+
+`plan.md`'s Verify group and `validation.md`'s Definition-of-Done often overlap (e.g. both say `uv run poe lint`). For overlapping commands, run each unique command **once** and mark both gates satisfied for that command — don't re-run a passing test just because it's listed in two places.
+
+**Run `plan.md`'s Verify group commands** in order. These are local-gate verifications, not code changes — they produce no commit. Capture exit codes and key output lines for the Phase 10 report.
+
+**Run `validation.md` numbered checks** sequentially (some depend on prior state — do not parallelise):
+
+- Fenced command + expectation → execute, compare exit code / status / output substring against the stated expectation
+- Non-command check (file content, structural assertion) → inspect and confirm
+
+For any failure:
+
+- If the cause is obviously trivial and within the spec's scope (lint nit, missing import, doc-row gap, typo) → fix it and commit the fix as its own atomic commit. Conventional Commits header reflects the fix (typically `fix(<scope>): ...` or `docs(<scope>): ...`). `git commit -s`.
+- If the fix isn't trivial, stop and report — do not iterate on guesses, and do not patch the spec to make a check pass.
+
+After every check passes, `TaskUpdate` the Verify group → `completed` and assemble a verification summary for Phase 10:
+
+- Each `plan.md` Verify command + result (pass/fail + key line)
+- Each `validation.md` check + result (pass/fail + the asserted condition that held)
+
+## Phase 8 — Pre-push review
+
+After Phase 7 passes and before pushing, run two reviews of the branch diff. Both fire **before `git push`** (Phase 9) so any fixes can land as cheap fix-up commits on the local branch.
+
+If the run halts mid-phase (user dismisses the synthesis question, tool error during a fix-up commit, etc.), surface the situation per Phase 3's branch-idempotence policy and stop — partial-resume of Phase 8 is out of scope. A re-run starts Phase 8 from scratch on the same branch; the existing per-group commits and any landed fix-ups are preserved.
+
+`TaskUpdate` the `Pre-push review` task → `in_progress`.
+
+### Capture diff context once
+
+Run these once and pass the output to every reviewer:
+
+- `git log main..HEAD --oneline` — the commit list
+- `git diff --stat main...HEAD` — the file-level summary
+- `git diff main...HEAD` — the full diff
+
+For very large diffs (≥ ~2000 lines or ≥ ~30 files), pass each subagent the commit list, the file-level summary, and the list of paths to read directly via `Read` — sending a multi-megabyte diff inline to four reviewers wastes tokens and can blow the context window.
+
+### A. Built-in `/review` skill
+
+Invoke the `Skill` tool with `skill: "review"` and ``args: "branch changes against main (`git diff main...HEAD`)"``. The string is best-effort — `/review` is built around PR URLs and a "local changes" working-tree mode, so it may interpret a branch-vs-main scope fluidly or report it has nothing concrete to review; either result is fine. Surface whatever it returns verbatim, do not narrate the invocation mechanism, do not retry. The load-bearing reviewer is the three-perspective deep review in **B** below; `/review` here is a sanity-check pass. If the invocation itself fails (tool error, unreachable), surface the error and continue to B.
+
+### B. Three-perspective deep review
+
+Spawn three `Agent` calls **in a single message** (parallel) using `subagent_type: "general-purpose"`. Each subagent gets a perspective-specific brief, the diff context captured above, and the spec/rule files relevant to its lens. Cap each response at ~400 words — the goal is a structured findings list, not narrative.
+
+The shared question for every perspective: *from this lens, is anything in the diff wrong, surprising, missing, or obviously improvable?* Each finding line takes the shape:
+
+`<finding-type>: <one-line summary> — <file:line if applicable> — <suggested fix, or "surface to user">`
+
+**Perspective 1 — Spec adherence.** Inputs: `specs/<dir>/requirements.md`, `plan.md`, `validation.md`, the commit list, the diff. Look for: groups/tasks in `plan.md` not visible in any commit; commits introducing work outside the spec's scope; deviations from `plan.md`'s prescribed file/line targets without surfacing; the roadmap-completion task missing from its expected group commit (the diff should show ` ✅` appended to the `## Phase N — <Title>` heading in `specs/roadmap.md`). Finding-types: `missing-task`, `extra-scope`, `silent-deviation`, `roadmap-completion-missing`.
+
+**Perspective 2 — Code quality and simplicity.** Inputs: the diff, the commit list, `.claude/rules/karpathy-guidelines.md`, `.claude/rules/git-workflow.md`, `.claude/rules/conventional-commits.md`. Look for: speculative features the spec doesn't require; abstractions for single-use code; error handling for impossible scenarios; "improvements" to adjacent code beyond the change scope; comments explaining WHAT instead of WHY (especially comments referencing the current task / fix / caller); non-atomic commits; CC type/scope that misrepresents the commit's content. Finding-types: `bloat`, `abstraction`, `adjacent-edit`, `dead-comment`, `commit-shape`.
+
+**Perspective 3 — Risk and robustness.** Inputs: the diff, `specs/tech-stack.md`, and any load-bearing invariants documented in the project's `CLAUDE.md` files anywhere in the tree (repo root, `.claude/`, or nested per-directory) — the subagent reads what's actually present at runtime; the skill itself does not bake in domain knowledge or project-specific invariants. Look for: security concerns (auth bypass, credential exposure, secrets in logs, injection); validation gaps (edge cases `validation.md` doesn't cover but the diff plausibly hits); regression risks to invariants the subagent surfaces from `tech-stack.md` or `CLAUDE.md`; observability gaps (a new code path with no trace/log); performance or scaling concerns (N+1 queries, unbounded growth, blocking I/O on the request path). Finding-types: `security`, `regression`, `edge-case`, `observability`, `performance`.
+
+### Synthesize
+
+Combine findings from `/review` + the three subagents into one grouped list:
+
+- **Blockers** — in-scope issues that should be fixed before PR (broken validation, missing spec coverage, security regression, architectural violation, commit-shape error that would survive the squash-merge)
+- **Suggestions** — optional improvements (simpler approach, better naming, additional test case, observability gap)
+- **Nits** — cosmetic only (typos, formatting)
+
+Deduplicate findings raised by more than one reviewer; keep the strongest framing. Demote out-of-scope findings (changes adjacent to the spec but not within it) to **Suggestions** with an `(out-of-scope, optional)` tag — never silently promote them to blockers, and never silently apply them.
+
+### Resolve
+
+Surface the grouped report to the user. If there are blockers, use a single `AskUserQuestion` (multi-select) to choose which to fix. For suggestions/nits, list them and ask once whether to apply any (default: skip).
+
+For each accepted fix:
+
+- Apply as a small atomic fix-up commit per Phase 6's commit rules — Conventional Commits header (typically `fix(<scope>): ...`, `refactor(<scope>): ...`, or `docs(<scope>): ...`), `git commit -s`, stage explicit paths, no `--amend`, no `--no-verify`
+- Unrelated fixes → multiple commits
+
+For blockers the user declines to fix, confirm explicitly that you should proceed and record a one-liner for the Phase 10 report (`Proceeded over blocker: <one-liner>`).
+
+After fix-ups:
+
+- Re-run the `validation.md` numbered checks whose covered area intersects the fix-up diff (don't re-run the whole Verify group unless every check is plausibly affected)
+- Re-invoke `/review` at most **once**, and only if any fix-up commit touched code (not docs/config-only paths). Do **not** re-spawn the three subagents — they fire once per skill run.
+
+`TaskUpdate` the `Pre-push review` task → `completed`.
+
+## Phase 8.5 — Draft retrospective (conditional)
+
+Skip this phase entirely if the deviation list is empty.
+
+If the deviation list is non-empty, write `specs/<date>-<slug>/retrospective.draft.md` and commit it before pushing. The draft gives the reviewer a structured starting point — they promote it to `retrospective.md` (edit + rename) or delete it before merge; nothing flows into `/sdd-distill-lessons` until a human confirms it.
+
+**File structure** — follow `.claude/templates/sdd/feature-spec/retrospective.example.md`:
+
+- H1: `# Phase <N> Retrospective Draft — <Phase Title>`
+- Opening note (blockquote): `> **DRAFT** — written by \`/sdd-implement-spec\` from tracked implementation deviations. Promote to \`retrospective.md\` (edit + rename) or delete before merge if nothing here is worth capturing.`
+- `## Deviations from the spec` — one bullet per item in the tracked deviation list (same content as the PR body's `## Spec deviations`).
+- `## Root cause` — leave the `[ONE_OR_TWO_SHORT_PARAGRAPHS …]` placeholder; do not speculate.
+- `## Lesson for future specs` — leave the `[LESSON_1 …]` placeholder; do not speculate.
+- `## Promotion candidate` — write `no — update if this lesson names a load-bearing invariant for \`specs/tech-stack.md\`.`
+
+**Commit:**
+
+- Stage only the draft file: `git add specs/<date>-<slug>/retrospective.draft.md`
+- Verify with `git diff --cached --name-only` (must list exactly that one path)
+- `git commit -s -m "docs(spec): draft retrospective for phase <N>"` (≤ 69 chars; body: one sentence — "Agent-generated draft from implementation deviations; reviewer should promote to retrospective.md or delete.")
+
+## Phase 9 — Push and open the PR
+
+```
+git push -u origin <branch>
+```
+
+**Search for related issues** before drafting the PR body. Run `gh issue list --search "<keyword from phase title>"` and try one or two close synonyms (e.g. for Phase 24, search "oauth", "broker", "credentials"). Per `.claude/rules/git-workflow.md`, link related issues in the PR body. If any open issues plausibly relate to the phase and weren't named in Phase 3, surface them to the user and ask whether to link any with `Closes #<issue>` (full resolution) or `Refs #<issue>` (partial). If nothing relevant turns up, proceed with only the Phase 3 issue (if any).
+
+Open the PR with `gh pr create`. The PR title shape is the Conventional Commits header that will become the squash-merge commit (commitlint enforces this on the merge):
+
+- Pick the type+scope of the headline change for the phase. Often this is the same shape as the largest non-Verify group's commit (e.g. `feat(broker): support reverse-proxy path prefix`).
+- If the phase spans multiple modules (backend + UI + docs is common), prefer the most user-facing scope — the squash-merge commit must read like a release-note line for the phase as a whole, not a description of one slice.
+- ≤ 69 chars; lowercase imperative; no trailing period.
+
+Body via HEREDOC:
+
+```
+## Summary
+
+Implements **Phase <N>: <Title>** from the SDD roadmap.
+
+Spec: `specs/<date>-<slug>/`
+
+### What changed
+
+- <one bullet per non-Verify group — short noun phrase, e.g. "Config plumbing for `JENTIC_ROOT_PATH`". The group whose commit performs the roadmap-completion task should mention it inline (e.g. "Docs + roadmap entry marked ✅ per lifecycle"); do not add a separate trailing bullet for the marker.>
+
+## Validation
+
+All gates from `specs/<date>-<slug>/validation.md` passed:
+
+- <check 1 title> — pass
+- <check 2 title> — pass
+…
+
+### Out of scope (from `validation.md` "Not Required")
+
+- <one bullet per item under `## Not Required` in `validation.md` — short paraphrase, not a verbatim copy>
+
+## Spec deviations
+
+- <one bullet per tracked deviation — name the spec file + section + what changed in practice. Plain past-tense sentences, e.g. "`plan.md` Group 3 referenced `src/foo.py` but the function had already moved to `src/bar.py`; implemented against the current path.">
+
+A `specs/<date>-<slug>/retrospective.draft.md` has been committed on this branch as a structured starting point — promote it to `retrospective.md` (edit + rename) or delete before merge. Once merged, `/sdd-distill-lessons` can roll confirmed retrospectives into `specs/lessons.md` so future specs absorb the lesson. See `.claude/rules/sdd-constitution.md` (post-implementation feedback loop).
+
+## Test plan
+
+- [ ] CI green
+- [ ] Manual smoke per `validation.md` (only if `validation.md` has manual-smoke checks)
+
+Closes #<issue>
+Refs: `specs/<date>-<slug>/`
+```
+
+PR body rules:
+
+- `## Spec deviations` is included **only** when the deviation list maintained through Phases 6–8 is non-empty; omit the heading entirely otherwise.
+- `Closes #<issue>` is included **only** when the user provided an issue number in Phase 3 — the implementation PR for a phase typically fully resolves its tracking issue. If no issue was given, omit the line entirely (do not write `Closes #` with no number).
+- `Refs:` always points at the spec dir.
+- **No `🤖 Generated with [Claude Code]` trailer.** Sibling SDD skills (`sdd-new-spec`, `sdd-new-phase`) follow the same convention — the PR is the final step of an SDD workflow whose spec was reviewed and merged separately, so the "generated by Claude" framing doesn't fit. Do not add it back.
+
+## Phase 10 — Report back
+
+Return to the user in this shape:
+
+- **Spec**: `Phase <N> — <Title>` (`specs/<date>-<slug>/`)
+- **Branch**: name
+- **Commits** (in order): each line as `<sha-short> <type>(<scope>): <description> — <group title>`. Include verification fix-up commits and pre-push review fix-up commits, each tagged with the group/finding they amend.
+- **PR URL**
+- **Implementation summary**: one short paragraph naming what was built and where (modules / files / migrations / UI surfaces touched). Aim for the shape a reviewer would skim before opening the diff.
+- **Verification summary**:
+  - `plan.md` Verify group: each command + pass/fail
+  - `validation.md`: each numbered check + pass/fail
+- **Pre-push review outcome**: one of `clean` (no findings), `findings addressed` (had findings, applied fixes — list their SHAs and what they addressed), or `proceeded over blocker` (had blockers, user accepted as-is — include the one-liner). Suggestions or nits the user declined to apply get one short bullet each as optional follow-ups, not regressions. If `/review` couldn't run (tool error), say so on this line instead.
+- **Deviations from the spec** (if any): the same running list emitted in the PR body's `## Spec deviations` section — tasks that were split or merged, file/line targets that drifted, validation checks that needed clarification, fix-up commits that revealed gaps. Each item is one sentence naming the spec file (`requirements.md` / `plan.md` / `validation.md`), the section, and what changed in practice. If deviations existed, also note that `specs/<date>-<slug>/retrospective.draft.md` was committed on the branch — the reviewer should promote it to `retrospective.md` (edit + rename) or delete before merge.
+- **Next step**: human review on the PR. The spec dir stays as history per the lifecycle rule; the roadmap entry was marked `✅` by the relevant commit in this PR.
+
+If the run halted before completion, replace the post-completion sections with:
+
+- **Halted at**: Group / numbered task + the specific reason
+- **Last successful commit**: SHA + label
+- **Verification status so far**: any checks that did pass; checks that were skipped or failed
+- **What to do next**: concrete options (revise the spec, fix locally, re-run skill once the blocker is unblocked)

--- a/.claude/skills/sdd-new-phase/SKILL.md
+++ b/.claude/skills/sdd-new-phase/SKILL.md
@@ -1,0 +1,141 @@
+---
+name: sdd-new-phase
+description: Append a new active phase to specs/roadmap.md. Parses existing phases (active and ✅-completed) to compute the next stable phase number per the lifecycle rule, grounds the proposal against specs/mission.md and specs/tech-stack.md, groups structured questions (goal, dependencies, priority) via AskUserQuestion, then collects a freeform bullet list for the phase body. Edits specs/roadmap.md in place, then invokes the built-in /review skill against the pending change before stopping — committing, pushing, and opening a PR are left to the user. Does not create a feature spec; that is /sdd-new-spec's job.
+argument-hint: "[short title or one-sentence intent] (optional)"
+---
+
+# /sdd-new-phase — add a new active phase to the roadmap
+
+You are operating within a Spec-Driven Development (SDD) workflow. See `.claude/rules/sdd-constitution.md`.
+
+The **constitution** (mission / tech-stack / roadmap) already exists in `specs/`. This skill adds a fresh active phase — a shippable, independently reviewable, testable vertical slice of work — to `specs/roadmap.md` as a new `## Phase N — Title` block. After writing the edit it invokes the built-in `/review` skill against the pending change, then stops. Branching, committing, and opening a PR are user actions. Once the roadmap change is merged, `/sdd-new-spec <N>` materializes the phase into a feature spec.
+
+## Inputs
+
+Argument in `$ARGUMENTS` (optional):
+
+- empty → prompt the user for a one-sentence description of the phase
+- short title or one-sentence intent → used as the starting point for title + goal derivation
+
+## Hard constraints
+
+- **Roadmap-only — zero code changes, zero git actions.** This skill never modifies anything outside `specs/roadmap.md`. It does not run `git`, `gh`, or any commit / branch / push / PR commands. The user handles git themselves after reviewing the edit.
+- **Do not renumber existing phases.** Phase numbers are stable identifiers; completed phases stay in the file with a `✅` marker on their heading (per the lifecycle rule in `specs/roadmap.md`). The new phase number is always `max(all existing phase numbers) + 1` — count both active and ✅-completed phases.
+- **Do not create a feature spec.** That is `/sdd-new-spec`'s job.
+- **Do not touch the `## Later Phases (Not Yet Planned)` section** or the trailing `<!-- Only include items here if they are clearly out of current scope. -->` comment. Active phases and the parking lot are distinct.
+- **Do not write to disk before AskUserQuestion completes.** The structured questions lock in decisions that shape the entry; writing early wastes the call.
+- **Ground the phase against `specs/mission.md` and `specs/tech-stack.md`.** If the proposal obviously conflicts with the constitution (outside mission scope, violates a tech-stack invariant), stop and surface the conflict before asking the user to lock decisions.
+- **`Depends on:` must reference real active phases.** If the user names a dependency, it must match a current `## Phase N — Title` in `specs/roadmap.md` (case-insensitive contains match is fine). Typos get corrected; invented names get rejected.
+
+## Phase 0 — Load context
+
+Load in parallel:
+
+- @specs/mission.md
+- @specs/tech-stack.md
+- @specs/roadmap.md
+- @specs/lessons.md
+- @.claude/rules/sdd-constitution.md
+
+No git state checks — this skill doesn't touch git.
+
+After loading, scan `specs/lessons.md` for any lessons that apply to the proposed phase. Carry the relevant ones into Phase 2 (use them to shape `AskUserQuestion` options where appropriate) and Phase 4 (apply them when writing the phase body). Mention in Phase 6 which lessons influenced the entry. The lessons file is operational, not load-bearing: a lesson that does not apply to this phase is fine to skip — do not force-fit guidance.
+
+## Phase 1 — Parse roadmap, propose phase identity
+
+Parse `specs/roadmap.md` to extract:
+
+- Every phase block (`## Phase N — Title`, with or without a trailing `✅`): number, title, goal, `Depends on:`, `Priority:`, and a `completed` flag set when the heading ends with `✅`. Ignore the `## Later Phases (Not Yet Planned)` section.
+- **Active phases** are those without `✅`; **completed phases** are those with `✅`. The duplicate-overlap check below runs against active phases only — overlapping with already-shipped work is not a conflict.
+- **Next phase number**: `max(all phase numbers, active and completed) + 1`. Phase numbers never get reused, so completed phases count toward the ceiling.
+
+If `$ARGUMENTS` is empty, prompt the user for a one-sentence description of what the phase delivers.
+
+**Duplicate-overlap check:** if the proposal obviously overlaps with an existing active phase (strong keyword overlap with a phase title or goal), surface the overlap to the user and ask whether to proceed anyway, merge into the existing phase, or cancel. Do not silently proceed past an apparent duplicate.
+
+**Constitution-conflict check:** reason briefly about whether the proposal fits within the project's mission scope and tech-stack invariants. If there is an obvious conflict (proposes a capability outside the mission; proposes a runtime dependency the tech-stack forbids; violates a load-bearing constraint like the broker-last router rule), surface it and pause. If there is no obvious conflict, proceed silently — do not pad the response with "nothing conflicts" noise.
+
+Derive a candidate **title** in Title Case (e.g. "Local Service Routing", not "local service routing" or "LOCAL SERVICE ROUTING"). Show it to the user alongside the proposed phase number and confirm (or let them override) before Phase 2.
+
+## Phase 2 — AskUserQuestion (MANDATORY, before any disk write)
+
+Issue a single `AskUserQuestion` call containing three grouped questions. Each question offers 3–5 concrete options plus a freeform "other" write-in.
+
+**Question 1 — Goal** (shapes the `**Goal:**` line):
+  - Prompt: "One-sentence goal for this phase — what does shipping it mean?"
+  - Options: 3–4 goal phrasings derived from the user's initial description, grounded against mission/tech-stack, plus "other (write your own)". Each option is a single sentence starting with an action verb (e.g. "Allow…", "Replace…", "Add…", "Reduce…").
+
+**Question 2 — Dependencies** (shapes the `**Depends on:**` line):
+  - Prompt: "Which existing active phase must ship before this one?"
+  - Options: "none (self-contained)", each **active** (non-✅) phase title from `specs/roadmap.md` as a separate option, and "other (multiple — specify comma-separated)". Do not offer ✅-completed phases as dependency options — they have already shipped and cannot block new work. If the user picks "other", validate the comma-separated names against active phase titles (case-insensitive contains match). Reject inventions with a one-line correction prompt.
+
+**Question 3 — Priority** (shapes the `**Priority:**` line):
+  - Prompt: "What priority level does this phase carry?"
+  - Options: `High`, `High (blocker)`, `Medium–High`, `Medium`, plus "other (write your own)". Use the en-dash (`–`, U+2013) in `Medium–High`, not a hyphen — match existing roadmap formatting exactly.
+  - The priority legend at the top of `specs/roadmap.md` is the source of truth for what each value means; consult it when the user asks what to pick. In short: `(blocker)` fixes a trust/security gap that makes Mini unsafe for real agent usage **today** (early-access safety bar). Items required for a future production-readiness bar do not need `(blocker)` — Mini is not recommended for production regardless, so state the production rationale in the phase body and pick a normal priority. Other levels express relative queue position.
+
+Only after the user answers all three do you proceed.
+
+## Phase 3 — Collect freeform phase body
+
+Ask the user a single freeform question:
+
+> Now describe the phase body — the concrete bullets that define "shippable". Each bullet should be one change (file, module, route, migration, test, doc, etc.). Freeform; I'll format them.
+
+Parse their response into bullets (one per line, `- ` prefix). Do not invent bullets; keep only what the user wrote. Light formatting is fine (normalize leading dashes, capitalization, trailing punctuation); content changes are not.
+
+If the response is fewer than three bullets, ask once: "A phase usually lists at least three concrete tasks — anything to add, or is this intentionally small?" Accept a short phase if the user confirms.
+
+If the user clearly typed a paragraph of prose rather than bullets, split it into a short **context paragraph** (kept as-is before the bullet list) and ask them for the concrete bullets. A phase may have both a context paragraph and a bullet list — see any active phase in `specs/roadmap.md` with prose between the `**Priority:**` line and the bullets for the shape.
+
+## Phase 4 — Edit the roadmap
+
+Edit `specs/roadmap.md` to insert the new phase. **Insertion rules:**
+
+- Phase blocks (active and ✅-completed alike) are separated from the `## Later Phases (Not Yet Planned)` section by a `---` horizontal rule.
+- Insert the new block **immediately before the `---` that precedes `## Later Phases`** — after the last existing phase block, regardless of whether the trailing phase is active or completed. Phase numbers are sequential by number, not by status.
+- Separate the new block from the previous phase with a single blank line; match the existing file's spacing.
+- Do not renumber any existing phase. Do not strip `✅` markers from completed phases.
+- Do not edit the `## Later Phases (Not Yet Planned)` section or the trailing HTML comment.
+
+**Block format** — match existing phases exactly:
+
+```
+## Phase <N> — <Title>
+
+**Goal:** <goal sentence ending with a period>.
+**Depends on:** <none (self-contained) | comma-separated phase titles, optional parenthetical rationale>
+**Priority:** <priority, optional parenthetical rationale>
+
+<optional 1–3 sentence context paragraph — include only if the user provided prose alongside bullets>
+
+- <bullet 1>
+- <bullet 2>
+- <bullet 3>
+```
+
+If `Depends on:` is `none`, follow an existing example like `none (self-contained broker change)` when the user provided a one-line reason; bare `none` is also fine. Do not invent a rationale.
+
+## Phase 5 — Review the edit
+
+Immediately after the `specs/roadmap.md` edit lands, invoke the built-in `review` skill via the `Skill` tool with argument `local changes`. The `review` skill handles a working-tree diff when given that argument — treat it as a normal capability of the skill.
+
+- Invoke the `Skill` tool with `skill: "review"` and `args: "local changes"`.
+- Do not skip or defer this step; it is part of the skill's contract.
+- Do **not** narrate the invocation mechanism, describe the skill as PR-oriented, explain arguments, or frame the call as a workaround. Just run it and report its findings.
+- Surface the reviewer's findings verbatim in your response; do not summarize them away.
+- If the reviewer flags issues that are clearly in-scope for this skill (e.g. a malformed phase block, a broken `Depends on:` reference, wrong phase number), offer to apply a fix and ask the user to confirm before re-editing. Do not auto-apply fixes.
+- If the `Skill` invocation itself fails (tool error, unrecognized arg, unreachable), surface the error to the user and proceed to Phase 6; do not silently drop the step, and do not retry more than once.
+
+## Phase 6 — Report back
+
+Return to the user in a few lines:
+
+- Phase number and title that were added
+- File edited: `specs/roadmap.md`
+- **Review outcome:** a one-line verdict from Phase 5 — `clean` (no blockers, no suggestions), `suggestions available` (reviewer offered optional improvements), or `blocker` (reviewer flagged an in-scope issue that should be fixed before commit). If Phase 5's invocation failed, say so here instead (`review skipped — <one-line error>`).
+- **Actionable suggestions from the review** (only if the outcome was `suggestions available` or `blocker`): a short bulleted list of the concrete fix offers Phase 5 surfaced, each a single line the user can accept or decline. Do not repeat the full review body — it was already printed verbatim in Phase 5.
+- Next steps (user-driven — this skill does not do them):
+  1. Review the diff (`git diff specs/roadmap.md`).
+  2. Branch + commit + PR per `.claude/rules/git-workflow.md` and `.claude/rules/conventional-commits.md` (suggested header: `docs(roadmap): add phase <N> — <short-slug>`).
+  3. Once merged, run `/sdd-new-spec <N>` to materialize the phase into a feature spec.

--- a/.claude/skills/sdd-new-phase/SKILL.md
+++ b/.claude/skills/sdd-new-phase/SKILL.md
@@ -53,7 +53,7 @@ If `$ARGUMENTS` is empty, prompt the user for a one-sentence description of what
 
 **Duplicate-overlap check:** if the proposal obviously overlaps with an existing active phase (strong keyword overlap with a phase title or goal), surface the overlap to the user and ask whether to proceed anyway, merge into the existing phase, or cancel. Do not silently proceed past an apparent duplicate.
 
-**Constitution-conflict check:** reason briefly about whether the proposal fits within the project's mission scope and tech-stack invariants. If there is an obvious conflict (proposes a capability outside the mission; proposes a runtime dependency the tech-stack forbids; violates a load-bearing constraint like the broker-last router rule), surface it and pause. If there is no obvious conflict, proceed silently — do not pad the response with "nothing conflicts" noise.
+**Constitution-conflict check:** reason briefly about whether the proposal fits within the project's mission scope and tech-stack invariants. If there is an obvious conflict (proposes a capability outside the mission; proposes a runtime dependency the tech-stack forbids; violates a load-bearing constraint named in `specs/tech-stack.md`), surface it and pause. If there is no obvious conflict, proceed silently — do not pad the response with "nothing conflicts" noise.
 
 Derive a candidate **title** in Title Case (e.g. "Local Service Routing", not "local service routing" or "LOCAL SERVICE ROUTING"). Show it to the user alongside the proposed phase number and confirm (or let them override) before Phase 2.
 
@@ -114,7 +114,7 @@ Edit `specs/roadmap.md` to insert the new phase. **Insertion rules:**
 - <bullet 3>
 ```
 
-If `Depends on:` is `none`, follow an existing example like `none (self-contained broker change)` when the user provided a one-line reason; bare `none` is also fine. Do not invent a rationale.
+If `Depends on:` is `none`, follow an existing example like `none (self-contained gate change)` when the user provided a one-line reason; bare `none` is also fine. Do not invent a rationale.
 
 ## Phase 5 — Review the edit
 

--- a/.claude/skills/sdd-new-spec/SKILL.md
+++ b/.claude/skills/sdd-new-spec/SKILL.md
@@ -20,7 +20,7 @@ Argument in `$ARGUMENTS` (optional):
 
 ## Hard constraints
 
-- **Spec-only — zero code changes.** This skill never modifies `src/`, `ui/`, `tests/`, `alembic/`, `docs/`, `AGENTS.md`, `CLAUDE.md`, or any implementation/doc file outside `specs/<date>-<slug>/`. It does not run test suites or linters against code. The only files it touches are the three it scaffolds. The PR it opens is for review of the spec itself; the implementation that the spec describes happens in a follow-up PR.
+- **Spec-only — zero code changes.** This skill never modifies any code tree, `docs/`, `CLAUDE.md`, or any implementation/doc file outside `specs/<date>-<slug>/`. It does not run test suites or linters against code. The only files it touches are the three it scaffolds. The PR it opens is for review of the spec itself; the implementation that the spec describes happens in a follow-up PR.
 - **Do not write to disk before the Phase 4 AskUserQuestion step completes.** The grouped questions exist to lock in decisions that shape the files; writing early wastes the call.
 - **AskUserQuestion groups exactly three questions**, one per output file (requirements, plan, validation). Issue them in a single call.
 - **Do not create a new roadmap phase.** If the user wants one, tell them edits to `specs/roadmap.md` are a separate explicit action — this skill only materializes existing phases.
@@ -44,7 +44,6 @@ Then load context in parallel:
 - @specs/lessons.md
 - @.claude/rules/git-workflow.md
 - @.claude/rules/conventional-commits.md
-- @.claude/rules/testing.md
 - @.claude/rules/karpathy-guidelines.md
 
 After loading, scan `specs/lessons.md` for any lessons that apply to the phase being scaffolded. Carry the relevant ones into Phase 4 (use them to shape `AskUserQuestion` options where appropriate) and Phase 6 (apply them when writing requirements / plan / validation content). Mention in Phase 9 which lessons influenced this scaffold. The lessons file is operational, not load-bearing: a lesson that does not apply to this phase is fine to skip — do not force-fit guidance.
@@ -57,7 +56,7 @@ For each phase extract: number, title, `**Goal:**`, `**Depends on:**`, `**Priori
 
 **Parsing `**Depends on:**`** — the value is one or more comma-separated dependency references; trim each.
 
-- A reference of the form `none` (optionally followed by a parenthetical rationale, e.g. `none (self-contained broker change)`) means the phase has no dependency; produce an empty list and skip resolution.
+- A reference of the form `none` (optionally followed by a parenthetical rationale, e.g. `none (self-contained gate change)`) means the phase has no dependency; produce an empty list and skip resolution.
 - For every other reference, strip any trailing ` (<rationale>)` parenthetical to recover the bare phase-title fragment, then resolve it case-insensitively against the headings parsed above via **substring match** (the fragment must appear inside one and only one heading). Substring matching handles short fragments like `Backend Unit Test Coverage` correctly even when the canonical heading is longer; if a fragment matches more than one heading, surface the ambiguity and stop.
 
 A phase is a **candidate** when it is active and every resolved dependency carries `✅` on its heading (i.e. that dependency has shipped per the lifecycle rule). Active phases with still-pending dependencies (resolved phases whose heading lacks `✅`) are valid to pick but must be flagged. A reference that resolves to no phase at all — and is not the `none` form above — is a malformed roadmap; surface the mismatch and stop.
@@ -90,16 +89,16 @@ Launch **three `Explore` subagents in parallel** — a single message with multi
 - Return: constraints that MUST be preserved (one-line rationale each), relevant `docs/*.md` links, stakeholder-context signals, and any prior-context that reframes the phase.
 
 **Subagent B — Plan research** (grounds `plan.md`):
-- Map the `src/` modules, routers, migrations, and UI pages the phase will touch (based on the roadmap-phase body).
-- Identify file-layout conventions (where new routers live, where tests live, where generated UI client code goes per `CLAUDE.md`).
-- Find similar-shape features that have already shipped (git log + `src/`) as implementation references.
-- Return: concrete file/module paths to touch or create, existing patterns to follow, the order in which layers depend on each other, and any gotchas (e.g. broker catch-all must remain last in `main.py`).
+- Map the modules, entry points, packages, and (where applicable) migrations / pages the phase will touch (based on the roadmap-phase body), inside whichever code trees exist (e.g. `docker/src/`, `packages/*/src/`, `src/`).
+- Identify file-layout conventions (where new modules live, where tests live, where generated client code goes per `CLAUDE.md` if relevant).
+- Find similar-shape features that have already shipped (git log + the touched code trees) as implementation references.
+- Return: concrete file/module paths to touch or create, existing patterns to follow, the order in which layers depend on each other, and any gotchas (e.g. a load-bearing invariant the phase must not break).
 
 **Subagent C — Validation research** (grounds `validation.md`):
-- Identify the test suites and CI workflows relevant to the areas touched (per `.claude/rules/testing.md` and `.github/workflows/`).
-- Find existing endpoints / UI flows / trace-log inspections that will demonstrate the phase works end-to-end.
-- Check whether `schemathesis` contract tests, `ui/openapi.json` regeneration, or Playwright E2E apply.
-- Return: concrete test targets (`uv run poe test …`, `npm run test:run`, `npm run test:e2e`), curl / UI check commands with expected responses, and whether contract / E2E / migration gates apply.
+- Identify the test suites and CI workflows relevant to the areas touched (per the test rules in `.claude/rules/` and `.github/workflows/`).
+- Find existing entry points (CLI invocations, endpoints, UI flows, trace-log inspections — whichever apply) that will demonstrate the phase works end-to-end.
+- Check whether contract tests, generated-client regeneration, or end-to-end gates apply.
+- Return: concrete test targets (e.g. `cd docker && uv run poe test …`), invocation commands with expected output, and whether contract / E2E / migration gates apply.
 
 **Rules:**
 - Every brief must instruct the subagent to lead its summary with a `## Blockers` section (write `_none_` when there are none). Examples of blockers: the phase depends on an assumption that is false in the current code; prior work already landed and the phase is partly obsolete; a load-bearing file referenced by the phase body does not exist.
@@ -137,7 +136,7 @@ Issue a single `AskUserQuestion` call containing three questions, one per output
 
 **Question 3 — Validation** (shapes `validation.md`):
   - Prompt: "What is the primary acceptance signal, and are there merge gates beyond green CI?"
-  - Options should cover common shapes (e.g. "integration test passing", "contract test (`schemathesis`) passing", "UI flow verified manually", "endpoint reproducible via curl", "docs + AGENTS.md must update", "other").
+  - Options should cover common shapes (e.g. "integration test passing", "CLI invocation reproducible from a documented command", "UI flow verified manually", "docs must update alongside the change", "other").
 
 Only after the user answers do you proceed.
 
@@ -166,7 +165,7 @@ Sections in this order:
 - **Scope** — one or two short paragraphs naming what this phase delivers. Written in plain language, informed by the user's Question 1 answer. Not a copy of the roadmap bullet list.
 - **Out of Scope** — explicit exclusions the user confirmed. Empty is allowed — do not invent exclusions.
 - **Decisions** — one `### <Decision Title>` subsection per decision from the user's answers. Body is a short paragraph: what was chosen, why, and any consequence for implementation (alternatives noted if weighed).
-- **Constraints** — load-bearing invariants from `specs/mission.md` and `specs/tech-stack.md` that this phase must preserve. Only what is actually relevant (e.g. "broker catch-all must be registered last" only if the work touches router registration). Do not copy every invariant.
+- **Constraints** — load-bearing invariants from `specs/mission.md` and `specs/tech-stack.md` that this phase must preserve. Only what is actually relevant (e.g. cite a specific invariant only when the work touches the surface that depends on it). Do not copy every invariant.
 - **Context** — one to three short paragraphs: why this phase exists now, what it enables, how it fits the roadmap. Cross-reference any relevant `docs/*.md`.
 - **Stakeholder Notes** — `- **<Name or Role>** — <need; how satisfied>`. Omit the whole section if the user named no stakeholders.
 
@@ -187,7 +186,7 @@ Numbered task groups. Granularity per the user's Question 2 answer.
 ```
 
 - Tasks are plain numbered items, **not checkboxes**. One concrete change each (file / function / test / route / migration / CLI command).
-- **The last group is always `Verify`**, listing the concrete checks that confirm the whole plan succeeded: command + expected result (e.g. `uv run poe test tests/broker` exits 0; `curl localhost:8900/…` returns 200 with JSON containing `{ … }`).
+- **The last group is always `Verify`**, listing the concrete checks that confirm the whole plan succeeded: command + expected result (e.g. `cd docker && uv run poe test tests/test_gate.py` exits 0; `echo '{...}' | docker run -i --rm ghcr.io/jentic/jentic-api-scorecard:dev score` returns JSON with `{ "summary": { "score": <number> } }`).
 - **Include the roadmap-completion task** as a concrete numbered task in the final non-Verify group (typically a docs/lifecycle group). The task says to append ` ✅` — a single space followed by the U+2705 checkmark — to the `## Phase N — <Title>` heading in `specs/roadmap.md` and leave the rest of the block untouched, per the lifecycle rule in `specs/roadmap.md`. The leading space is load-bearing: the Verify assertion `grep -F`s for the exact ` ✅` suffix, so a heading rendered as `Title✅` (no space) silently fails the gate. Phase-completion marking is a phase-specific markdown edit that ships with the work, not generic meta-workflow — `/sdd-implement-spec` halts on plans that omit it. Pair it with an assertion in the Verify group that confirms the heading now ends with ` ✅` (e.g. `grep -F "## Phase <N> — <Title> ✅" specs/roadmap.md` exits 0).
 - **Do not include meta-workflow** in the plan (test-suite runs belong in `Verify`; squash/commit/PR creation are governed by `.claude/rules/git-workflow.md` and `.claude/rules/conventional-commits.md` — no need to repeat per phase).
 

--- a/.claude/skills/sdd-new-spec/SKILL.md
+++ b/.claude/skills/sdd-new-spec/SKILL.md
@@ -1,0 +1,262 @@
+---
+name: sdd-new-spec
+description: Scaffold a feature spec for a roadmap phase and open it as a PR for human review. Reads specs/roadmap.md, lets the user pick a phase (or accepts one as argument), runs preflight checks, cuts a feature branch, writes specs/YYYY-MM-DD-<slug>/ (requirements.md, plan.md, validation.md — grounded in specs/mission.md and specs/tech-stack.md), commits, pushes, and opens a PR. Makes zero code changes — the PR is for review of the spec itself; implementation follows in a separate PR once the spec is approved. Groups clarifying questions (one per output file) via AskUserQuestion before any disk write.
+argument-hint: "[phase-number | \"phase title fragment\"] (optional)"
+---
+
+# /sdd-new-spec — scaffold a feature spec for a roadmap phase
+
+You are operating within a Spec-Driven Development (SDD) workflow. See `.claude/rules/sdd-constitution.md`.
+
+The **constitution** (mission / tech-stack / roadmap) already exists in `specs/`. This skill takes one **phase** from `specs/roadmap.md` and turns it into a workable **feature spec** — a dated directory under `specs/` with three files: requirements (what + why), plan (how), validation (done).
+
+## Inputs
+
+Argument in `$ARGUMENTS` (optional):
+
+- empty → list candidate phases and ask the user to pick
+- integer (`1`, `7`) → use that phase number directly
+- title fragment (`"local service routing"`) → case-insensitive match against phase titles; if ambiguous, list matches and ask
+
+## Hard constraints
+
+- **Spec-only — zero code changes.** This skill never modifies `src/`, `ui/`, `tests/`, `alembic/`, `docs/`, `AGENTS.md`, `CLAUDE.md`, or any implementation/doc file outside `specs/<date>-<slug>/`. It does not run test suites or linters against code. The only files it touches are the three it scaffolds. The PR it opens is for review of the spec itself; the implementation that the spec describes happens in a follow-up PR.
+- **Do not write to disk before the Phase 4 AskUserQuestion step completes.** The grouped questions exist to lock in decisions that shape the files; writing early wastes the call.
+- **AskUserQuestion groups exactly three questions**, one per output file (requirements, plan, validation). Issue them in a single call.
+- **Do not create a new roadmap phase.** If the user wants one, tell them edits to `specs/roadmap.md` are a separate explicit action — this skill only materializes existing phases.
+- **Ground every requirement and constraint in `specs/mission.md`, `specs/tech-stack.md`, or the roadmap phase itself.** Do not invent scope the sources do not support.
+- **PR contains the spec, nothing else.** Staged set must be exactly the three files under `specs/<date>-<slug>/` before committing. If anything else appears, stop and surface it.
+
+## Phase 0 — Preflight
+
+Run these checks in parallel. Stop with a clear message on any failure — do not auto-fix, do not stash, do not force.
+
+- `git status --porcelain` is empty (working tree clean)
+- Current branch is `main`
+- `git fetch origin main` succeeds; local `main` is not behind `origin/main`. If behind and fast-forwardable, offer `git pull --ff-only` and wait for user confirmation. If diverged, stop.
+- `gh auth status` succeeds — fail fast here if `gh` is not installed or not authenticated; Phase 8 depends on it.
+
+Then load context in parallel:
+
+- @specs/mission.md
+- @specs/tech-stack.md
+- @specs/roadmap.md
+- @specs/lessons.md
+- @.claude/rules/git-workflow.md
+- @.claude/rules/conventional-commits.md
+- @.claude/rules/testing.md
+- @.claude/rules/karpathy-guidelines.md
+
+After loading, scan `specs/lessons.md` for any lessons that apply to the phase being scaffolded. Carry the relevant ones into Phase 4 (use them to shape `AskUserQuestion` options where appropriate) and Phase 6 (apply them when writing requirements / plan / validation content). Mention in Phase 9 which lessons influenced this scaffold. The lessons file is operational, not load-bearing: a lesson that does not apply to this phase is fine to skip — do not force-fit guidance.
+
+## Phase 1 — Pick a roadmap phase
+
+Parse phases from `specs/roadmap.md` — the `## Phase N — <title>` blocks. Ignore the `Later Phases (Not Yet Planned)` section.
+
+For each phase extract: number, title, `**Goal:**`, `**Depends on:**`, `**Priority:**`, and a `completed` flag set when the heading ends with ` ✅` (space + U+2705 checkmark). **Active phases** (no `✅`) are the candidate pool; **completed phases** (✅) are skipped from selection but used to resolve `Depends on:` references.
+
+**Parsing `**Depends on:**`** — the value is one or more comma-separated dependency references; trim each.
+
+- A reference of the form `none` (optionally followed by a parenthetical rationale, e.g. `none (self-contained broker change)`) means the phase has no dependency; produce an empty list and skip resolution.
+- For every other reference, strip any trailing ` (<rationale>)` parenthetical to recover the bare phase-title fragment, then resolve it case-insensitively against the headings parsed above via **substring match** (the fragment must appear inside one and only one heading). Substring matching handles short fragments like `Backend Unit Test Coverage` correctly even when the canonical heading is longer; if a fragment matches more than one heading, surface the ambiguity and stop.
+
+A phase is a **candidate** when it is active and every resolved dependency carries `✅` on its heading (i.e. that dependency has shipped per the lifecycle rule). Active phases with still-pending dependencies (resolved phases whose heading lacks `✅`) are valid to pick but must be flagged. A reference that resolves to no phase at all — and is not the `none` form above — is a malformed roadmap; surface the mismatch and stop.
+
+**If `$ARGUMENTS` identifies exactly one phase**, jump straight to showing that phase's full block and confirm with the user before continuing.
+
+**Otherwise** present candidates as a compact list:
+
+```
+N. <title> — priority: <High|Medium|Low> — deps: <satisfied|pending: <names>>
+   goal: <one-line goal>
+```
+
+Ask the user to pick one by number. Do not proceed until the user confirms.
+
+If the user wants to change the phase's scope at this step, route them to update `specs/roadmap.md` first and re-run the skill.
+
+## Phase 2 — Research in parallel (MANDATORY)
+
+Launch **three `Explore` subagents in parallel** — a single message with multiple `Agent` tool calls, `subagent_type: Explore`, one per output file. Do not proceed to Phase 3 until all three return.
+
+- **Thoroughness:** `very thorough` on every subagent. Feature specs are load-bearing; shallow grounding produces shallow specs.
+- **Model:** pass `model: "opus"` in every `Agent` tool call. Max capability for grounding.
+- **Briefs are self-contained.** Each subagent does not see this conversation. Include: phase number, phase title, the full roadmap-phase body copied verbatim from `specs/roadmap.md`, and a one-paragraph focus directive specific to its output file.
+
+**Subagent A — Requirements research** (grounds `requirements.md`):
+- Read `specs/mission.md` and `specs/tech-stack.md` for invariants / constraints this phase must preserve.
+- Scan `docs/` for documents the phase directly relates to (e.g. `architecture.md`, `auth.md`, `workflows.md`, `decisions.md`).
+- Scan recent git log for prior attempts at similar functionality or adjacent work.
+- Return: constraints that MUST be preserved (one-line rationale each), relevant `docs/*.md` links, stakeholder-context signals, and any prior-context that reframes the phase.
+
+**Subagent B — Plan research** (grounds `plan.md`):
+- Map the `src/` modules, routers, migrations, and UI pages the phase will touch (based on the roadmap-phase body).
+- Identify file-layout conventions (where new routers live, where tests live, where generated UI client code goes per `CLAUDE.md`).
+- Find similar-shape features that have already shipped (git log + `src/`) as implementation references.
+- Return: concrete file/module paths to touch or create, existing patterns to follow, the order in which layers depend on each other, and any gotchas (e.g. broker catch-all must remain last in `main.py`).
+
+**Subagent C — Validation research** (grounds `validation.md`):
+- Identify the test suites and CI workflows relevant to the areas touched (per `.claude/rules/testing.md` and `.github/workflows/`).
+- Find existing endpoints / UI flows / trace-log inspections that will demonstrate the phase works end-to-end.
+- Check whether `schemathesis` contract tests, `ui/openapi.json` regeneration, or Playwright E2E apply.
+- Return: concrete test targets (`uv run poe test …`, `npm run test:run`, `npm run test:e2e`), curl / UI check commands with expected responses, and whether contract / E2E / migration gates apply.
+
+**Rules:**
+- Every brief must instruct the subagent to lead its summary with a `## Blockers` section (write `_none_` when there are none). Examples of blockers: the phase depends on an assumption that is false in the current code; prior work already landed and the phase is partly obsolete; a load-bearing file referenced by the phase body does not exist.
+- Subagents are read-only (`Explore` type; they cannot edit, write, or commit).
+- If any subagent surfaces a non-empty `## Blockers` section, stop and report to the user before Phase 3.
+- Summaries from all three subagents feed Phase 4 (AskUserQuestion options) and Phase 6 (file content).
+
+## Phase 3 — Derive slug, directory, and branch
+
+Derive identifiers in order, checking for conflicts at each step **before** asking the user anything they could not act on.
+
+1. **Slug** — kebab-case from the phase title, lowercase, alphanumerics and hyphens only. Drop leading `Phase N — `. Target ≤ 40 chars; strip filler words (`the`, `and`, `of`) only if over. Example: `Phase 1 — Local Service Routing` → `local-service-routing`.
+2. **Date** — today's date as `YYYY-MM-DD` from the current environment (do not ask).
+3. **Directory** — `specs/<date>-<slug>/`.
+4. **Directory idempotence check** — if `specs/<date>-<slug>/` already exists, stop, show what's there, ask whether to reuse / rename / abort. Do this **before** the issue-number question so the user does not waste effort on a scaffold that cannot proceed.
+5. **Branch prefix** — follow `.claude/rules/git-workflow.md`:
+   - `feature/` by default
+   - `fix/` if the phase goal describes a defect or starts with "Fix"
+   - `chore/` for tooling / maintenance / dependency phases
+   - `docs/` if the phase is purely documentation
+6. **Issue number** — ask the user once: "Is there a GitHub issue for this phase? (issue number or 'no')". If yes, branch is `<prefix>/<issue>-<slug>`; else `<prefix>/<slug>`.
+7. **Branch idempotence check** — if the target branch exists locally or on `origin`, stop, ask whether to switch to it / rename / abort.
+
+## Phase 4 — AskUserQuestion (MANDATORY, before any disk write)
+
+Issue a single `AskUserQuestion` call containing three questions, one per output file. Each question offers 3–5 concrete options plus a freeform "other" so the user can redirect. Frame each as a decision the scaffold needs locked-in.
+
+**Question 1 — Requirements** (shapes `requirements.md`):
+  - Prompt: "Any scope to explicitly exclude, external constraints, or up-front decisions to record?"
+  - Options should cover common shapes (e.g. "no exclusions, follow roadmap bullets exactly", "exclude UI changes for now", "lock a specific naming choice", "external deadline or dependent team", "other").
+
+**Question 2 — Plan** (shapes `plan.md`):
+  - Prompt: "How should the plan be structured — ordering and granularity?"
+  - Options should cover common shapes (e.g. "test-first", "skeleton-first then flesh out", "risky-bits-first to de-risk", "3–4 large groups", "6–10 small groups", "other").
+
+**Question 3 — Validation** (shapes `validation.md`):
+  - Prompt: "What is the primary acceptance signal, and are there merge gates beyond green CI?"
+  - Options should cover common shapes (e.g. "integration test passing", "contract test (`schemathesis`) passing", "UI flow verified manually", "endpoint reproducible via curl", "docs + AGENTS.md must update", "other").
+
+Only after the user answers do you proceed.
+
+## Phase 5 — Cut the branch
+
+```
+git checkout -b <branch>
+```
+
+Do not push yet — Phase 8 handles push after the commit.
+
+## Phase 6 — Write the three files
+
+Create `specs/<date>-<slug>/`. Write three files using these templates as structural scaffolds — fill in the placeholders from the phase content and the user's answers. **Use templates for structure only; do not copy text verbatim.** Files are plain markdown — no YAML frontmatter.
+
+- @.claude/templates/sdd/feature-spec/requirements.example.md
+- @.claude/templates/sdd/feature-spec/plan.example.md
+- @.claude/templates/sdd/feature-spec/validation.example.md
+
+All three share an H1 of `# Phase <N> <Requirements|Plan|Validation> — <Phase Title>` (the phase title is the human-readable title from `specs/roadmap.md`, not the kebab slug).
+
+### requirements.md
+
+Sections in this order:
+
+- **Scope** — one or two short paragraphs naming what this phase delivers. Written in plain language, informed by the user's Question 1 answer. Not a copy of the roadmap bullet list.
+- **Out of Scope** — explicit exclusions the user confirmed. Empty is allowed — do not invent exclusions.
+- **Decisions** — one `### <Decision Title>` subsection per decision from the user's answers. Body is a short paragraph: what was chosen, why, and any consequence for implementation (alternatives noted if weighed).
+- **Constraints** — load-bearing invariants from `specs/mission.md` and `specs/tech-stack.md` that this phase must preserve. Only what is actually relevant (e.g. "broker catch-all must be registered last" only if the work touches router registration). Do not copy every invariant.
+- **Context** — one to three short paragraphs: why this phase exists now, what it enables, how it fits the roadmap. Cross-reference any relevant `docs/*.md`.
+- **Stakeholder Notes** — `- **<Name or Role>** — <need; how satisfied>`. Omit the whole section if the user named no stakeholders.
+
+### plan.md
+
+Numbered task groups. Granularity per the user's Question 2 answer.
+
+**Task numbering is sequential across all groups** (1, 2, 3, … N), not reset per group:
+
+```
+## Group 1 — <Title>
+1. <Concrete task>
+2. <Concrete task>
+
+## Group 2 — <Title>
+3. <Concrete task>
+4. <Concrete task>
+```
+
+- Tasks are plain numbered items, **not checkboxes**. One concrete change each (file / function / test / route / migration / CLI command).
+- **The last group is always `Verify`**, listing the concrete checks that confirm the whole plan succeeded: command + expected result (e.g. `uv run poe test tests/broker` exits 0; `curl localhost:8900/…` returns 200 with JSON containing `{ … }`).
+- **Include the roadmap-completion task** as a concrete numbered task in the final non-Verify group (typically a docs/lifecycle group). The task says to append ` ✅` — a single space followed by the U+2705 checkmark — to the `## Phase N — <Title>` heading in `specs/roadmap.md` and leave the rest of the block untouched, per the lifecycle rule in `specs/roadmap.md`. The leading space is load-bearing: the Verify assertion `grep -F`s for the exact ` ✅` suffix, so a heading rendered as `Title✅` (no space) silently fails the gate. Phase-completion marking is a phase-specific markdown edit that ships with the work, not generic meta-workflow — `/sdd-implement-spec` halts on plans that omit it. Pair it with an assertion in the Verify group that confirms the heading now ends with ` ✅` (e.g. `grep -F "## Phase <N> — <Title> ✅" specs/roadmap.md` exits 0).
+- **Do not include meta-workflow** in the plan (test-suite runs belong in `Verify`; squash/commit/PR creation are governed by `.claude/rules/git-workflow.md` and `.claude/rules/conventional-commits.md` — no need to repeat per phase).
+
+Do not pad. If three groups plus `Verify` cover the work, that is correct.
+
+### validation.md
+
+Structure:
+
+- **Definition of Done** — opening sentence: "All of the following must be true before this branch is merged."
+- Numbered subsections `### <N>. <Check Title>` — each contains either a fenced code-block command and an exact expectation (HTTP status, exit code, output substring, file contents), or a short description of a non-command check (e.g. `tsconfig.json` must contain `"strict": true`). Be concrete: "HTTP 200, body contains `<h1>Jentic</h1>`" — not "endpoint works".
+- **Not Required** — final section. Explicit list of what this phase does **not** need (no automated tests for this phase, no CI pipeline required, no browser check, etc.) — matches what the user flagged in Question 3. Prevents scope creep and reviewer confusion.
+
+## Phase 7 — Commit the spec files
+
+Atomic commit per `.claude/rules/git-workflow.md`.
+
+- Stage **only** the three files under `specs/<date>-<slug>/`. Do **not** use `git add -A` or `git add .` — name the three paths explicitly.
+- Safety check: `git diff --cached --name-only` must list exactly three paths, all inside `specs/<date>-<slug>/`. If anything else appears, abort and surface it — the skill does not commit code.
+- Commit with `git commit -s` (DCO sign-off) and a Conventional Commits header per `.claude/rules/conventional-commits.md`:
+  - Type `docs`, scope `spec`
+  - Header: `docs(spec): scaffold phase <N> — <short-slug>` (≤ 69 chars total; truncate the slug if needed)
+  - Body: one short paragraph naming what the spec covers and linking the roadmap phase. Include `Refs #<issue>` if the user provided an issue number. **Do not** use GitHub close-keywords (`Closes`, `Fixes`, `Resolves`) — this PR does not resolve the phase.
+
+## Phase 8 — Push and open the PR
+
+- `git push -u origin <branch>`
+- Open a PR with `gh pr create`. Pass the body via a HEREDOC to preserve formatting. Title is the commit header. Body shape:
+
+  ```
+  ## Summary
+
+  Spec scaffold for **Phase <N>: <title>** from `specs/roadmap.md`.
+
+  This PR adds **spec files only** — no code changes. Implementation follows in a separate PR once this spec is approved.
+
+  ### Scope
+  [one-paragraph summary pulled from the Scope section of requirements.md]
+
+  ### Out of Scope
+  - [bullets from requirements.md, or "none declared"]
+
+  ### Key decisions
+  - [one bullet per `###` decision title in requirements.md]
+
+  ## Files
+
+  - `specs/<date>-<slug>/requirements.md`
+  - `specs/<date>-<slug>/plan.md`
+  - `specs/<date>-<slug>/validation.md`
+
+  ## Review guidance
+
+  Reviewers should verify:
+  - The phase goal is captured faithfully (see `specs/roadmap.md` Phase <N>).
+  - Scope, constraints, and decisions match intent.
+  - The plan's task groups are appropriately granular and each has a concrete verification step.
+  - Validation gates are realistic for the phase.
+
+  Refs: `specs/roadmap.md` Phase <N>[; #<issue> if applicable].
+  ```
+
+- Do **not** include `Closes #<issue>` / `Fixes #<issue>` in the PR body — only `Refs`. The phase closes on the implementation PR, not this one.
+
+## Phase 9 — Report back
+
+Return to the user in a few lines:
+
+- Phase chosen (number + title)
+- Branch, commit SHA, PR URL
+- Files created (full paths)
+- Next step: human review on the PR. Once merged, the implementation work described in `plan.md` happens in a separate branch/PR — this skill does not execute it.

--- a/.claude/templates/sdd/constitution/mission.example.md
+++ b/.claude/templates/sdd/constitution/mission.example.md
@@ -1,0 +1,59 @@
+---
+type: constitution
+section: mission
+generated_by: spec-driven-agent
+generated_at: [ISO_TIMESTAMP]
+confidence: high
+notes: Template example for constitution mission
+---
+
+# Mission
+
+[PROJECT_NAME] exists because [CORE_PROBLEM_OR_MOTIVATION].
+
+[BRIEF_CONTEXT_OR_STORY_THAT_EXPLAINS_WHY_THIS_MATTERS].
+
+Guidance:
+- Explain why this problem matters in real-world terms
+- Keep it concise but meaningful
+
+## What We Do
+
+[PROJECT_NAME] is a [HIGH_LEVEL_DESCRIPTION_OF_SYSTEM_OR_PRODUCT].
+
+We:
+- [PRIMARY_CAPABILITY_1]
+- [PRIMARY_CAPABILITY_2]
+- [PRIMARY_CAPABILITY_3]
+
+Guidance:
+- Focus on capabilities, not implementation details
+
+## Who We Serve
+
+- **[USER_TYPE_1]** — [description of their needs or pain points]
+- **[USER_TYPE_2]** — [description of their needs or role]
+- **[USER_TYPE_3]** — [optional additional stakeholders]
+
+## Target Audience
+
+- **[AUDIENCE_1]** — [why this project is relevant to them]
+- **[AUDIENCE_2]** — [context in which this project is used]
+- **[AUDIENCE_3]** — [optional additional audience]
+
+## What Success Looks Like
+
+[DESCRIBE_THE_IDEAL_OUTCOME].
+
+Prefer:
+- measurable outcomes
+- observable user behavior
+- concrete system capabilities
+
+Avoid vague statements.
+
+## Assumptions & Unknowns
+
+- [ASSUMPTION_1]
+- [ASSUMPTION_2]
+- [UNKNOWN_REQUIRING_CLARIFICATION]

--- a/.claude/templates/sdd/constitution/roadmap.example.md
+++ b/.claude/templates/sdd/constitution/roadmap.example.md
@@ -1,0 +1,143 @@
+---
+type: constitution
+section: roadmap
+generated_by: spec-driven-agent
+generated_at: [ISO_TIMESTAMP]
+confidence: high
+notes: Template example for constitution roadmap
+---
+
+# Roadmap
+
+**Phases marked ✅ have shipped; everything else is planned.**
+
+Phases are intentionally small — each one must be a **shippable, independently reviewable, and testable slice of work**.
+
+Start from the repository’s current state. Do not plan from scratch unless the project is actually empty.
+
+Guidelines:
+- Prefer vertical slices with end-to-end functionality.
+- Avoid splitting work purely by technical layers.
+- Each phase should produce visible, testable progress.
+- If a phase feels too large, split it.
+
+**Priority values:** `High`, `Medium–High` (en-dash, U+2013), `Medium`. Append `(blocker)` to a
+`High` priority when the phase fixes a gap that makes the system unsafe for its current intended
+use (e.g. a known trust/security issue). Items required for a later readiness bar beyond today's
+intended use do not need `(blocker)` — state the forward-looking rationale in the phase body and
+use the appropriate normal priority. Only `(blocker)` implies a release gate for today's bar;
+other levels express relative queue position.
+
+**Lifecycle:** when a phase ships, append ` ✅` (a single space followed by the U+2705 checkmark)
+to its `## Phase N — Title` heading and leave the rest of the block in place — do not delete or
+renumber. The leading space is load-bearing — completion-verify steps `grep -F` for the exact
+` ✅` suffix. Phase numbers are stable identifiers; completed phases stay in the file as
+history. New work takes the next number after the largest existing phase.
+
+## Phase 1 — [FOUNDATION_PHASE_NAME]
+
+**Goal:** [establish a minimal runnable system]  
+**Depends on:** none  
+**Priority:** [High | Medium–High | Medium]
+
+- [set up core runtime / framework / entrypoint]
+- [confirm local development workflow works]
+- [verify basic end-to-end execution]
+
+## Phase 2 — [BASE_STRUCTURE_PHASE_NAME]
+
+**Goal:** [introduce shared structure and conventions]  
+**Depends on:** Phase 1  
+**Priority:** [High | Medium–High | Medium]
+
+- [add shared layout / structure / core modules]
+- [establish styling / organization / conventions]
+- [ensure all existing flows use the shared structure]
+
+## Phase 3 — [FIRST_CORE_FEATURE]
+
+**Goal:** [deliver first meaningful user-facing capability]  
+**Depends on:** Phase 2  
+**Priority:** [High | Medium–High | Medium]
+
+- [introduce first core model / module]
+- [seed or create minimal usable data if needed]
+- [expose first usable route / screen / command / API]
+
+## Phase 4 — [DETAIL_OR_INTERACTION]
+
+**Goal:** [enable interaction with individual items]  
+**Depends on:** Phase 3  
+**Priority:** [High | Medium–High | Medium]
+
+- [support viewing or interacting with a single entity]
+- [display key attributes and state]
+- [validate the end-to-end user flow]
+
+## Phase 5 — [SECOND_CORE_CAPABILITY]
+
+**Goal:** [expand system capabilities with a second feature]  
+**Depends on:** Phase 4  
+**Priority:** [High | Medium–High | Medium]
+
+- [introduce another important model / module]
+- [connect it to existing functionality]
+- [make relationships visible in behavior]
+
+## Phase 6 — [THIRD_CORE_CAPABILITY]
+
+**Goal:** [extend system with supporting capability]  
+**Depends on:** Phase 5  
+**Priority:** [High | Medium–High | Medium]
+
+- [add supporting subsystem or feature]
+- [integrate with previous data and flows]
+- [verify combined behavior works]
+
+## Phase 7 — [PRIMARY_USER_ACTION]
+
+**Goal:** [enable a key user action]  
+**Depends on:** Phase 6  
+**Priority:** [High | Medium–High | Medium]
+
+- [implement a primary user workflow]
+- [add validation and error handling]
+- [provide success and failure feedback]
+
+## Phase 8 — [OPERATIONAL_VIEW]
+
+**Goal:** [support monitoring or management]  
+**Depends on:** Phase 7  
+**Priority:** [High | Medium–High | Medium]
+
+- [add dashboard / admin / summary view]
+- [surface aggregate or operational data]
+- [enable basic management workflows]
+
+## Phase 9 — [POLISH_AND_ACCESSIBILITY]
+
+**Goal:** [improve usability and accessibility]  
+**Depends on:** Phase 8  
+**Priority:** [High | Medium–High | Medium]
+
+- [improve responsiveness and UX]
+- [audit accessibility and semantics]
+- [refine interaction details]
+
+## Phase 10 — [HARDENING]
+
+**Goal:** [increase reliability and robustness]  
+**Depends on:** Phase 9  
+**Priority:** [High | Medium–High | Medium]
+
+- [add error handling and fallback states]
+- [improve validation and resilience]
+- [add logging / observability]
+
+## Later Phases (Not Yet Planned)
+
+- [FUTURE_CAPABILITY_1]
+- [FUTURE_CAPABILITY_2]
+- [FUTURE_CAPABILITY_3]
+
+<!-- Only include items here if they are clearly out of current scope. -->

--- a/.claude/templates/sdd/constitution/tech-stack.example.md
+++ b/.claude/templates/sdd/constitution/tech-stack.example.md
@@ -1,0 +1,93 @@
+---
+type: constitution
+section: tech-stack
+generated_by: spec-driven-agent
+generated_at: [ISO_TIMESTAMP]
+confidence: high
+notes: Template example for constitution tech stack
+---
+
+# Tech Stack
+
+[PROJECT_NAME] uses the following technology choices based on the current repository state and implementation evidence.
+
+Guidance:
+- Prefer facts from code, configs, dependencies, and docs
+- Distinguish confirmed facts from inferred choices
+- Do not invent technologies not supported by evidence
+
+## Architecture Summary
+
+- **Application style:** [SERVER_SIDE_APP | CLIENT_SERVER_APP | API_SERVICE | CLI | LIBRARY | HYBRID]
+- **Primary language(s):** [LANGUAGE_1], [LANGUAGE_2]
+- **Rendering model:** [SERVER_RENDERED | SPA | STATIC | API_ONLY | MIXED]
+- **Deployment/runtime shape:** [LOCAL_PROCESS | CONTAINER | SERVERLESS | EDGE | UNKNOWN]
+- **Current maturity:** [PROTOTYPE | EARLY_STAGE | PRODUCTION | UNKNOWN]
+
+## Core Stack
+
+| Layer | Choice | Evidence / Rationale |
+|---|---|---|
+| Language | [LANGUAGE] | [evidence or reason] |
+| Runtime | [RUNTIME] | [evidence or reason] |
+| Main framework | [FRAMEWORK] | [evidence or reason] |
+| UI approach | [UI_APPROACH] | [evidence or reason] |
+| Styling | [STYLING_APPROACH] | [evidence or reason] |
+| Build / packaging | [BUILD_TOOL] | [evidence or reason] |
+
+Add or remove rows based on what is actually present in the repository.
+
+## Key Libraries and Frameworks
+
+- **[LIBRARY_1]** — [role in system]
+- **[LIBRARY_2]** — [role in system]
+- **[LIBRARY_3]** — [role in system]
+
+## Data and Storage
+
+- **Primary storage:** [DATABASE | FILES | EXTERNAL_SERVICE | NONE]
+- **Access pattern:** [ORM | RAW_SQL | QUERY_BUILDER | API | FILESYSTEM]
+- **Migrations:** [how schema changes are handled or UNKNOWN]
+- **Caching / state:** [if applicable or NONE]
+- **Notes:** [constraints or limitations]
+
+## Testing
+
+- **Test framework(s):** [TEST_TOOL]
+- **Test types visible:** [UNIT | INTEGRATION | E2E | NONE_OBSERVED]
+- **Current testing pattern:** [brief description]
+
+## Tooling and Developer Experience
+
+- **Local development:** [dev server / scripts / watch mode]
+- **Build / release:** [build approach]
+- **Formatting / linting:** [tools]
+- **Type checking:** [tools]
+- **CI/CD:** [tooling or NONE_OBSERVED]
+
+## Deployment and Operations
+
+- **Deployment target:** [CLOUD | VM | STATIC_HOST | CONTAINER | UNKNOWN]
+- **Environment management:** [ENV_FILES | SECRET_MANAGER | UNKNOWN]
+- **Observability:** [LOGGING | METRICS | NONE_OBSERVED]
+- **Error handling / resilience:** [brief description]
+
+## Constraints and Conventions
+
+- [IMPORTANT_CONVENTION]
+- [ARCHITECTURAL_CONSTRAINT]
+- [REPO_OR_TEAM_CONVENTION]
+- [DEPENDENCY_OR_ENVIRONMENT_CONSTRAINT]
+
+## What We Are Not Using
+
+- No **[TOOL_OR_PATTERN]** — [reason based on evidence]
+- No **[TOOL_OR_PATTERN]** — [reason]
+
+Only include this section if supported by repository evidence.
+
+## Open Questions / Uncertain Areas
+
+- [UNCERTAINTY_1]
+- [UNCERTAINTY_2]
+- [MISSING_INFORMATION]

--- a/.claude/templates/sdd/feature-spec/plan.example.md
+++ b/.claude/templates/sdd/feature-spec/plan.example.md
@@ -1,0 +1,24 @@
+# Phase [PHASE_NUMBER] Plan — [PHASE_TITLE]
+
+## Group 1 — [FIRST_GROUP_TITLE]
+
+1. [CONCRETE_TASK — file / module / function / command]
+2. [CONCRETE_TASK]
+3. [CONCRETE_TASK]
+
+## Group 2 — [SECOND_GROUP_TITLE]
+
+4. [CONCRETE_TASK]
+5. [CONCRETE_TASK]
+
+## Group 3 — [THIRD_GROUP_TITLE]
+
+6. [CONCRETE_TASK]
+7. [CONCRETE_TASK]
+8. [CONCRETE_TASK]
+
+## Group N — Verify
+
+9. [CONCRETE_COMMAND_AND_EXPECTED_RESULT — e.g. `uv run poe test tests/broker` exits 0]
+10. [CONCRETE_COMMAND_AND_EXPECTED_RESULT — e.g. `curl localhost:8900/search?q=...` returns 200 with JSON containing `{ "operations": [...] }`]
+11. [CONCRETE_COMMAND_AND_EXPECTED_RESULT]

--- a/.claude/templates/sdd/feature-spec/plan.example.md
+++ b/.claude/templates/sdd/feature-spec/plan.example.md
@@ -19,6 +19,6 @@
 
 ## Group N — Verify
 
-9. [CONCRETE_COMMAND_AND_EXPECTED_RESULT — e.g. `uv run poe test tests/broker` exits 0]
-10. [CONCRETE_COMMAND_AND_EXPECTED_RESULT — e.g. `curl localhost:8900/search?q=...` returns 200 with JSON containing `{ "operations": [...] }`]
+9. [CONCRETE_COMMAND_AND_EXPECTED_RESULT — e.g. `cd docker && uv run poe test tests/test_gate.py` exits 0]
+10. [CONCRETE_COMMAND_AND_EXPECTED_RESULT — e.g. `echo '{...}' | docker run -i --rm ghcr.io/jentic/jentic-api-scorecard:dev score` returns JSON with `{ "summary": { "score": <number> } }`]
 11. [CONCRETE_COMMAND_AND_EXPECTED_RESULT]

--- a/.claude/templates/sdd/feature-spec/requirements.example.md
+++ b/.claude/templates/sdd/feature-spec/requirements.example.md
@@ -1,0 +1,37 @@
+# Phase [PHASE_NUMBER] Requirements — [PHASE_TITLE]
+
+## Scope
+
+[ONE_OR_TWO_SHORT_PARAGRAPHS describing what this phase delivers. Written in plain language, informed by the user's Question 1 answer. Not a copy of the roadmap bullet list.]
+
+## Out of Scope
+
+- [EXPLICIT_EXCLUSION_1 — deferred to a later phase / not needed now]
+- [EXPLICIT_EXCLUSION_2]
+- [EXPLICIT_EXCLUSION_3]
+
+## Decisions
+
+### [DECISION_1_TITLE]
+[RATIONALE_PARAGRAPH — what was chosen, why, and any consequence it imposes on implementation. Mention alternatives if the user weighed them.]
+
+### [DECISION_2_TITLE]
+[RATIONALE_PARAGRAPH.]
+
+## Constraints
+
+Load-bearing invariants from `specs/mission.md` and `specs/tech-stack.md` that this phase must preserve. List only what is relevant to the work — do not copy every invariant.
+
+- **[CONSTRAINT_1]** — [why it matters for this phase specifically]
+- **[CONSTRAINT_2]** — [why it matters]
+
+## Context
+
+[ONE_TO_THREE_SHORT_PARAGRAPHS explaining why this phase exists now, what it enables, and how it fits the roadmap's trajectory. Cross-reference any `docs/*.md` the phase touches.]
+
+## Stakeholder Notes
+
+- **[STAKEHOLDER_NAME_OR_ROLE]** — [what they need; how this phase satisfies them]
+- **[STAKEHOLDER_NAME_OR_ROLE]** — [optional]
+
+[Omit this whole section if the user named no stakeholders.]

--- a/.claude/templates/sdd/feature-spec/retrospective.example.md
+++ b/.claude/templates/sdd/feature-spec/retrospective.example.md
@@ -1,0 +1,21 @@
+# Phase [PHASE_NUMBER] Retrospective — [PHASE_TITLE]
+
+Optional. Written manually after the implementation PR merges, when the implementation surfaced a spec gap worth remembering. `/sdd-implement-spec`'s `## Spec deviations` PR-body section is the raw material; this file is the human-curated distillation.
+
+## Deviations from the spec
+
+- [DEVIATION_1 — name the spec file (`requirements.md` / `plan.md` / `validation.md`), the section, and what the implementation actually had to do]
+- [DEVIATION_2]
+
+## Root cause
+
+[ONE_OR_TWO_SHORT_PARAGRAPHS — why the spec missed this. Typical causes: missing repo context during scaffolding; an adjacent change landed after the spec was written; an assumption in the roadmap phase turned out to be wrong; a load-bearing constraint was not surfaced in `tech-stack.md`.]
+
+## Lesson for future specs
+
+- [LESSON_1 — actionable guidance for `/sdd-new-spec` and `/sdd-new-phase`, specific enough to apply (not generic advice). Example: "when a phase touches the broker router, the spec must remind the implementer that the broker catch-all must remain last in `src/main.py`".]
+- [LESSON_2]
+
+## Promotion candidate
+
+[`yes` or `no` plus one sentence. Default `no` — most lessons are empirical reminders that belong in `specs/lessons.md`. `yes` only when the lesson names a load-bearing invariant that belongs in `specs/tech-stack.md`.]

--- a/.claude/templates/sdd/feature-spec/retrospective.example.md
+++ b/.claude/templates/sdd/feature-spec/retrospective.example.md
@@ -13,7 +13,7 @@ Optional. Written manually after the implementation PR merges, when the implemen
 
 ## Lesson for future specs
 
-- [LESSON_1 — actionable guidance for `/sdd-new-spec` and `/sdd-new-phase`, specific enough to apply (not generic advice). Example: "when a phase touches the broker router, the spec must remind the implementer that the broker catch-all must remain last in `src/main.py`".]
+- [LESSON_1 — actionable guidance for `/sdd-new-spec` and `/sdd-new-phase`, specific enough to apply (not generic advice). Example: "when a phase touches the gate allowlist, the spec must remind the implementer that local files always require a key, regardless of URL form".]
 - [LESSON_2]
 
 ## Promotion candidate

--- a/.claude/templates/sdd/feature-spec/validation.example.md
+++ b/.claude/templates/sdd/feature-spec/validation.example.md
@@ -1,0 +1,31 @@
+# Phase [PHASE_NUMBER] Validation — [PHASE_TITLE]
+
+## Definition of Done
+
+All of the following must be true before this branch is merged.
+
+### 1. [CHECK_TITLE]
+
+```
+[CONCRETE_COMMAND]
+```
+
+[EXACT_EXPECTATION — HTTP status, exit code, output substring, file contents. Be concrete: "HTTP 200, body contains `<h1>Jentic</h1>`" — not "endpoint works".]
+
+### 2. [CHECK_TITLE]
+
+```
+[CONCRETE_COMMAND]
+```
+
+[EXACT_EXPECTATION.]
+
+### 3. [CHECK_TITLE]
+
+[DESCRIPTION_OF_CHECK — may or may not have a command. For file-contents assertions: "`package.json` must list `hono` without a `^` or `~` prefix".]
+
+## Not Required
+
+- [WHAT_IS_EXPLICITLY_DEFERRED_TO_A_LATER_PHASE]
+- [WHAT_NEED_NOT_BE_TESTED_IN_THIS_PHASE]
+- [WHAT_IS_OUT_OF_SCOPE_FOR_VALIDATION]

--- a/.claude/templates/sdd/feature-spec/validation.example.md
+++ b/.claude/templates/sdd/feature-spec/validation.example.md
@@ -10,7 +10,7 @@ All of the following must be true before this branch is merged.
 [CONCRETE_COMMAND]
 ```
 
-[EXACT_EXPECTATION — HTTP status, exit code, output substring, file contents. Be concrete: "HTTP 200, body contains `<h1>Jentic</h1>`" — not "endpoint works".]
+[EXACT_EXPECTATION — exit code, output substring, file contents. Be concrete: "`docker run … score --url <allowlisted-url>` exits 0 and stdout contains a `\"score\":` JSON field" — not "scorer works".]
 
 ### 2. [CHECK_TITLE]
 

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,8 @@ __pycache__/
 .pytest_cache/
 node_modules/
 dist/
+!/.claude
+/.claude/settings.local.json
+/.claude/worktrees/*
+/.claude/scheduled_tasks*
+!/.claude/worktrees/.gitkeep

--- a/README.md
+++ b/README.md
@@ -4,7 +4,20 @@ Score an OpenAPI document against the [Jentic API AI Readiness Framework (JAIRF)
 
 ## What it does
 
-Pass an OpenAPI spec — by URL or by piping bundled JSON to the container — and the scorer evaluates it across six JAIRF dimensions (foundational compliance, developer experience, AI-readiness, agent usability, security, AI discoverability), then prints an overall score plus a per-dimension breakdown.
+Pass an OpenAPI spec — by URL or by piping bundled JSON to the container — and the scorer evaluates it across six JAIRF dimensions (foundational compliance, developer experience, AI-readiness, agent usability, security, AI discoverability) and emits the result as JSON. Today the published Docker image is JSON-only; piping its output to `jq` is the way to read a score:
+
+```bash
+$ docker run --rm ghcr.io/jentic/jentic-api-scorecard \
+    score --url https://raw.githubusercontent.com/jentic/jentic-public-apis/refs/heads/main/apis/openapi/<spec-path> \
+  | jq '{score: .summary.score, level: .summary.level, grade: .summary.grade}'
+{
+  "score": 68.62,
+  "level": "ai-aware",
+  "grade": "B+"
+}
+```
+
+The npm CLI on the roadmap will layer a human-readable scorecard on top of the same JSON (target shape — *not yet shipped*, see [`docs/architecture.md`](docs/architecture.md) §1):
 
 ```
 Jentic API Readiness Scorecard
@@ -20,9 +33,6 @@ Source: https://petstore3.swagger.io/api/v3/openapi.json
     AU    Agent Usability                                  93.70  A+
     SEC   Security                                         42.50  D-
     AID   AI Discoverability                              100.00  A+
-
-  Run with --verbose for signal breakdown.
-  Full report: --format json --include-diagnostics
 ```
 
 ## How it works

--- a/README.md
+++ b/README.md
@@ -1,1 +1,67 @@
 # Jentic API Scorecard
+
+Score an OpenAPI document against the [Jentic API AI Readiness Framework (JAIRF)](https://github.com/jentic/api-ai-readiness-framework) and get a readable scorecard. Today the project ships as a public Docker image; an `npx @jentic/api-scorecard` CLI wrapper is on the roadmap (see [`docs/architecture.md`](docs/architecture.md)).
+
+## What it does
+
+Pass an OpenAPI spec — by URL or by piping bundled JSON to the container — and the scorer evaluates it across six JAIRF dimensions (foundational compliance, developer experience, AI-readiness, agent usability, security, AI discoverability), then prints an overall score plus a per-dimension breakdown.
+
+```
+Jentic API Readiness Scorecard
+Source: https://petstore3.swagger.io/api/v3/openapi.json
+
+  Final score:    68.62 / 100
+  Readiness:      ai-aware  (B+)
+
+  Dimensions
+    FC    Foundational Compliance                          99.51  A+
+    DXJ   Developer Experience & Jentic Compatibility      68.89  B+
+    ARAX  AI-Readiness & Agent Experience                  54.62  C
+    AU    Agent Usability                                  93.70  A+
+    SEC   Security                                         42.50  D-
+    AID   AI Discoverability                              100.00  A+
+
+  Run with --verbose for signal breakdown.
+  Full report: --format json --include-diagnostics
+```
+
+## How it works
+
+The image bundles [`jentic-apitools-cli`](https://pypi.org/project/jentic-apitools-cli/) — the JAIRF scoring engine — alongside Python 3.12 and Node 24 (the engine spawns Redocly / Spectral / Speclynx via `npx`). Scoring runs locally inside the container; URL inputs are fetched by the engine, stdin inputs are written to a tempfile and scored from there. Anonymous scoring is restricted to specs in [jentic-public-apis](https://github.com/jentic/jentic-public-apis); other inputs require `JENTIC_API_KEY=mvp-preview` (a documented public placeholder for the MVP preview, not a secret). For the full architecture and design rationale, see [`docs/architecture.md`](docs/architecture.md).
+
+## Quick start
+
+Score an allowlisted public spec, no key required (replace `<spec-path>` with any path under [jentic-public-apis/apis/openapi/](https://github.com/jentic/jentic-public-apis/tree/main/apis/openapi)):
+
+```bash
+docker run --rm ghcr.io/jentic/jentic-api-scorecard \
+  score --url https://raw.githubusercontent.com/jentic/jentic-public-apis/refs/heads/main/apis/openapi/<spec-path>
+```
+
+Score any other URL or a local spec — set the MVP preview key:
+
+```bash
+docker run --rm \
+  -e JENTIC_API_KEY=mvp-preview \
+  ghcr.io/jentic/jentic-api-scorecard \
+  score --url https://petstore3.swagger.io/api/v3/openapi.json
+```
+
+Pipe a local spec via stdin:
+
+```bash
+cat openapi.json | docker run -i --rm \
+  -e JENTIC_API_KEY=mvp-preview \
+  ghcr.io/jentic/jentic-api-scorecard \
+  score
+```
+
+Add `--with-llm` (and forward an LLM provider key, e.g. `-e OPENAI_API_KEY`) to enable LLM-backed signal analysis.
+
+## Status
+
+Delivery 1 of the scorecard ships only the GHCR image — direct `docker run` is the supported invocation today. The `@jentic/api-scorecard` npm wrapper that orchestrates the image, host-side spec bundling, and the pretty CLI UX is planned but not yet published. Track scope and roadmap in [`docs/architecture.md`](docs/architecture.md); file issues at https://github.com/jentic/jentic-api-scorecard/issues.
+
+## License
+
+Apache 2.0 — see [`LICENSE`](LICENSE) and [`NOTICE`](NOTICE).

--- a/specs/lessons.md
+++ b/specs/lessons.md
@@ -1,0 +1,7 @@
+# Lessons
+
+Aggregated checklist of recurring lessons distilled from `specs/<date>-<slug>/retrospective.md` files. `/sdd-new-spec` and `/sdd-new-phase` load this file before scaffolding so future specs absorb the learning. Refresh manually via `/sdd-distill-lessons`.
+
+## Lessons
+
+_(empty — no retrospectives have been distilled yet)_

--- a/specs/mission.md
+++ b/specs/mission.md
@@ -1,0 +1,51 @@
+---
+type: constitution
+section: mission
+generated_by: spec-driven-agent
+generated_at: 2026-05-21T20:06:51Z
+confidence: high
+---
+
+# Mission
+
+Jentic API Scorecard exists because OpenAPI authors have no clean way to tell whether their API is *ready for AI agents and LLM integrations*. Standards like spec-validity tell you the document parses; nothing tells you whether an agent can actually understand, authenticate against, and operate the API safely. The Jentic API AI Readiness Framework (JAIRF) names the missing rubric — operational signals across foundational compliance, developer experience, AI-readiness, agent usability, security, and AI discoverability — and this project ships the rubric as a runnable scorecard.
+
+Run target: score an OpenAPI spec from one shell command, with no install required, and get back a graded report plus per-signal evidence.
+
+## What We Do
+
+Jentic API Scorecard is a CLI tool that scores an OpenAPI document against JAIRF and emits a Jentic API Readiness Scorecard. The user-facing UX is `npx @jentic/api-scorecard score <input>` (npm CLI orchestrating a public Docker image — see `docs/architecture.md` §1). For Delivery 1 only the public Docker image (`ghcr.io/jentic/jentic-api-scorecard`) ships; the npm wrapper is on the roadmap.
+
+We:
+
+- **Score an OpenAPI spec by URL or piped JSON** — six JAIRF dimensions (FC, DXJ, ARAX, AU, SEC, AID) with overall score, level (`ai-aware`, etc.), and grade (A+ … F).
+- **Run scoring locally** in an isolated Docker container — no spec content leaves the user's machine; no calls to Jentic's backend during scoring.
+- **Gate anonymous use** to specs in [`jentic/jentic-public-apis`](https://github.com/jentic/jentic-public-apis); other inputs require `JENTIC_API_KEY=mvp-preview` (a documented public placeholder during the MVP preview, not a secret — see `docs/architecture.md` §9).
+- **Emit machine-readable JSON** verbatim from the engine, plus pretty / Markdown projections for human readers (deferred to the npm CLI; today the image emits JSON only).
+- **Optionally invoke LLM-backed analysis** via `--with-llm` when an LLM provider key (OpenAI / Anthropic / Gemini / AWS Bedrock) is forwarded by the host.
+
+## Who We Serve
+
+- **OpenAPI spec authors and maintainers** — the primary persona. The team that owns an OpenAPI document and wants a concrete, evidence-grounded answer to "how AI-ready is this spec, and what should I fix first?" Today they consume the tool by running the Docker image; once the npm CLI ships, by `npx @jentic/api-scorecard score …`.
+- **CI integrators (secondary)** — the same teams once they want to gate merges on JAIRF score thresholds. Delivery 1 emits stable JSON and exit codes that make this trivial; a `--min-score N` gate flag is explicitly deferred (see `docs/architecture.md` §10).
+
+## Target Audience
+
+- **Public API teams** publishing OpenAPI specs that will be consumed by AI agents — the value lift is highest here, since the score directly predicts agent compatibility.
+- **Internal platform teams** evaluating their own catalog before exposing it to agents — the same scoring works against private specs (with `JENTIC_API_KEY` set).
+- **Open-source maintainers of OpenAPI specs in the [jentic-public-apis](https://github.com/jentic/jentic-public-apis) catalog** — anonymous mode is built precisely for them; no signup, just `docker run` against a raw GitHub URL.
+
+## What Success Looks Like
+
+- A user with an OpenAPI spec and Docker installed can score it from one shell command and read a graded report in under 30 seconds.
+- Scoring is **reproducible**: pinning one CLI version pins one image tag pins one engine version. Two users with the same CLI version against the same spec get the same score (modulo LLM-backed signals, which are stochastic).
+- The result JSON is **stable enough to be consumed by automation** — verbatim engine output, no CLI-introduced schema, no envelope keys (see `docs/architecture.md` §7). CI integrators can `jq` the score field without paying attention to CLI version.
+- The **MVP key scheme is recognizably transitional**: `JENTIC_API_KEY=mvp-preview` works today; any other value rejects with a guidance message; real keys land in a follow-up release with one container-side function change (see `docs/architecture.md` §9).
+- Anonymous use is **safe by default**: only specs in the documented allowlist can be scored without a key. The container enforces this; the host CLI cannot bypass it.
+
+## Assumptions & Unknowns
+
+- **`jentic-apitools-cli` is the engine.** The mission assumes the upstream engine remains the JAIRF reference implementation. If JAIRF and the engine diverge, the constitution will need to revisit which one the mission describes.
+- **`JENTIC_API_KEY=mvp-preview` is transitional.** When real key issuance ships, the user-facing flow (`export JENTIC_API_KEY=…`) does not change — but the validation moves from a static check to an HTTP call to `api.jentic.com`. This is design intent (`docs/architecture.md` §9), not a current capability.
+- **The npm CLI is on the roadmap, not shipped today.** Delivery 1 ships only the Docker image. The user-facing `npx @jentic/api-scorecard …` UX is the target; today's actual UX is `docker run …`. Both paths are documented in the README.
+- **Sandboxing assumption.** We assume `docker run --rm` provides sufficient isolation for arbitrary public OpenAPI specs to score safely. We do not currently sandbox further (no `--cpus`, no `--memory`, no network namespaces). Architecture.md §10 defers concurrency / CPU control to "concrete user pain."

--- a/specs/roadmap.md
+++ b/specs/roadmap.md
@@ -1,0 +1,164 @@
+---
+type: constitution
+section: roadmap
+generated_by: spec-driven-agent
+generated_at: 2026-05-21T20:06:51Z
+confidence: medium
+---
+
+# Roadmap
+
+**Phases marked ✅ have shipped; everything else is planned.**
+
+Phases are intentionally small — each one must be a **shippable, independently reviewable, and testable slice of work**.
+
+The starting point is the current repository state: the `docker/` runner ships, but no CI, no npm CLI, no real auth, and no HTML renderer exist. Reference design lives in `docs/architecture.md`; this roadmap sequences how we close the gap.
+
+**Priority values:** `High`, `Medium–High` (en-dash, U+2013), `Medium`. `(blocker)` is reserved for phases that fix a current trust/security gap making the system unsafe for its **today** use; forward-looking production work uses normal priority and states the rationale in the phase body. `(blocker)` implies a release gate for today's bar; other levels express relative queue position.
+
+**Lifecycle:** when a phase ships, append ` ✅` (a single space followed by the U+2705 checkmark) to its `## Phase N — Title` heading and leave the rest of the block in place — do not delete or renumber. The leading space is load-bearing — completion-verify steps `grep -F` for the exact ` ✅` suffix. Phase numbers are stable identifiers; completed phases stay in the file as history. New work takes the next number after the largest existing phase.
+
+## Phase 1 — Ship CI: docker-image build + GHCR publish on tag
+
+**Goal:** automate image builds so cutting a git tag publishes a versioned image to GHCR.
+**Depends on:** none (self-contained CI scaffolding)
+**Priority:** High
+
+Currently every image is hand-built and hand-pushed; there's no recorded provenance and no enforcement that the image on GHCR matches the source tree at any tag. This phase makes the runner shippable.
+
+- Add `.github/workflows/docker-image.yml` triggered on tag refs `v*`.
+- Build context `./docker`; tag the resulting image as both `:<version>` (from the git tag) and `:latest`.
+- Push to `ghcr.io/jentic/jentic-api-scorecard` using the workflow's `GITHUB_TOKEN`.
+- Smoke-test the published image post-push: `docker run --rm <image> score --url <jentic-public-apis-url>` exits 0 and emits JSON with a `summary.score` field.
+- Update `docs/architecture.md` §4 / §8 only if the implemented workflow diverges from the description there.
+
+## Phase 2 — Scaffold packages/ + first end-to-end CLI smoke
+
+**Goal:** stand up the npm workspaces root and the smallest `score` subcommand that orchestrates the published GHCR image.
+**Depends on:** Phase 1
+**Priority:** High
+
+The npm CLI is the user-facing UX (`npx @jentic/api-scorecard score …`) per `docs/architecture.md` §1. Until it ships, the public README has to point users at raw `docker run` invocations. This phase lands the minimum vertical slice that delivers the documented UX end-to-end (rough, but real).
+
+- Create the npm workspaces root: `package.json`, `lerna.json`, `tsconfig.base.json`. Fixed/locked Lerna versioning (`docs/architecture.md` §2).
+- Scaffold `packages/cli/` (`@jentic/api-scorecard`) with a single `score` subcommand that:
+  - Reads `JENTIC_API_KEY` from env and forwards it via `-e JENTIC_API_KEY` to `docker run`.
+  - Hard-codes the image tag matching its own npm version (CLI version = image tag invariant).
+  - Pipes spec input through stdin (local file → bundle via `@redocly/openapi-core`; URL → forward `--url` to the container; gate enforcement stays container-side).
+  - Streams container stdout to host stdout; prints engine errors on stderr.
+- Scaffold `packages/html-renderer/` (`@jentic/api-scorecard-html`) with the typed `render(result): string` stub only — no implementation yet.
+- README and `.claude/CLAUDE.md` repository-state sections are updated to reflect that `packages/` now exists.
+
+## Phase 3 — Pretty / JSON / Markdown output + verbose & diagnostics flags
+
+**Goal:** ship the human-readable scorecard, the canonical JSON form, and the Markdown projection so the UX matches `docs/architecture.md` §5.
+**Depends on:** Phase 2
+**Priority:** High
+
+Phase 2 lands a working CLI that streams engine JSON. This phase layers the renderers on top so the default `npx … score` shows the scorecard headline + dimensions (matching the sample output in `docs/architecture.md` §1), with `--format`, `--verbose`, `--include-diagnostics`, `-o`, and `--quiet` doing what the spec describes.
+
+- Implement `pretty` renderer (default) with headline + dimension table. Treat `summary.dimensions[]` as the canonical shape; tolerate unknown keys.
+- Implement `json` renderer (engine-verbatim, `diagnostics` array stripped unless `--include-diagnostics`).
+- Implement `markdown` renderer (Markdown table; `--include-diagnostics` adds a Markdown list).
+- Add `--verbose` (per-signal breakdown in pretty mode only — no effect on JSON / Markdown payloads).
+- Add `-o FILE` (writes report to file; spinner stays on stderr).
+- Add `--quiet` (suppresses spinner explicitly; auto-suppresses when stderr is not a TTY).
+
+## Phase 4 — npm publish CI on tag (both packages)
+
+**Goal:** automate npm publishing so cutting a git tag also publishes `@jentic/api-scorecard` and `@jentic/api-scorecard-html` (Lerna fixed-version means both ship together).
+**Depends on:** Phase 3
+**Priority:** High
+
+The CLI version = image tag invariant requires that the same git tag triggers both publishes. Manual npm publish is brittle and easy to mis-version.
+
+- Add `.github/workflows/npm-publish.yml` triggered on tag refs `v*`.
+- Run `npm publish` for `packages/cli` and `packages/html-renderer` with provenance enabled (`--provenance`).
+- Smoke-test post-publish: `npx @jentic/api-scorecard@<version> score --help` succeeds; the version string reported by `--version` matches the tag.
+- Document the release ritual: branch → tag → both workflows fire → image and packages land together.
+
+## Phase 5 — Husky + commit-msg hook for human commits
+
+**Goal:** enforce Conventional Commits and DCO sign-off on every human / CI commit, not just Claude-driven ones.
+**Depends on:** Phase 2 (needs the npm root)
+**Priority:** Medium–High
+
+Today only the Claude PreToolUse hook checks `git commit` payloads. Direct `git commit` from a contributor's terminal can land malformed messages, and the squash-merge commit message must follow Conventional Commits (per `.claude/rules/git-workflow.md`).
+
+- Install `husky`, `@commitlint/cli`, `@commitlint/config-conventional`, and `lint-staged` at the npm root.
+- Add `.husky/commit-msg` running commitlint against the staged message.
+- Add `.husky/pre-commit` running `lint-staged` (ruff for Python files in `docker/`; eslint for TS files in `packages/`).
+- The Claude PreToolUse hook continues to soft-no-op until `node_modules/.bin/commitlint` exists; once Phase 5 ships, the hook activates.
+
+## Phase 6 — `--with-llm` plumbing end-to-end
+
+**Goal:** the CLI scans for LLM provider keys, errors fast if `--with-llm` is set without one, and forwards present keys via docker's passthrough form.
+**Depends on:** Phase 3
+**Priority:** Medium–High
+
+Architecture.md §5 describes `--with-llm` precisely. The container already accepts `--with-llm` and forwards `--enable-llm-analysis` to the engine. The host-side scan-and-forward is the remaining piece. Until it ships, users can only invoke `--with-llm` by piping their own `docker run -e …` invocation.
+
+- CLI scans its env for `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GEMINI_API_KEY`, and `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` / `AWS_SESSION_TOKEN` / `AWS_REGION`.
+- If `--with-llm` is set and none are present, exit non-zero **before** `docker run` is invoked, with a guidance message.
+- Forward each present key via `-e <NAME>` (docker passthrough form). Do not log keys in spinner / error / telemetry output.
+- Document the security note (provider keys appear in `docker inspect` for the run; this is standard Docker behavior, see `docs/architecture.md` §5).
+
+## Phase 7 — `--bundle` host-side fetch + bundling
+
+**Goal:** support scoring URLs that only the host can reach (internal networks, VPN-gated specs, auth-required URLs).
+**Depends on:** Phase 3
+**Priority:** Medium
+
+`--bundle` is the escape hatch from `docs/architecture.md` §5. It implies key-required (the anonymous allowlist does not apply once the source URL stops reaching the container).
+
+- CLI fetches the URL on the host, runs Redocly bundling (`@redocly/openapi-core`), pipes bundled JSON to the container's stdin.
+- For local paths, `--bundle` is a no-op (bundling is always how local files are handled).
+- Update the input-dispatch table in the CLI's help output to match `docs/architecture.md` §5.
+
+## Phase 8 — Real auth: replace `mvp-preview` with an HTTP validator
+
+**Goal:** `JENTIC_API_KEY=<real-key>` validates against `api.jentic.com`; the placeholder check becomes a deprecation message pointing users to signup.
+**Depends on:** Phase 4 (so signup-driven onboarding can flow through the documented `npx` UX)
+**Priority:** High
+
+The `mvp-preview` placeholder is explicitly transitional (`docs/architecture.md` §9). The phase that ships real keys is a release-gate moment for the project — it's the difference between an MVP preview and a real product. **Not a `(blocker)` today**, because the placeholder system is documented and safe; this is forward-looking work that unblocks the next product phase.
+
+- Replace the static comparison in `docker/src/jentic_scorecard_runner/gate.py` with `httpx.get("https://api.jentic.com/v1/validate", headers={"Authorization": f"Bearer {key}"})`.
+- Keep the `mvp-preview` value temporarily as a recognized placeholder with a deprecation message ("This MVP key is deprecated; sign up at https://jentic.com/signup for a real key.") for one minor version, then remove.
+- Add `httpx` to `docker/pyproject.toml`.
+- Bump the engine pin if needed and rebuild the image (CLI version bump rides along).
+- Update `docs/architecture.md` §9 to mark the MVP scheme as superseded.
+
+## Phase 9 — HTML renderer implementation
+
+**Goal:** `@jentic/api-scorecard-html`'s `render(result): string` ships a real HTML scorecard suitable for embedding in CI artifacts and dashboards.
+**Depends on:** Phase 3 (so the input shape — engine-verbatim JSON minus `diagnostics` unless requested — is settled)
+**Priority:** Medium
+
+The HTML renderer is scaffolded in `packages/html-renderer/` after Phase 2 but ships a stub. This phase lands the actual rendering.
+
+- Implement `render(result): string` returning self-contained HTML (no external CSS / JS dependencies).
+- Render headline, dimensions, optional per-signal breakdown when the input includes signals, optional diagnostics block when present.
+- Add a CLI flag `--format html` (and `-o report.html`) wiring the renderer in.
+- Snapshot-test the renderer against a representative result JSON.
+
+## Phase 10 — `--min-score N` for CI gating
+
+**Goal:** `score --min-score 70` exits non-zero if the final score is below 70, enabling CI to gate on JAIRF compliance.
+**Depends on:** Phase 3 (output formats settled)
+**Priority:** Medium
+
+Sequenced after Phase 3 ships JSON / Markdown stably — CI integrators need a stable JSON shape before the gate flag is interesting.
+
+- Add `--min-score <N>` flag that exits non-zero if `summary.score < N`. New exit code or reuse `GENERIC_ERROR=1`? Default to a new code (e.g. `7 — score below threshold`) and document it in `docs/architecture.md` §6.
+- Document the CI recipe in the README ("score --min-score 70 --format json -o report.json && upload report.json").
+
+## Later Phases (Not Yet Planned)
+
+- Multi-spec / portfolio scoring across many APIs in one invocation
+- Plugins / custom rubrics on top of JAIRF
+- `--cpus` / `--memory` flags + matching engine worker-pool hints (deferred until a concrete user-pain signal)
+- Login subcommand / persistent credentials file
+- Server-side calls to Jentic for usage tracking / rate limiting
+
+<!-- Items above are clearly out of current scope for the initial product trajectory. -->

--- a/specs/tech-stack.md
+++ b/specs/tech-stack.md
@@ -1,0 +1,112 @@
+---
+type: constitution
+section: tech-stack
+generated_by: spec-driven-agent
+generated_at: 2026-05-21T20:06:51Z
+confidence: high
+---
+
+# Tech Stack
+
+The current state, grounded in repository evidence. Planned-but-not-built items are called out under **Roadmap, not yet built** and **What We Are Not Using** so this file never claims more than the code supports.
+
+`docs/architecture.md` is the canonical design spec for the project. Conflict-resolution rule: when this file disagrees with code, the code wins; when this file disagrees with `docs/architecture.md` about *intent*, `docs/architecture.md` wins.
+
+## Architecture Summary
+
+- **Application style:** CLI (Docker image today; an npm CLI wrapper is on the roadmap — see `docs/architecture.md` §1)
+- **Primary language:** Python 3.12 (in `docker/`; TypeScript will join when `packages/` lands)
+- **Rendering model:** API_ONLY — the container emits JSON to stdout. Pretty / Markdown rendering is deferred to the npm CLI.
+- **Deployment / runtime shape:** CONTAINER (`ghcr.io/jentic/jentic-api-scorecard`, multi-stage Docker build under `docker/`)
+- **Current maturity:** PROTOTYPE — the runner code, image build, and tests exist; CI, the npm CLI, and real auth do not. See `docs/architecture.md` §2 for the design spec; see `What We Are Not Using` below for the gap.
+
+## Core Stack
+
+| Layer | Choice | Evidence |
+|---|---|---|
+| Language | Python 3.12 | `docker/pyproject.toml:5` (`requires-python = ">=3.12"`); `docker/Dockerfile:1` (`FROM python:3.12-slim`) |
+| Runtime (host) | Docker | `docker/Dockerfile`; `ghcr.io/jentic/jentic-api-scorecard` is the deliverable |
+| Runtime (in image) | Python 3.12 + Node 24 LTS | `docker/Dockerfile:1, 3-6` (Node copied from `node:24-slim` for engine's `npx` dispatch) |
+| Scoring engine | `jentic-apitools-cli` (PyPI) | `docker/pyproject.toml:7` (pinned exactly); shells out to `npx`-launched Redocly / Spectral / Speclynx validators |
+| Dependency manager | uv | `docker/uv.lock`; `docker/Dockerfile:9` pins `ghcr.io/astral-sh/uv:0.8.5`; `[tool.uv]` in `docker/pyproject.toml:17-18` |
+| Build / packaging | Docker multi-stage | `docker/Dockerfile`; build-time `npx` cache warming via `docker/.build/sample.yaml` (`docker/Dockerfile:20-24`) |
+| Test framework | pytest | `docker/pyproject.toml:12, 51`; tests in `docker/tests/` |
+| Lint / format | ruff | `docker/pyproject.toml:13, 20-31`; PostToolUse hook `.claude/hooks/ruff-fix.sh` runs on every Python edit |
+| Task runner | poethepoet (poe) | `docker/pyproject.toml:14, 33-48`; tasks: `lint`, `lint:fix`, `test` |
+
+## Key Libraries and Frameworks
+
+- **`jentic-apitools-cli`** — the JAIRF scoring engine. Invoked as `jentic-apitools score <target> --format json --include-diagnostics --quiet [--enable-llm-analysis]`. Pinned exactly in `docker/pyproject.toml`; reproducibility is "pin one CLI version → pin one image tag → pin one engine version" (see `docs/architecture.md` §8).
+- **uv** — fast Python resolver/installer; lockfile (`docker/uv.lock`) is the source of truth for dependency versions. `uv sync --frozen --no-dev --no-install-project` runs at image build time. `[tool.uv]` declares `package = false` because the runner is image-internal, never published to PyPI.
+- **Docker (multi-stage build)** — base `python:3.12-slim`; binaries copied from `node:24-slim` and `ghcr.io/astral-sh/uv:0.8.5`. `ENTRYPOINT ["uv", "run", "python", "-m", "jentic_scorecard_runner"]` is fixed; every `docker run` appends arguments.
+
+## Data and Storage
+
+- **Primary storage:** NONE. The container processes a single spec per invocation and exits. No DB, no persistent state, no cache between runs. The build-time npm cache lives in image layers (read-only at runtime).
+- **Access pattern:** stdin → tempfile → engine; URL → engine (engine fetches). I/O is chunked (`read(65536)`) to avoid RSS blow-up on large specs.
+- **Migrations:** N/A.
+- **Caching:** image-layer npm cache (`/var/cache/npm`) populated by the build-time score against `docker/.build/sample.yaml`. **Invariant:** containers must perform no package installs at runtime — see `docs/architecture.md` §6 ("Pre-baked dependencies").
+
+## Testing
+
+- **Test framework:** pytest 9.x (`docker/pyproject.toml:12`).
+- **Test types visible:** unit (`docker/tests/test_gate.py`, `test_main.py`) + integration (`docker/tests/test_integration.py` exercises a built Docker image end-to-end).
+- **Convention: no mocks.** Tests use the real gate logic and (for integration) the real engine via subprocess. Environment is manipulated with pytest's `monkeypatch`; external services are not stubbed. Run with `cd docker && uv run poe test`.
+
+## Tooling and Developer Experience
+
+- **Local development:** `cd docker && uv sync` to install; `cd docker && uv run python -m jentic_scorecard_runner score …` to invoke the runner outside Docker.
+- **Build / release:** `docker build ./docker` produces the image. Release is **manual today** — tag, build, push to GHCR by hand. Automation is on the roadmap.
+- **Formatting / linting:** ruff (rules `E4`, `E7`, `E9`, `F`, `I`, `PLC0415`, `PLC2701`; line length 100; `lines-after-imports = 2`). Run `cd docker && uv run poe lint:fix`.
+- **Type checking:** none. Python 3.12 syntax (`list[str]`, `X | None`) is used; no mypy / pyright in CI.
+- **CI/CD:** NONE_OBSERVED. `.github/` does not exist on disk at all. `docker-image.yml` and `npm-publish.yml` are described in `docs/architecture.md` §4 / §8 as planned, not implemented.
+- **Conventional Commits enforcement:** Claude PreToolUse hook `.claude/hooks/commitlint-before-commit.py` blocks malformed `git commit -m` payloads. The hook soft-no-ops until commitlint is installed at the repo root (`node_modules/.bin/commitlint`); the husky `commit-msg` hook for human/CI commits is on the roadmap.
+- **DCO sign-off:** required by convention. `git commit -s` adds `Signed-off-by:` per `.claude/rules/git-workflow.md`.
+
+## Deployment and Operations
+
+- **Deployment target:** GHCR (`ghcr.io/jentic/jentic-api-scorecard`). Manual today; automated via `docker-image.yml` on the roadmap.
+- **Environment management:** env-vars only (`JENTIC_API_KEY`, optional LLM provider keys). No `.env` file, no secret manager.
+- **Observability:** stderr for engine warnings + (eventual) host-side spinner phases. No metrics, no tracing, no telemetry — and no calls to Jentic's backend during scoring (see `docs/architecture.md` §9).
+- **Error handling / resilience:** structured exit codes (`docker/src/jentic_scorecard_runner/exit_codes.py`: `SUCCESS=0`, `GENERIC_ERROR=1`, `AUTH_INVALID_KEY=2`, `GATE_REJECTED=3`, `SPEC_FAILURE=5`, `ENGINE_FAILURE=6`). Engine exit code 2 is mapped to `SPEC_FAILURE`; any other non-zero is `ENGINE_FAILURE`. 300s engine timeout enforced in `score.py`.
+
+## Constraints and Conventions
+
+- **Gate before score (CRITICAL).** `docker/src/jentic_scorecard_runner/__main__.py:45-49` calls `check_gate(url)` before `run_score(...)`. Reordering lets anonymous inputs reach the engine, defeating the auth model. Symptom: `--url` to a non-allowlisted host returns a normal score instead of exit code 3.
+- **Anonymous URL allowlist is hard-coded regex.** `_ALLOWLIST_PATTERN` in `docker/src/jentic_scorecard_runner/gate.py:18-20` matches `^https://raw\.githubusercontent\.com/jentic/jentic-public-apis/refs/heads/main/apis/openapi/`. Do not extend the gate to add new accepted values until real auth ships (see `docs/architecture.md` §9).
+- **`JENTIC_API_KEY=mvp-preview` is the only non-anonymous accepted value.** Hard-coded as `_MVP_KEY` in `gate.py:16`. **Not a secret** — the image is public and the value is trivially extractable. Its purpose is to exercise auth plumbing now so swapping in a real validator is a one-function change.
+- **Engine invocation is rigid.** Always `--format json --include-diagnostics --quiet` (+ `--enable-llm-analysis` when applicable). The runner does not expose these on its own surface; the container always emits canonical JSON.
+- **Result JSON is engine-verbatim.** The runner does not invent a schema, rename keys, or restructure. The CLI consumes whatever `jentic-apitools score --format json` emits (minus `diagnostics` unless `--include-diagnostics` is set on the host CLI). See `docs/architecture.md` §7.
+- **Exit codes are public CLI contract.** Container codes 0/1/2/3/5/6 plus host code 4 (Docker missing) are documented in `docs/architecture.md` §5–§6. Changes break automation.
+- **No runtime package installs.** All Python wheels and JS tarballs are baked at build time; `RUN jentic-apitools score sample.yaml …` warms the npm cache. Any image change that re-introduces runtime installs is a Dockerfile bug.
+- **Python tooling resolves only from `docker/`.** `pyproject.toml`, `uv.lock`, and `poethepoet` live there; `uv run poe …` from the repo root fails (`Failed to spawn: poe`). Always `cd docker &&` first. The root may host an npm workspaces tree later (see roadmap), but Python stays in `docker/`.
+- **Tests use no mocks.** Hit the real gate / real engine. Tests are the source of truth for the runner's contract; if a test passes it's because the real boundary works, not because a fake one does.
+- **Modern Python type syntax only.** `list[str]`, `dict[str, int]`, `X | None` (PEP 585 / PEP 604). No `typing.List` / `typing.Optional`. Top-level imports only (ruff `PLC0415`); no cross-module `_private` imports (ruff `PLC2701`). See `.claude/rules/python-code-style.md`.
+- **Git workflow:** branch (`feat/`, `fix/`, `chore/`, `docs/`, `test/`) → atomic commits with DCO sign-off → PR → squash-merge. Direct push to `main` is forbidden. See `.claude/rules/git-workflow.md`.
+
+## What We Are Not Using
+
+- **No FastAPI / web server.** This is a CLI, not a service. The architecture deliberately has no backend in the loop (`docs/architecture.md` §1).
+- **No database.** No persistent state; one spec per `docker run` invocation.
+- **No husky / lint-staged today.** Pre-commit hooks are described in `docs/architecture.md` §4 as planned; only the Claude PreToolUse commitlint hook is live today.
+- **No CI workflows today.** `.github/` is absent entirely. `docker-image.yml` and `npm-publish.yml` are roadmap.
+- **No type checker (mypy / pyright).** Ruff handles linting; type checks are not enforced.
+- **No usage tracking / telemetry / rate-limiting beyond the static URL allowlist.** Explicit non-goals (`docs/architecture.md` §10).
+- **No `dockerode` (Docker SDK).** When the npm CLI lands, it shells out to `docker` via `child_process.spawn`. Decision recorded in `docs/architecture.md` §2.
+
+## Roadmap, not yet built
+
+These exist in `docs/architecture.md` but **not on disk**. Future phases will land them:
+
+- **`packages/` Lerna monorepo** — TypeScript npm workspaces root with `@jentic/api-scorecard` (CLI) and `@jentic/api-scorecard-html` (renderer stub).
+- **`.github/workflows/docker-image.yml`** — build + push image on tag.
+- **`.github/workflows/npm-publish.yml`** — publish npm packages on tag.
+- **`.husky/`** — pre-commit + commit-msg hooks for human/CI commits (commitlint, lint-staged).
+- **Real auth validator.** Replaces the static `mvp-preview` check with an HTTP call to `api.jentic.com`. One-function change inside the container.
+- **HTML renderer implementation.** `@jentic/api-scorecard-html` ships as a stub today (per the architecture doc); the actual renderer is post-MVP.
+
+## Open Questions / Uncertain Areas
+
+- **`docker/uv.lock` re-pin cadence.** No documented schedule for refreshing the lock. Currently bound to the engine pin; we re-lock when bumping `jentic-apitools-cli`.
+- **Engine signal stability.** `jentic-apitools-cli` is `1.0.0a16` (alpha). Signal names and metadata shapes may change in breaking ways before 1.0; the renderer (when it lands) needs to tolerate unknown / missing keys per `docs/architecture.md` §7.
+- **LLM provider selection logic.** Architecture.md §5 says the engine "picks a provider" when multiple LLM keys are forwarded. The selection algorithm is not documented here; defer to upstream engine docs.


### PR DESCRIPTION
## Summary

Imports the `.claude/` Claude Code harness from `jentic-mini`, adapts it to this repo, lands a project-guide CLAUDE.md and a real README, and bootstraps the SDD constitution under `specs/`. Four atomic commits, all in `docs/` or `.claude/` — zero changes under `docker/`.

- `chore(harness): adapt .claude/ to the scorecard repo` — full `.claude/` tree (rules, hooks, skills, templates, output-styles, settings.json), `.gitignore` carve-outs, hooks rewired to `docker/` (ruff via `cd docker && uv run`, commitlint via repo-root `node_modules`). Drops four rules describing a stack we don't have (FastAPI, `ui/`, vault, SQLite).
- `chore(harness): strip remaining mini-isms from rules and skills` — second-pass cleanup of illustrative examples (broker / oauth-broker / `cd ui && npm run` / `AGENTS.md` / Python 3.11) replaced with scorecard-grounded equivalents (gate / score / `cd docker && uv run poe` / Python 3.12).
- `docs(CLAUDE): add project guide and rewrite README` — `.claude/CLAUDE.md` with the load-bearing CRITICAL invariant (gate runs before score), auth/gate table, exit-code map, and `cd docker &&` requirement. README rewritten to shipped-state-only docs (`docker run …` is the documented UX; npm CLI flagged as roadmap).
- `docs(specs): bootstrap SDD constitution` — three-file constitution generated by `/sdd-create-constitution` from a four-subagent evidence pass: `mission.md` (high confidence), `tech-stack.md` (high confidence, every claim file:line-grounded), `roadmap.md` (medium confidence, Phase 1 = ship CI, Phases 2-10 sequenced from `docs/architecture.md` §10).

`docs/architecture.md` remains the canonical product/architecture doc; the constitution captures load-bearing invariants and cross-references it for operational detail (CLI flags, JSON schema, verification checks).

## Test plan

- [x] `chmod +x .claude/hooks/ruff-fix.sh` confirmed; smoke-tested against an absolute-path payload (matches Claude Code's hook-input shape) — exits clean on `.py`, no-ops on non-`.py`.
- [x] `commitlint-before-commit.py` smoke-tested with a malformed message — soft-no-ops as expected since `node_modules/.bin/commitlint` doesn't exist yet (will activate once husky lands; tracked as roadmap Phase 5).
- [x] Verified `cd docker && uv run poe test` works; `uv run poe test` from repo root fails with `Failed to spawn: poe` (documented in `.claude/CLAUDE.md` and `specs/tech-stack.md`).
- [x] Constitution file:line citations cross-checked against `docker/src/jentic_scorecard_runner/{__main__,gate,score,exit_codes}.py`, `docker/Dockerfile`, and `docker/pyproject.toml`. All accurate.
- [x] Self-review pass via `/review` — six findings actionable, all addressed; two findings deferred (Phase 8 priority/dependency tension, `uv.lock` re-pin cadence) as forward-looking watch items.