### PR TITLE
docs(roadmap): retarget Phase 12 to alpha release channel

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -44,6 +44,7 @@ Source: https://petstore3.swagger.io/api/v3/openapi.json
 | Lerna versioning | Fixed/locked: every package shares one version |
 | Version coupling | CLI npm version = image tag. Engine (`jentic-apitools-cli`) versions independently and is pinned exactly inside each image. Pinning one CLI version reproduces the full stack. |
 | Image flow | CLI fully abstracts image management. It pulls `ghcr.io/jentic/jentic-api-scorecard:<cli-version>` automatically. No user-facing image flags. |
+| Tagging | Exact-version GHCR tags only (e.g. `:1.0.0-alpha.3`). The CLI consumes only exact tags, so no floating `:alpha` / `:latest` is published. The one floating tag is `:unstable`, which rolls on every green `main` for direct `docker run` users. |
 | Docker mode | Shell out to `docker` CLI via `child_process.spawn`. No `dockerode`. |
 | Input dispatch | Local path → CLI bundles via Redocly → pipes to container stdin. URL → CLI passes `--url` to container, engine fetches directly. URL + `--bundle` → CLI fetches and bundles host-side, pipes via stdin (escape hatch for internal/auth-gated URLs). |
 | Anonymous gate | URL must match `^https://raw\.githubusercontent\.com/jentic/jentic-public-apis/refs/heads/main/apis/openapi/`. Enforced container-side. Local files require a key. |
@@ -139,7 +140,7 @@ jentic-api-scorecard/
 └── .github/workflows/
     ├── ci.yml                                (lint + test on PRs; also callable via workflow_call)
     ├── docker-publish.yml                    (build + push :unstable to GHCR on main; gated on ci.yml)
-    └── release.yml                           (versioned image + npm publish on tag — future)
+    └── alpha-publish.yml                     (alpha-tagged image + npm publish on v*-alpha.* tag — future)
 ```
 
 A few layout notes worth calling out:
@@ -595,21 +596,23 @@ The shape below was captured by running `jentic-apitools score https://petstore3
 
 **Coupling**: CLI npm version = GHCR image tag. The Python engine package (`jentic-apitools-cli`) versions independently upstream; each image build pins one specific engine version.
 
-`v1.0.0` (the first stable release):
-- npm `@jentic/api-scorecard-cli@1.0.0` and `@jentic/api-scorecard-formatter-html@1.0.0` (Lerna fixed-version, both publish together).
-- `ghcr.io/jentic/jentic-api-scorecard:1.0.0`.
+**Channels**: today the project ships only an **alpha channel**. The first stable release (`@latest` npm dist-tag) is deferred until the flag surface settles and real auth replaces `mvp-preview` (§9). Until then, `@jentic/api-scorecard-cli@alpha` is the discovery entry point:
+
+- The first cut is `1.0.0-alpha.0`; subsequent cuts increment the prerelease counter (`1.0.0-alpha.1`, `1.0.0-alpha.2`, …).
+- npm `@jentic/api-scorecard-cli@1.0.0-alpha.<N>` publishes under the `alpha` dist-tag. `@jentic/api-scorecard-formatter-html` is `"private": true` and does not publish on alpha cuts; it joins the channel once its real implementation ships.
+- `ghcr.io/jentic/jentic-api-scorecard:1.0.0-alpha.<N>` — the exact alpha tag the CLI of that version consumes. No floating `:alpha` is published; the CLI never asks for one.
 - `docker/pyproject.toml` (used at image build time) pins `jentic-apitools-cli==<exact-version>` (e.g. `1.0.0a16`).
 
-The CLI hard-codes the image tag matching its own npm version. Users who want to reproduce yesterday's score install yesterday's CLI version (`npx @jentic/api-scorecard-cli@1.0.0`) — that pulls `:1.0.0`, which has the engine version pinned exactly. **Reproducibility = pin one CLI version**; the engine version it transitively carries is recorded in `metadata.engine.version` of the result JSON (the engine emits this directly).
+The CLI hard-codes the image tag matching its own npm version. Users who want to reproduce yesterday's score install yesterday's CLI version (`npx @jentic/api-scorecard-cli@1.0.0-alpha.3`) — that pulls `:1.0.0-alpha.3`, which has the engine version pinned exactly. **Reproducibility = pin one CLI version**; the engine version it transitively carries is recorded in `metadata.engine.version` of the result JSON (the engine emits this directly).
 
 When the engine releases an update we want to ship, we:
 1. Bump `jentic-apitools-cli` in `docker/pyproject.toml`.
