### PR TITLE
ci(release): align latest dist-tag after publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,6 +56,8 @@ jobs:
       - name: Extract released version
         id: version
         run: echo "value=$(node -p 'require("./lerna.json").version')" >> "$GITHUB_OUTPUT"
+      - name: Align latest dist-tag
+        run: npm dist-tag add @jentic/api-scorecard-cli@$(node -p 'require("./lerna.json").version') latest
 
   publish-docker:
     needs: [release]


### PR DESCRIPTION
## Summary

- Add a step to the release workflow that moves the `latest` dist-tag to the newly published version after `lerna publish`
- npm mandates a `latest` dist-tag, but the workflow only publishes with `--dist-tag alpha`, leaving `latest` stuck on the first ever publish (`1.0.0-alpha.0`)
- This caused `npx @jentic/api-scorecard-cli` (without `@alpha`) to pull a stale version with no matching Docker image

## Test plan

- [x] Merge and trigger the release workflow; verify `npm dist-tag ls @jentic/api-scorecard-cli` shows `latest` pointing at the new version