### PR TITLE
fix(release): widen npm pack retry budget for CDN propagation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,14 +62,15 @@ jobs:
       # its internal pack, so the bytes the registry serves can't be
       # reproduced by `npm pack -w` against unmutated source. Pulling the
       # published tarball back guarantees the attestation digest matches
-      # what consumers actually download. The retries cover npm's
-      # registry CDN propagation lag (typically a few seconds).
+      # what consumers actually download. The retry budget (8 attempts,
+      # 30s spacing = ~4min total) covers npm's registry CDN propagation
+      # lag, which has been observed to exceed 30s on alpha.9.
       - name: Download published CLI tarball from registry
         uses: nick-fields/retry@v3
         with:
-          max_attempts: 5
-          retry_wait_seconds: 6
-          timeout_minutes: 2
+          max_attempts: 8
+          retry_wait_seconds: 30
+          timeout_minutes: 5
           retry_on: error
           command: |
             mkdir -p ./artifacts


### PR DESCRIPTION
## Summary

alpha.9 failed at the SBOM attestation step: `npm publish` ACK'd the write at 07:55:31, but the read API still served 404 at 07:56:00 — exceeding our 30s retry budget (5 attempts × 6s).

Bump `nick-fields/retry@v3` to 8 attempts × 30s = ~4min total budget, with `timeout_minutes` raised to 5 to match. Covers the observed ~30s propagation lag with safety margin.

## Failure log evidence (alpha.9)

```
07:55:32  Attempt 1: ETARGET — No matching version found for @jentic/api-scorecard-cli@1.0.0-alpha.9
07:55:39  Attempt 2: ETARGET (after 6s wait)
07:55:46  Attempt 3: ETARGET
07:55:53  Attempt 4: ETARGET
07:56:00  Attempt 5: ETARGET — final attempt failed
07:56:07  step exits 1
```

`npm view @jentic/api-scorecard-cli@1.0.0-alpha.9 dist.shasum` succeeded ~5min later, confirming the version eventually propagated. The retry budget was simply too tight.

## Why fixed wait, not exponential

`nick-fields/retry@v3` doesn't natively support exponential backoff (`retry_wait_seconds` is a single fixed value). A bash-loop alternative could schedule 1·5·15·30·60·90s, but trades the action's ergonomics for a small happy-path savings. Fixed 30s wastes ~30s in fast-path retries but reads cleaner; for a release workflow that runs ~once per cut, the trade-off favors readability.

## Test plan

- [x] YAML lint clean.
- [x] Math: 8 × 1s pack + 7 × 30s waits = 218s < 5min timeout, with margin for the actual `npm pack` runtime (network + tarball download).
- [x] Post-merge: cut alpha.10, observe whether retry succeeds before timeout.

Refs the alpha.9 failure run: https://github.com/jentic/jentic-api-scorecard/actions/runs/26355681874