-2. Cut a new CLI version (e.g. `1.0.1`).
-3. CI builds and pushes `ghcr.io/jentic/jentic-api-scorecard:1.0.1` containing the new engine, and publishes `@jentic/api-scorecard-cli@1.0.1`.
+2. Cut a new CLI version (e.g. `1.0.0-alpha.<N+1>`).
+3. CI builds and pushes `ghcr.io/jentic/jentic-api-scorecard:1.0.0-alpha.<N+1>` containing the new engine, and publishes `@jentic/api-scorecard-cli@1.0.0-alpha.<N+1>` under the `alpha` dist-tag.
 
-**Continuous delivery** (CI): every push to `main` triggers `docker-publish.yml`, which gates on `ci.yml` (lint + test) and then builds and pushes `ghcr.io/jentic/jentic-api-scorecard:unstable` (multi-arch: linux/amd64 + linux/arm64).
+**Continuous delivery** (CI): every push to `main` triggers `docker-publish.yml`, which gates on `ci.yml` (lint + test) and then builds and pushes `ghcr.io/jentic/jentic-api-scorecard:unstable` (multi-arch: linux/amd64 + linux/arm64). Merging to `main` does **not** publish a CLI version or an alpha tag — it makes the change available to the next alpha cut.
 
-**Release pipeline** (CI, future): pushing a git tag `v<version>` will trigger a Docker image build + push to GHCR with `:<version>` and `:latest`, and npm publish for both packages.
+**Release pipeline** (CI): pushing a git tag `v1.0.0-alpha.<N>` triggers an image build + push to GHCR with the exact `:1.0.0-alpha.<N>` tag (no floating `:alpha`/`:latest`) and an `npm publish --tag alpha --provenance` for `packages/cli`. `packages/formatter-html` is skipped automatically while it remains `"private": true`. The stable pipeline (`@latest` dist-tag, `:latest` not used) lands when the project cuts its first stable release.
 
 **Breaking changes**: the CLI does not introduce its own schema version. The result JSON is the engine's verbatim output, and the engine versions its scorecard format independently via `metadata.version` (e.g. `"1.0.27"`). Consumers tracking schema changes should key off `metadata.version` from the engine, not anything CLI-introduced. If we need to break the result shape on our side (we shouldn't — see §7), we'd announce it via the CLI's release notes, not via an envelope key we don't actually emit.
 

--- a/packages/formatter-html/package.json
+++ b/packages/formatter-html/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@jentic/api-scorecard-formatter-html",
   "version": "1.0.0",
