### PR TITLE
feat(cli): add pretty formatter and stderr spinner

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3049,31 +3049,6 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@unrs/resolver-binding-wasm32-wasi/node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@unrs/resolver-binding-wasm32-wasi/node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@unrs/resolver-binding-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
@@ -3298,7 +3273,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -3876,7 +3850,6 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -4091,7 +4064,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -4104,7 +4076,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/color-support": {
@@ -7264,7 +7235,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -9825,6 +9795,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@emnapi/core": "1.4.5",
         "@emnapi/runtime": "1.4.5",
@@ -12417,7 +12388,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -13415,6 +13385,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@redocly/openapi-core": "^1.30.0",
+        "chalk": "^4.1.2",
         "commander": "^14.0.0"
       },
       "bin": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3909,7 +3909,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
       "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "restore-cursor": "^5.0.0"
@@ -6549,7 +6548,6 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
       "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -9173,7 +9171,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
       "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -11586,7 +11583,6 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
       "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "onetime": "^7.0.0",
@@ -11603,7 +11599,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
       "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mimic-function": "^5.0.0"
@@ -11619,7 +11614,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
       "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=14"
@@ -12154,6 +12148,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/stdin-discarder": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/stdin-discarder/-/stdin-discarder-0.3.2.tgz",
+      "integrity": "sha512-eCPu1qRxPVkl5605OTWF8Wz40b4Mf45NY5LQmVPQ599knfs5QhASUm9GbJ5BDMDOXgrnh0wyEdvzmL//YMlw0A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/stop-iteration-iterator": {
@@ -13366,6 +13372,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/yoctocolors": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.1.2.tgz",
+      "integrity": "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/yoctocolors-cjs": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/yoctocolors-cjs/-/yoctocolors-cjs-2.1.3.tgz",
@@ -13386,13 +13404,143 @@
       "dependencies": {
         "@redocly/openapi-core": "^1.30.0",
         "chalk": "^4.1.2",
-        "commander": "^14.0.0"
+        "commander": "^14.0.0",
+        "ora": "^9.4.0"
       },
       "bin": {
         "jentic-api-scorecard": "bin/jentic-api-scorecard.mjs"
       },
       "engines": {
         "node": ">=20.10.0"
+      }
+    },
+    "packages/cli/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "packages/cli/node_modules/cli-spinners": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-3.4.0.tgz",
+      "integrity": "sha512-bXfOC4QcT1tKXGorxL3wbJm6XJPDqEnij2gQ2m7ESQuE+/z9YFIWnl/5RpTiKWbMq3EVKR4fRLJGn6DVfu0mpw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/cli/node_modules/is-interactive": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-2.0.0.tgz",
+      "integrity": "sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/cli/node_modules/is-unicode-supported": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
+      "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/cli/node_modules/log-symbols": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-7.0.1.tgz",
+      "integrity": "sha512-ja1E3yCr9i/0hmBVaM0bfwDjnGy8I/s6PP4DFp+yP+a+mrHO4Rm7DtmnqROTUkHIkqffC84YY7AeqX6oFk0WFg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-unicode-supported": "^2.0.0",
+        "yoctocolors": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/cli/node_modules/ora": {
+      "version": "9.4.0",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-9.4.0.tgz",
+      "integrity": "sha512-84cglkRILFxdtA8hAvLNdMrtBpPNBTrQ9/ulg0FA7xLMnD6mifv+enAIeRmvtv+WgdCE+LPGOfQmtJRrVaIVhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.6.2",
+        "cli-cursor": "^5.0.0",
+        "cli-spinners": "^3.2.0",
+        "is-interactive": "^2.0.0",
+        "is-unicode-supported": "^2.1.0",
+        "log-symbols": "^7.0.1",
+        "stdin-discarder": "^0.3.2",
+        "string-width": "^8.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/cli/node_modules/ora/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "packages/cli/node_modules/string-width": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.1.tgz",
+      "integrity": "sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==",
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.5.0",
+        "strip-ansi": "^7.1.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/cli/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
     "packages/formatter-html": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -54,7 +54,8 @@
   "dependencies": {
     "@redocly/openapi-core": "^1.30.0",
     "chalk": "^4.1.2",
-    "commander": "^14.0.0"
+    "commander": "^14.0.0",
+    "ora": "^9.4.0"
   },
   "engines": {
     "node": ">=20.10.0"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -53,6 +53,7 @@
   },
   "dependencies": {
     "@redocly/openapi-core": "^1.30.0",
+    "chalk": "^4.1.2",
     "commander": "^14.0.0"
   },
   "engines": {

--- a/packages/cli/src/commands/score.ts
+++ b/packages/cli/src/commands/score.ts
@@ -82,6 +82,9 @@ export async function runScore(input: string, options: ScoreOptions): Promise<nu
     parsed = JSON.parse(result.stdout) as ScorecardResult;
   } catch {
     clearSpinner();
+    process.stderr.write(
+      'warning: engine output was not valid JSON; passing through raw output.\n',
+    );
     process.stdout.write(result.stdout);
     return ExitCode.SUCCESS;
   }

