### PR TITLE
fix(release): pack and attest before lerna publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,14 +52,14 @@ jobs:
           gh release edit "v${VERSION}" --prerelease=false --latest
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Publish monorepo npm packages
-        run: npx lerna publish from-package --no-private --yes --dist-tag alpha
       - name: Extract released version
         id: version
         run: echo "value=$(node -p 'require("./lerna.json").version')" >> "$GITHUB_OUTPUT"
-      # `npm pack` is deterministic, so the local tarball is byte-identical
-      # (and SHA-256-identical) to the one lerna just pushed to the registry.
-      # We pack again only to get the bytes on disk for `actions/attest@v4`.
+      # Pack BEFORE `lerna publish` so the bytes we attest are the bytes
+      # lerna will publish: both calls invoke `npm-packlist` against the
+      # same source tree with normalized mtimes, so the tarballs are
+      # byte-identical (matching SHA-256). Packing AFTER publish picks up
+      # state lerna leaves behind on disk and produces a different digest.
       - name: Pack CLI tarball locally
         run: |
           mkdir -p ./artifacts
@@ -78,6 +78,8 @@ jobs:
         with:
           subject-path: ./artifacts/jentic-api-scorecard-cli-${{ steps.version.outputs.value }}.tgz
           sbom-path: ./artifacts/cli.sbom.spdx.json
+      - name: Publish monorepo npm packages
+        run: npx lerna publish from-package --no-private --yes --dist-tag alpha
 
   publish-docker:
     needs: [release]


### PR DESCRIPTION
## Summary

- The release workflow's previous order (publish → pack → attest) bound the SBOM attestation to a tarball nobody could download.
- `lerna publish` mutates state on disk during its run, so the subsequent `npm pack -w` produced a tarball with a different digest than the bytes lerna had already pushed to the registry. The attestation was real and signed, but pointed at a digest the registry never serves.
- Reordering: pack first against pristine source, attest those bytes, then `lerna publish`. Both `lerna publish`'s internal pack and our `npm pack` invoke `npm-packlist` against the same source tree with normalized mtimes, so the tarballs are byte-identical and the attestation binds to the digest the registry actually serves.

## Verification on alpha.7 (the broken release)

```
publish step (registry tarball):  sha512-FF+DNTzjtuin2Iod2P8dQy6ylrHYv2JqoAKi...
                                  sha256: 28d13bf45af5c95faf3f86be5f3d17015b467af818c5e953278c0ef3238dd296
attest step (workflow tarball):   sha256: 535a19a688f7b0d0650833fa673dab00a118a364bb641a46659c1da7b653bed5
```

Different sha256 → `gh api /repos/jentic/jentic-api-scorecard/attestations/sha256:28d13b...` returns 404, even though the SBOM attestation succeeded against the workflow's local tarball.

## Test plan

- [x] YAML lint clean (`python3 -c "import yaml; yaml.safe_load(...)"`).
- [x] Local `npm pack -w` reproduces the registry tarball when run against unmutated source (verified empirically on alpha.6 — matching SHA-256 across two consecutive packs).
- [x] Post-merge: cut alpha.8, verify `gh attestation verify ./jentic-api-scorecard-cli-1.0.0-alpha.8.tgz --owner jentic --predicate-type https://spdx.dev/Document/v2.3` succeeds (gh CLI >= 2.49.0 required).

Refs #26 (which introduced the broken ordering).