+  "private": true,
   "description": "HTML formatter for Jentic API Scorecard results (stub).",
   "keywords": [
     "openapi",

--- a/specs/roadmap.md
+++ b/specs/roadmap.md
@@ -166,18 +166,25 @@ Architecture.md §5 describes `--with-llm` precisely. The container already acce
 - For local paths, `--bundle` is a no-op (bundling is always how local files are handled).
 - Update the input-dispatch table in the CLI's help output to match `docs/architecture.md` §5.
 
-## Phase 12 — npm publish CI on tag (both packages)
+## Phase 12 — Alpha channel publish CI
 
-**Goal:** automate npm publishing so cutting a git tag also publishes `@jentic/api-scorecard-cli` and `@jentic/api-scorecard-formatter-html` (Lerna fixed-version means both ship together).
+**Goal:** an explicit release process cuts alpha versions on demand — `npx @jentic/api-scorecard-cli@alpha score …` pulls the latest cut, which runs the matching `ghcr.io/jentic/jentic-api-scorecard:<version>` image. Each cut bundles whichever phases have merged since the last one. Only `@jentic/api-scorecard-cli` publishes in alpha; `@jentic/api-scorecard-formatter-html` stays `"private": true` until Phase 14 ships its real implementation.
 **Depends on:** Phase 4
 **Priority:** High
 
-The CLI version = image tag invariant requires that the same git tag triggers both publishes. Manual npm publish is brittle and easy to mis-version.
+The roadmap is structured so each phase is independently shippable; an alpha channel makes shipped phases reach users without waiting for a stable cut. Stable release (`@latest` npm dist-tag, real-auth onboarding) is deferred until the flag surface settles and Phase 13's real-auth cutover lands — alpha is the only published channel until then, and the README says so.
 
-- Add `.github/workflows/npm-publish.yml` triggered on tag refs `v*`.
-- Run `npm publish` for `packages/cli` and `packages/formatter-html` with provenance enabled (`--provenance`).
-- Smoke-test post-publish: `npx @jentic/api-scorecard-cli@<version> score --help` succeeds; the version string reported by `--version` matches the tag.
-- Document the release ritual: branch → tag → both workflows fire → image and packages land together.
+Releases are **explicit, not automatic**. Merging to `main` does not publish — it makes the change available to the next alpha cut. The first cut is `1.0.0-alpha.0`; subsequent cuts increment the prerelease counter (`1.0.0-alpha.1`, `1.0.0-alpha.2`, …). The release ritual: bump version on a release branch, tag (`v1.0.0-alpha.<N>`), let CI publish. This keeps the project in control of when an alpha goes out and what's in it; intermediate-merge users can still test against the `:unstable` image from Phase 1.
+
+The CLI version = image tag invariant (`docs/architecture.md` §2) holds in alpha exactly as in stable: each cut publishes the npm prerelease version and builds the matching docker image at that same exact tag. Because the CLI only ever consumes exact-version tags, there is no floating `:alpha` or `:latest` on the docker side — the floating-tag audience is direct `docker run` users, who are already served by Phase 1's `:unstable` rolling-main tag. The npm `@alpha` dist-tag is the public discovery entry point so users don't have to track current alpha version numbers.
+
+- Add `.github/workflows/alpha-publish.yml` triggered on tag refs matching `v*-alpha.*`. Gate on `.github/workflows/ci.yml` via `workflow_call` (`needs: ci`).
+- Both packages stay at the same prerelease version via Lerna fixed-version (so the version bump on tag covers both); the tag carries the version.
+- Build and push `ghcr.io/jentic/jentic-api-scorecard:<version>` (the exact alpha version, no floating tag).
+- Run `npm publish --tag alpha --provenance` for `packages/cli`. `packages/formatter-html` is `"private": true` and skipped automatically by `npm publish`; it begins publishing once Phase 14 lifts the flag.
+- Smoke-test post-publish: `npx @jentic/api-scorecard-cli@alpha score --help` succeeds; the version reported by `--version` matches the published version; `docker run --rm ghcr.io/jentic/jentic-api-scorecard:<version> score --help` succeeds.
+- Document the alpha release ritual: release branch → version bump → tag (`v1.0.0-alpha.<N>`) → workflow fires → image and packages land together.
+- Update `docs/architecture.md` §2 to document the alpha channel and the no-floating-docker-tag invariant. README adds the alpha disclaimer that flag surface is in flux until stable (`--format`, `--quiet`, `--verbose` arrive across Phases 6–9).
 
 ## Phase 13 — Real auth: replace `mvp-preview` with an HTTP validator
 
@@ -205,6 +212,7 @@ The HTML formatter is scaffolded in `packages/formatter-html/` after Phase 2 but
 - React (or Preact via `preact/compat` if bundle size becomes uncomfortable) is acceptable here because the toolchain is fully encapsulated in this package — the CLI imports the built `format(result): string` and pays no JSX/bundler weight. This is the load-bearing reason this formatter is a separate package while `pretty` / `json` / `markdown` live inside `packages/cli/src/formatters/`.
 - Render headline, dimensions, optional per-signal breakdown when the input includes signals, optional diagnostics block when present. Use virtualized rendering (e.g. `react-window`) for long lists so `--detail diagnostics` outputs at the high end (10K+ rows, ~100MB HTML) don't freeze the browser.
 - Add a CLI flag `--format html` to `packages/cli/`. Behavior when `-o` is not set: error if stdout is a TTY (refuse to dump HTML into the terminal); stream to stdout if stdout is a pipe (so `score … --format html > scorecard.html` works).
+- Lift `"private": true` from `packages/formatter-html/package.json` so the package starts publishing on the same alpha cuts as the CLI.
 - Snapshot-test the formatter against a representative result JSON.
 
 ## Later Phases (Not Yet Planned)


### PR DESCRIPTION
## Summary

- **Phase 12 retargets to an alpha channel.** Explicit tag-triggered cuts on `v*-alpha.*` (not every-merge), `1.0.0-alpha.0` baseline, `@alpha` npm dist-tag. Stable release (`@latest`) is deferred until the flag surface settles and Phase 13 ships real auth.
- **Exact-version GHCR tags only.** No floating `:alpha`/`:latest` is published — the CLI consumes only exact tags, so a floating tag has no consumer. `:unstable` from Phase 1 keeps rolling on every green `main` for direct `docker run` users.
- **`@jentic/api-scorecard-formatter-html` marked `"private": true`** so alpha cuts publish only the CLI. Phase 14 lifts the flag when its real implementation ships.
- **`docs/architecture.md` §2/§4/§8 updated in lockstep** so the canonical doc matches the roadmap (per CLAUDE.md: the architecture doc is canonical, not aspirational).

## Test plan

- [ ] Roadmap Phase 12 reads as a coherent alpha-publish phase (explicit release ritual, exact-version tags, formatter-html skip noted).
- [ ] Phase 14 carries the bullet to lift `"private": true` from formatter-html.
- [ ] `architecture.md` §8 describes the alpha channel; §2 table has the new "Tagging" row; §4 tree references `alpha-publish.yml`.
- [ ] `packages/formatter-html/package.json` has `"private": true` immediately after `version`.
- [ ] No code paths changed; no tests required.