--- a/packages/cli/src/commands/score.ts
+++ b/packages/cli/src/commands/score.ts
@@ -37,7 +37,7 @@ export async function runScore(input: string, options: ScoreOptions): Promise<nu
   if (isURL(input)) {
     containerArgs.push('--url', input);
   } else if (isExistingFile(input)) {
-    spin(`⏳ Bundling ${input}…`);
+    spin(`Bundling ${input}…`);
     try {
       stdinPayload = await bundleSpec(input);
     } catch (err) {
@@ -53,7 +53,7 @@ export async function runScore(input: string, options: ScoreOptions): Promise<nu
     return ExitCode.GENERIC_ERROR;
   }
 
-  spin(`⏳ Scoring…`);
+  spin(`Scoring…`);
 
   let result;
   try {
@@ -87,7 +87,7 @@ export async function runScore(input: string, options: ScoreOptions): Promise<nu
   }
 
   const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
-  done(`✓ done in ${elapsed}s`);
+  done(`Done in ${elapsed}s`);
 
   const output = formatPretty(parsed, input);
   process.stdout.write(output);

--- a/packages/cli/src/commands/score.ts
+++ b/packages/cli/src/commands/score.ts
@@ -87,7 +87,7 @@ export async function runScore(input: string, options: ScoreOptions): Promise<nu
   }
 
   const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
-  done(`Done in ${elapsed}s`);
+  done(`Scoring done in ${elapsed}s`);
 
   const output = formatPretty(parsed, input);
   process.stdout.write(output);

--- a/packages/cli/src/commands/score.ts
+++ b/packages/cli/src/commands/score.ts
@@ -3,6 +3,8 @@ import { existsSync, statSync } from 'node:fs';
 import { bundleSpec } from '../bundle.ts';
 import { runDocker } from '../docker.ts';
 import { ExitCode } from '../exit-codes.ts';
+import { formatPretty, ScorecardResult } from '../formatters/pretty.ts';
+import { spin, done, clearSpinner } from '../spinner.ts';
 
 export interface ScoreOptions {
   withLlm?: boolean;
@@ -20,17 +22,6 @@ function isExistingFile(input: string): boolean {
   }
 }
 
-async function execDocker(opts: Parameters<typeof runDocker>[0]): Promise<number> {
-  try {
-    const result = await runDocker(opts);
-    return result.exitCode;
-  } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    process.stderr.write(`error: failed to run docker: ${message}\n`);
-    return ExitCode.GENERIC_ERROR;
-  }
-}
-
 export async function runScore(input: string, options: ScoreOptions): Promise<number> {
   const containerArgs: string[] = ['score'];
   if (options.withLlm) {
@@ -40,26 +31,66 @@ export async function runScore(input: string, options: ScoreOptions): Promise<nu
   const apiKey = process.env['JENTIC_API_KEY'];
   const forwardJenticKey = apiKey !== undefined && apiKey !== '';
 
+  let stdinPayload: string | undefined;
+  const startTime = Date.now();
+
   if (isURL(input)) {
     containerArgs.push('--url', input);
-    return execDocker({ args: containerArgs, forwardJenticKey });
-  }
-
-  if (isExistingFile(input)) {
-    let bundled: string;
+  } else if (isExistingFile(input)) {
+    spin(`⏳ Bundling ${input}…`);
     try {
-      bundled = await bundleSpec(input);
+      stdinPayload = await bundleSpec(input);
     } catch (err) {
+      clearSpinner();
       const message = err instanceof Error ? err.message : String(err);
       process.stderr.write(`error: failed to bundle ${input}: ${message}\n`);
       return ExitCode.SPEC_FAILURE;
     }
-
-    return execDocker({ args: containerArgs, stdinPayload: bundled, forwardJenticKey });
+  } else {
+    process.stderr.write(
+      `error: input '${input}' is neither an https:// URL nor an existing file.\n`,
+    );
+    return ExitCode.GENERIC_ERROR;
   }
 
-  process.stderr.write(
-    `error: input '${input}' is neither an https:// URL nor an existing file.\n`,
-  );
-  return ExitCode.GENERIC_ERROR;
+  spin(`⏳ Scoring…`);
+
+  let result;
+  try {
+    result = await runDocker({
+      args: containerArgs,
+      stdinPayload,
+      forwardJenticKey,
+    });
+  } catch (err) {
+    clearSpinner();
+    const message = err instanceof Error ? err.message : String(err);
+    process.stderr.write(`error: failed to run docker: ${message}\n`);
+    return ExitCode.GENERIC_ERROR;
+  }
+
+  if (result.exitCode !== 0) {
+    clearSpinner();
+    if (result.stdout) {
+      process.stdout.write(result.stdout);
+    }
+    return result.exitCode;
+  }
+
+  let parsed: ScorecardResult;
+  try {
+    parsed = JSON.parse(result.stdout) as ScorecardResult;
+  } catch {
+    clearSpinner();
+    process.stdout.write(result.stdout);
+    return ExitCode.SUCCESS;
+  }
+
+  const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
+  done(`✓ done in ${elapsed}s`);
+
+  const output = formatPretty(parsed, input);
+  process.stdout.write(output);
+
+  return ExitCode.SUCCESS;
 }

--- a/packages/cli/src/docker.ts
+++ b/packages/cli/src/docker.ts
@@ -84,7 +84,7 @@ export function runDocker(opts: DockerRunOptions): Promise<DockerRunResult> {
       settle(() => reject(err));
     });
 
-    child.on('exit', (code, signal) => {
+    child.on('close', (code, signal) => {
       const stdout = Buffer.concat(stdoutChunks).toString('utf8');
       if (signal !== null) {
         const signo = osConstants.signals[signal] ?? 0;

--- a/packages/cli/src/docker.ts
+++ b/packages/cli/src/docker.ts
@@ -18,6 +18,7 @@ export interface DockerRunOptions {
 
 export interface DockerRunResult {
   exitCode: number;
+  stdout: string;
 }
 
 const FORWARDED_SIGNALS: NodeJS.Signals[] = ['SIGINT', 'SIGTERM', 'SIGHUP'];
@@ -38,11 +39,12 @@ export function runDocker(opts: DockerRunOptions): Promise<DockerRunResult> {
 
   return new Promise((resolve, reject) => {
     const child = spawn('docker', dockerArgs, {
-      stdio: [opts.stdinPayload !== undefined ? 'pipe' : 'inherit', 'inherit', 'inherit'],
+      stdio: [opts.stdinPayload !== undefined ? 'pipe' : 'inherit', 'pipe', 'inherit'],
     });
 
     let settled = false;
     const signalHandlers = new Map<NodeJS.Signals, () => void>();
+    const stdoutChunks: Buffer[] = [];
 
     const cleanup = (): void => {
       for (const [sig, handler] of signalHandlers) {
@@ -66,25 +68,30 @@ export function runDocker(opts: DockerRunOptions): Promise<DockerRunResult> {
       process.on(sig, handler);
     }
 
+    child.stdout!.on('data', (chunk: Buffer) => {
+      stdoutChunks.push(chunk);
+    });
+
     child.on('error', (err: NodeJS.ErrnoException) => {
       if (err.code === 'ENOENT') {
         process.stderr.write(
           "error: 'docker' command not found.\n" +
             '  Install Docker: https://docs.docker.com/get-docker/\n',
         );
-        settle(() => resolve({ exitCode: ExitCode.DOCKER_MISSING }));
+        settle(() => resolve({ exitCode: ExitCode.DOCKER_MISSING, stdout: '' }));
         return;
       }
       settle(() => reject(err));
     });
 
     child.on('exit', (code, signal) => {
+      const stdout = Buffer.concat(stdoutChunks).toString('utf8');
       if (signal !== null) {
         const signo = osConstants.signals[signal] ?? 0;
-        settle(() => resolve({ exitCode: 128 + signo }));
+        settle(() => resolve({ exitCode: 128 + signo, stdout }));
         return;
       }
-      settle(() => resolve({ exitCode: code ?? ExitCode.GENERIC_ERROR }));
+      settle(() => resolve({ exitCode: code ?? ExitCode.GENERIC_ERROR, stdout }));
     });
 
     if (opts.stdinPayload !== undefined && child.stdin) {

--- a/packages/cli/src/docker.ts
+++ b/packages/cli/src/docker.ts
@@ -68,9 +68,11 @@ export function runDocker(opts: DockerRunOptions): Promise<DockerRunResult> {
       process.on(sig, handler);
     }
 
-    child.stdout!.on('data', (chunk: Buffer) => {
-      stdoutChunks.push(chunk);
-    });
+    if (child.stdout) {
+      child.stdout.on('data', (chunk: Buffer) => {
+        stdoutChunks.push(chunk);
+      });
+    }
 
     child.on('error', (err: NodeJS.ErrnoException) => {
       if (err.code === 'ENOENT') {

--- a/packages/cli/src/formatters/pretty.ts
+++ b/packages/cli/src/formatters/pretty.ts
@@ -26,6 +26,11 @@ export interface ScorecardSummary {
 export interface ApiMetadata {
   name?: string;
   apiDescriptionVersion?: string;
+  operationCount?: number;
+  schemaCount?: number;
+  tagCount?: number;
+  securitySchemeCount?: number;
+  securitySchemeTypes?: string[];
 }
 
 export interface EngineMetadata {
@@ -47,6 +52,12 @@ function colorGrade(grade: string): string {
   if (grade.startsWith('B')) return chalk.green(grade);
   if (grade.startsWith('C')) return chalk.yellow(grade);
   return chalk.red(grade);
+}
+
+function colorScore(score: number, formatted: string): string {
+  if (score >= 80) return chalk.green(formatted);
+  if (score >= 60) return chalk.yellow(formatted);
+  return chalk.red(formatted);
 }
 
 const BAR_WIDTH = 20;
@@ -90,8 +101,34 @@ export function formatPretty(result: ScorecardResult, source: string): string {
   }
 
   lines.push(`  ${chalk.dim('OpenAPI Document:')} ${source}`);
-  lines.push(`  Final score:      ${summary.score.toFixed(2)} ${chalk.dim('/ 100')}`);
-  lines.push(`  Readiness:        ${chalk.bold(summary.level)}  (${colorGrade(summary.grade)})`);
+  const finalScore = colorScore(summary.score, summary.score.toFixed(2));
+  lines.push(`  Final score:      ${chalk.bold(finalScore)} ${chalk.dim('/ 100')}`);
+  lines.push(
+    `  Readiness:        ${chalk.bold(summary.level.toUpperCase())}  (${colorGrade(summary.grade)})`,
+  );
+
+  if (apiMetadata) {
+    const stats: string[] = [];
+    if (apiMetadata.operationCount !== undefined) {
+      stats.push(`${chalk.bold(apiMetadata.operationCount)} operations`);
+    }
+    if (apiMetadata.schemaCount !== undefined) {
+      stats.push(`${chalk.bold(apiMetadata.schemaCount)} schemas`);
+    }
+    if (apiMetadata.tagCount !== undefined) {
+      stats.push(`${chalk.bold(apiMetadata.tagCount)} tags`);
+    }
+    if (apiMetadata.securitySchemeCount !== undefined) {
+      stats.push(`${chalk.bold(apiMetadata.securitySchemeCount)} security schemes`);
+    }
+    if (apiMetadata.securitySchemeTypes && apiMetadata.securitySchemeTypes.length > 0) {
+      stats.push(`${chalk.bold(apiMetadata.securitySchemeTypes.length)} security types`);
+    }
+    if (stats.length > 0) {
+      lines.push('');
+      lines.push(chalk.dim(`  ${stats.join('  ·  ')}`));
+    }
+  }
 
   if (summary.dimensions && summary.dimensions.length > 0) {
     lines.push('');

--- a/packages/cli/src/formatters/pretty.ts
+++ b/packages/cli/src/formatters/pretty.ts
@@ -1,3 +1,5 @@
+import chalk from 'chalk';
+
 export interface Dimension {
   kind: string;
   name: string;
@@ -16,33 +18,48 @@ export interface ScorecardResult {
   summary: ScorecardSummary;
 }
 
+function colorGrade(grade: string): string {
+  if (grade.startsWith('A')) return chalk.green(grade);
+  if (grade.startsWith('B')) return chalk.green(grade);
+  if (grade.startsWith('C')) return chalk.yellow(grade);
+  return chalk.red(grade);
+}
+
+function colorScore(score: number, formatted: string): string {
+  if (score >= 80) return chalk.green(formatted);
+  if (score >= 60) return chalk.yellow(formatted);
+  return chalk.red(formatted);
+}
+
 export function formatPretty(result: ScorecardResult, source: string): string {
   const { summary } = result;
   const lines: string[] = [];
 
-  lines.push('Jentic API Readiness Scorecard');
-  lines.push(`Source: ${source}`);
+  lines.push(chalk.bold('Jentic API Readiness Scorecard'));
+  lines.push(`${chalk.dim('Source:')} ${source}`);
   lines.push('');
-  lines.push(`  Final score:    ${summary.score.toFixed(2)} / 100`);
-  lines.push(`  Readiness:      ${summary.level}  (${summary.grade})`);
+  const scoreStr = colorScore(summary.score, summary.score.toFixed(2));
+  lines.push(`  Final score:    ${scoreStr} ${chalk.dim('/ 100')}`);
+  lines.push(`  Readiness:      ${chalk.bold(summary.level)}  (${colorGrade(summary.grade)})`);
 
   if (summary.dimensions && summary.dimensions.length > 0) {
     lines.push('');
-    lines.push('  Dimensions');
+    lines.push(chalk.bold('  Dimensions'));
 
     const kindWidth = Math.max(...summary.dimensions.map((d) => d.kind.length));
     const nameWidth = Math.max(...summary.dimensions.map((d) => d.name.length));
 
     for (const dim of summary.dimensions) {
-      const kind = dim.kind.padEnd(kindWidth);
+      const kind = chalk.cyan(dim.kind.padEnd(kindWidth));
       const name = dim.name.padEnd(nameWidth);
-      const score = dim.score.toFixed(2).padStart(6);
-      lines.push(`    ${kind}  ${name}  ${score}  ${dim.grade}`);
+      const score = colorScore(dim.score, dim.score.toFixed(2).padStart(6));
+      const grade = colorGrade(dim.grade);
+      lines.push(`    ${kind}  ${name}  ${score}  ${grade}`);
     }
 
     lines.push('');
-    lines.push('  Run with --detail signals for signal breakdown.');
-    lines.push('  Full report: --format json --detail diagnostics');
+    lines.push(chalk.dim('  Run with --detail signals for signal breakdown.'));
+    lines.push(chalk.dim('  Full report: --format json --detail diagnostics'));
   }
 
   lines.push('');

--- a/packages/cli/src/formatters/pretty.ts
+++ b/packages/cli/src/formatters/pretty.ts
@@ -107,29 +107,6 @@ export function formatPretty(result: ScorecardResult, source: string): string {
     `  Readiness:        ${chalk.bold(summary.level.toUpperCase())}  (${colorGrade(summary.grade)})`,
   );
 
-  if (apiMetadata) {
-    const stats: string[] = [];
-    if (apiMetadata.operationCount !== undefined) {
-      stats.push(`${chalk.bold(apiMetadata.operationCount)} operations`);
-    }
-    if (apiMetadata.schemaCount !== undefined) {
-      stats.push(`${chalk.bold(apiMetadata.schemaCount)} schemas`);
-    }
-    if (apiMetadata.tagCount !== undefined) {
-      stats.push(`${chalk.bold(apiMetadata.tagCount)} tags`);
-    }
-    if (apiMetadata.securitySchemeCount !== undefined) {
-      stats.push(`${chalk.bold(apiMetadata.securitySchemeCount)} security schemes`);
-    }
-    if (apiMetadata.securitySchemeTypes && apiMetadata.securitySchemeTypes.length > 0) {
-      stats.push(`${chalk.bold(apiMetadata.securitySchemeTypes.length)} security types`);
-    }
-    if (stats.length > 0) {
-      lines.push('');
-      lines.push(chalk.dim(`  ${stats.join('  ·  ')}`));
-    }
-  }
-
   if (summary.dimensions && summary.dimensions.length > 0) {
     lines.push('');
     lines.push(chalk.bold('  Dimensions'));
@@ -146,7 +123,33 @@ export function formatPretty(result: ScorecardResult, source: string): string {
       const grade = colorGrade(dim.grade.padEnd(2));
       lines.push(`    ${kind}  ${name}  ${bar}  ${score}  ${grade}`);
     }
+  }
 
+  if (apiMetadata) {
+    const stat = (n: number, label: string): string => `${chalk.bold(n)} ${chalk.dim(label)}`;
+    const stats: string[] = [];
+    if (apiMetadata.operationCount !== undefined) {
+      stats.push(stat(apiMetadata.operationCount, 'operations'));
+    }
+    if (apiMetadata.schemaCount !== undefined) {
+      stats.push(stat(apiMetadata.schemaCount, 'schemas'));
+    }
+    if (apiMetadata.tagCount !== undefined) {
+      stats.push(stat(apiMetadata.tagCount, 'tags'));
+    }
+    if (apiMetadata.securitySchemeCount !== undefined) {
+      stats.push(stat(apiMetadata.securitySchemeCount, 'security schemes'));
+    }
+    if (apiMetadata.securitySchemeTypes && apiMetadata.securitySchemeTypes.length > 0) {
+      stats.push(stat(apiMetadata.securitySchemeTypes.length, 'security types'));
+    }
+    if (stats.length > 0) {
+      lines.push('');
+      lines.push(`  ${stats.join(chalk.dim('  ·  '))}`);
+    }
+  }
+
+  if (summary.dimensions && summary.dimensions.length > 0) {
     lines.push('');
     lines.push(chalk.dim('  Run with --detail signals for signal breakdown.'));
     lines.push(chalk.dim('  Full report: --format json --detail diagnostics'));

--- a/packages/cli/src/formatters/pretty.ts
+++ b/packages/cli/src/formatters/pretty.ts
@@ -1,5 +1,14 @@
 import chalk from 'chalk';
 
+import { cliVersion } from '../version.ts';
+
+const BANNER = `     ██╗███████╗███╗   ██╗████████╗██╗ ██████╗
+     ██║██╔════╝████╗  ██║╚══██╔══╝██║██╔════╝
+     ██║█████╗  ██╔██╗ ██║   ██║   ██║██║
+██   ██║██╔══╝  ██║╚██╗██║   ██║   ██║██║
+╚█████╔╝███████╗██║ ╚████║   ██║   ██║╚██████╗
+ ╚════╝ ╚══════╝╚═╝  ╚═══╝   ╚═╝   ╚═╝ ╚═════╝`;
+
 export interface Dimension {
   kind: string;
   name: string;
@@ -14,8 +23,23 @@ export interface ScorecardSummary {
   dimensions?: Dimension[];
 }
 
+export interface ApiMetadata {
+  name?: string;
+  apiDescriptionVersion?: string;
+}
+
+export interface EngineMetadata {
+  version?: string;
+}
+
+export interface Metadata {
+  engine?: EngineMetadata;
+}
+
 export interface ScorecardResult {
   summary: ScorecardSummary;
+  apiMetadata?: ApiMetadata;
+  metadata?: Metadata;
 }
 
 function colorGrade(grade: string): string {
@@ -25,26 +49,54 @@ function colorGrade(grade: string): string {
   return chalk.red(grade);
 }
 
-function colorScore(score: number, formatted: string): string {
-  if (score >= 80) return chalk.green(formatted);
-  if (score >= 60) return chalk.yellow(formatted);
-  return chalk.red(formatted);
+const BAR_WIDTH = 20;
+
+function scoreBar(score: number): string {
+  const filled = Math.round((score / 100) * BAR_WIDTH);
+  const empty = BAR_WIDTH - filled;
+  return chalk.white('▄'.repeat(filled)) + chalk.blackBright('▄'.repeat(empty));
 }
 
 export function formatPretty(result: ScorecardResult, source: string): string {
-  const { summary } = result;
+  const { summary, apiMetadata, metadata } = result;
   const lines: string[] = [];
 
-  lines.push(chalk.bold('Jentic API Readiness Scorecard'));
-  lines.push(`${chalk.dim('Source:')} ${source}`);
   lines.push('');
-  const scoreStr = colorScore(summary.score, summary.score.toFixed(2));
-  lines.push(`  Final score:    ${scoreStr} ${chalk.dim('/ 100')}`);
-  lines.push(`  Readiness:      ${chalk.bold(summary.level)}  (${colorGrade(summary.grade)})`);
+  lines.push(chalk.cyan(BANNER));
+  lines.push(`${chalk.bold('  API Readiness Scorecard')} ${chalk.dim(`v${cliVersion}`)}`);
+
+  const engineRaw = metadata?.engine?.version;
+  if (engineRaw) {
+    const match = /^([^+]+)(?:\+jairf\.(.+))?$/.exec(engineRaw);
+    const engineVer = match?.[1] ?? engineRaw;
+    const frameworkVer = match?.[2];
+    const parts: string[] = [];
+    if (frameworkVer) parts.push(`Scoring Framework ${frameworkVer}`);
+    parts.push(`Scoring Engine ${engineVer}`);
+    lines.push(chalk.dim(`  ${parts.join('  |  ')}`));
+  }
+  lines.push('');
+
+  if (apiMetadata?.name) {
+    const version = apiMetadata.apiDescriptionVersion
+      ? chalk.dim(` v${apiMetadata.apiDescriptionVersion}`)
+      : '';
+    const heading = `${apiMetadata.name}${apiMetadata.apiDescriptionVersion ? ` v${apiMetadata.apiDescriptionVersion}` : ''}`;
+    const divider = chalk.dim('─'.repeat(heading.length));
+    lines.push(`  ${divider}`);
+    lines.push(`  ${chalk.bold(apiMetadata.name)}${version}`);
+    lines.push(`  ${divider}`);
+    lines.push('');
+  }
+
+  lines.push(`  ${chalk.dim('OpenAPI Document:')} ${source}`);
+  lines.push(`  Final score:      ${summary.score.toFixed(2)} ${chalk.dim('/ 100')}`);
+  lines.push(`  Readiness:        ${chalk.bold(summary.level)}  (${colorGrade(summary.grade)})`);
 
   if (summary.dimensions && summary.dimensions.length > 0) {
     lines.push('');
     lines.push(chalk.bold('  Dimensions'));
+    lines.push('');
 
     const kindWidth = Math.max(...summary.dimensions.map((d) => d.kind.length));
     const nameWidth = Math.max(...summary.dimensions.map((d) => d.name.length));
@@ -52,9 +104,10 @@ export function formatPretty(result: ScorecardResult, source: string): string {
     for (const dim of summary.dimensions) {
       const kind = chalk.cyan(dim.kind.padEnd(kindWidth));
       const name = dim.name.padEnd(nameWidth);
-      const score = colorScore(dim.score, dim.score.toFixed(2).padStart(6));
-      const grade = colorGrade(dim.grade);
-      lines.push(`    ${kind}  ${name}  ${score}  ${grade}`);
+      const bar = scoreBar(dim.score);
+      const score = dim.score.toFixed(2).padStart(6);
+      const grade = colorGrade(dim.grade.padEnd(2));
+      lines.push(`    ${kind}  ${name}  ${bar}  ${score}  ${grade}`);
     }
 
     lines.push('');

--- a/packages/cli/src/formatters/pretty.ts
+++ b/packages/cli/src/formatters/pretty.ts
@@ -1,0 +1,50 @@
+export interface Dimension {
+  kind: string;
+  name: string;
+  score: number;
+  grade: string;
+}
+
+export interface ScorecardSummary {
+  score: number;
+  level: string;
+  grade: string;
+  dimensions?: Dimension[];
+}
+
+export interface ScorecardResult {
+  summary: ScorecardSummary;
+}
+
+export function formatPretty(result: ScorecardResult, source: string): string {
+  const { summary } = result;
+  const lines: string[] = [];
+
+  lines.push('Jentic API Readiness Scorecard');
+  lines.push(`Source: ${source}`);
+  lines.push('');
+  lines.push(`  Final score:    ${summary.score.toFixed(2)} / 100`);
+  lines.push(`  Readiness:      ${summary.level}  (${summary.grade})`);
+
+  if (summary.dimensions && summary.dimensions.length > 0) {
+    lines.push('');
+    lines.push('  Dimensions');
+
+    const kindWidth = Math.max(...summary.dimensions.map((d) => d.kind.length));
+    const nameWidth = Math.max(...summary.dimensions.map((d) => d.name.length));
+
+    for (const dim of summary.dimensions) {
+      const kind = dim.kind.padEnd(kindWidth);
+      const name = dim.name.padEnd(nameWidth);
+      const score = dim.score.toFixed(2).padStart(6);
+      lines.push(`    ${kind}  ${name}  ${score}  ${dim.grade}`);
+    }
+
+    lines.push('');
+    lines.push('  Run with --detail signals for signal breakdown.');
+    lines.push('  Full report: --format json --detail diagnostics');
+  }
+
+  lines.push('');
+  return lines.join('\n');
+}

--- a/packages/cli/src/formatters/pretty.ts
+++ b/packages/cli/src/formatters/pretty.ts
@@ -149,12 +149,6 @@ export function formatPretty(result: ScorecardResult, source: string): string {
     }
   }
 
-  if (summary.dimensions && summary.dimensions.length > 0) {
-    lines.push('');
-    lines.push(chalk.dim('  Run with --detail signals for signal breakdown.'));
-    lines.push(chalk.dim('  Full report: --format json --detail diagnostics'));
-  }
-
   lines.push('');
   return lines.join('\n');
 }

--- a/packages/cli/src/formatters/pretty.ts
+++ b/packages/cli/src/formatters/pretty.ts
@@ -47,17 +47,18 @@ export interface ScorecardResult {
   metadata?: Metadata;
 }
 
-function colorGrade(grade: string): string {
-  if (grade.startsWith('A')) return chalk.green(grade);
-  if (grade.startsWith('B')) return chalk.green(grade);
-  if (grade.startsWith('C')) return chalk.yellow(grade);
-  return chalk.red(grade);
+function gradeColor(grade: string): (s: string) => string {
+  if (grade.startsWith('A') || grade.startsWith('B')) return chalk.green;
+  if (grade.startsWith('C')) return chalk.yellow;
+  return chalk.red;
 }
 
-function colorScore(score: number, formatted: string): string {
-  if (score >= 80) return chalk.green(formatted);
-  if (score >= 60) return chalk.yellow(formatted);
-  return chalk.red(formatted);
+function colorGrade(grade: string): string {
+  return gradeColor(grade)(grade);
+}
+
+function colorScore(grade: string, formatted: string): string {
+  return gradeColor(grade)(formatted);
 }
 
 const BAR_WIDTH = 20;
@@ -101,7 +102,7 @@ export function formatPretty(result: ScorecardResult, source: string): string {
   }
 
   lines.push(`  ${chalk.dim('OpenAPI Document:')} ${source}`);
-  const finalScore = colorScore(summary.score, summary.score.toFixed(2));
+  const finalScore = colorScore(summary.grade, summary.score.toFixed(2));
   lines.push(`  Final score:      ${chalk.bold(finalScore)} ${chalk.dim('/ 100')}`);
   lines.push(
     `  Readiness:        ${chalk.bold(summary.level.toUpperCase())}  (${colorGrade(summary.grade)})`,
@@ -147,6 +148,12 @@ export function formatPretty(result: ScorecardResult, source: string): string {
       lines.push('');
       lines.push(`  ${stats.join(chalk.dim('  ·  '))}`);
     }
+  }
+
+  if (summary.dimensions && summary.dimensions.length > 0) {
+    lines.push('');
+    lines.push(chalk.dim('  Run with --detail signals for signal breakdown.'));
+    lines.push(chalk.dim('  Full report: --format json --detail diagnostics'));
   }
 
   lines.push('');

--- a/packages/cli/src/spinner.ts
+++ b/packages/cli/src/spinner.ts
@@ -1,5 +1,6 @@
 import ora, { type Ora } from 'ora';
 
+// Single process-wide spinner — concurrent score invocations would interleave.
 let spinner: Ora | null = null;
 
 export function spin(message: string): void {

--- a/packages/cli/src/spinner.ts
+++ b/packages/cli/src/spinner.ts
@@ -1,0 +1,36 @@
+import { WriteStream } from 'node:tty';
+
+const isTTY = process.stderr instanceof WriteStream && process.stderr.isTTY;
+
+let currentLine = '';
+
+function clearLine(): void {
+  if (isTTY) {
+    process.stderr.write('\r\x1b[K');
+  }
+}
+
+export function spin(message: string): void {
+  if (!isTTY) return;
+  clearLine();
+  currentLine = message;
+  process.stderr.write(currentLine);
+}
+
+export function done(message: string): void {
+  if (!isTTY) return;
+  clearLine();
+  currentLine = '';
+  process.stderr.write(`${message}\n`);
+}
+
+export function hasSpinner(): boolean {
+  return isTTY;
+}
+
+export function clearSpinner(): void {
+  if (currentLine) {
+    clearLine();
+    currentLine = '';
+  }
+}

--- a/packages/cli/src/spinner.ts
+++ b/packages/cli/src/spinner.ts
@@ -1,36 +1,27 @@
-import { WriteStream } from 'node:tty';
+import ora, { type Ora } from 'ora';
 
-const isTTY = process.stderr instanceof WriteStream && process.stderr.isTTY;
-
-let currentLine = '';
-
-function clearLine(): void {
-  if (isTTY) {
-    process.stderr.write('\r\x1b[K');
-  }
-}
+let spinner: Ora | null = null;
 
 export function spin(message: string): void {
-  if (!isTTY) return;
-  clearLine();
-  currentLine = message;
-  process.stderr.write(currentLine);
+  if (spinner) {
+    spinner.text = message;
+    return;
+  }
+  spinner = ora({ text: message, stream: process.stderr }).start();
 }
 
 export function done(message: string): void {
-  if (!isTTY) return;
-  clearLine();
-  currentLine = '';
+  if (spinner) {
+    spinner.succeed(message);
+    spinner = null;
+    return;
+  }
   process.stderr.write(`${message}\n`);
 }
 
-export function hasSpinner(): boolean {
-  return isTTY;
-}
-
 export function clearSpinner(): void {
-  if (currentLine) {
-    clearLine();
-    currentLine = '';
+  if (spinner) {
+    spinner.stop();
+    spinner = null;
   }
 }

--- a/specs/roadmap.md
+++ b/specs/roadmap.md
@@ -67,7 +67,7 @@ Today only the Claude PreToolUse hook checks `git commit` payloads. Direct `git 
 - Add `.husky/pre-commit` running `lint-staged` (ruff for Python files in `docker/`; eslint for TS files in `packages/`).
 - The Claude PreToolUse hook continues to soft-no-op until `node_modules/.bin/commitlint` exists; once Phase 3 ships, the hook activates.
 
-## Phase 4 — Pretty formatter (default human-readable output)
+## Phase 4 — Pretty formatter (default human-readable output) ✅
 
 **Goal:** ship the human-readable scorecard so the default `npx … score` shows the headline + dimension table that matches the sample output in `docs/architecture.md` §1, replacing today's engine-verbatim JSON default.
 **Depends on:** Phase 2


### PR DESCRIPTION
## Summary

- Implements Phase 4 of the roadmap: pretty-formatted scorecard as the default CLI output
- Adds `packages/cli/src/formatters/pretty.ts` — renders headline + dimension table matching `docs/architecture.md` §5 sample output
- Adds `packages/cli/src/spinner.ts` — stderr phase spinner (bundling/scoring/done with timing), auto-suppresses when stderr is not a TTY
- Modifies `docker.ts` to capture container stdout (instead of inheriting) so the CLI can parse and format it
- Rewires `score.ts` to parse engine JSON and pipe through the pretty formatter; falls back to raw output if JSON parsing fails

**JSON access is temporarily regressed** per the roadmap: there is no `--format` flag yet (added in Phase 6). Users who need raw JSON in the meantime can still `docker run` the image directly.

## Test plan

- [x] `JENTIC_API_KEY=mvp-preview node packages/cli/bin/jentic-api-scorecard.mjs score docker/.build/sample.yaml` → pretty scorecard on stdout
- [x] Error paths (no key, bad input) still surface container stderr messages correctly
- [x] Spinner auto-suppresses when stderr is not a TTY (piped through `2>/dev/null`)
- [x] stdout is clean for piping (`| head` works without spinner noise)
- [x] `tsc --noEmit` and `eslint` pass

Refs Phase 4 in `specs/roadmap.md`.