### PR TITLE
fix(release): use tarball CDN for SBOM attestation download

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,19 +62,27 @@ jobs:
       # its internal pack, so the bytes the registry serves can't be
       # reproduced by `npm pack -w` against unmutated source. Pulling the
       # published tarball back guarantees the attestation digest matches
-      # what consumers actually download. The retry budget (8 attempts,
-      # 30s spacing = ~4min total) covers npm's registry CDN propagation
-      # lag, which has been observed to exceed 30s on alpha.9.
+      # what consumers actually download.
+      #
+      # We curl the tarball URL directly instead of `npm pack <pkg>@<ver>`
+      # because npm's package-metadata CDN (the JSON document at /<pkg>)
+      # propagates separately and slowly — observed >5min lag on alpha.9
+      # and alpha.10. The tarball CDN at /<pkg>/-/<pkg>-<ver>.tgz is
+      # available within ~1s of publish (alpha.10 evidence:
+      # `last-modified: 12:12:26 GMT`, `npm publish` ACK at 12:12:25).
+      # Retry covers the rare case of a missed CDN write.
       - name: Download published CLI tarball from registry
         uses: nick-fields/retry@v3
         with:
-          max_attempts: 8
-          retry_wait_seconds: 30
-          timeout_minutes: 5
+          max_attempts: 5
+          retry_wait_seconds: 6
+          timeout_minutes: 2
           retry_on: error
           command: |
             mkdir -p ./artifacts
-            npm pack "@jentic/api-scorecard-cli@${VERSION}" --pack-destination ./artifacts/
+            curl --fail --silent --show-error --location \
+              --output "./artifacts/jentic-api-scorecard-cli-${VERSION}.tgz" \
+              "https://registry.npmjs.org/@jentic/api-scorecard-cli/-/api-scorecard-cli-${VERSION}.tgz"
         env:
           VERSION: ${{ steps.version.outputs.value }}
       - name: Generate SPDX SBOM for CLI


### PR DESCRIPTION
## Summary

Switching from \`npm pack <pkg>@<version>\` to a direct \`curl\` of the tarball URL. \`npm pack\` reads npm's package-metadata document first, and that metadata layer has been observed to lag >5min on alpha.9 and alpha.10 — the tarball itself is on the CDN within ~1s of publish, so we sidestep metadata entirely.

PR #29 bumped the retry budget to ~4min on the assumption that the tarball was slow to propagate. Alpha.10 still failed after ~4min, revealing the real bottleneck: package metadata, not tarball bytes.

## Evidence on alpha.10

| Time (GMT) | Event |
|---|---|
| 12:12:25.110 | \`npm publish\` ACK in workflow log |
| 12:12:26 | Tarball \`last-modified\` per Cloudflare HEAD |
| 12:12:25.221 → 12:16:02 | \`npm pack @jentic/api-scorecard-cli@1.0.0-alpha.10\` returns ETARGET on every retry attempt |
| ~12:17 | Metadata catches up; \`npm view\` returns dist info |

\`curl --fail https://registry.npmjs.org/@jentic/api-scorecard-cli/-/api-scorecard-cli-1.0.0-alpha.10.tgz\` returns HTTP/2 200 with \`cf-cache-status: HIT\`. Sha1 of fetched bytes (\`6f32aab7…\`) matches \`npm view dist.shasum\` exactly.

## Why this is robust

- Tarball URL pattern \`<registry>/<scope>/<name>/-/<name>-<version>.tgz\` is documented and stable (npm has used it for ~15 years).
- \`curl --fail\` returns non-zero on any HTTP ≠ 2xx, so retries work as expected.
- Drops retry budget from ~4min back to ~30s, since real propagation lag at the tarball CDN is sub-second.

## Test plan

- [x] YAML lint clean.
- [x] Local rehearsal against alpha.10: curl-fetched sha1 matches \`npm view dist.shasum\`.
- [x] Filename pattern matches \`subject-path:\` glob exactly (\`jentic-api-scorecard-cli-\${VERSION}.tgz\`).
- [ ] Post-merge: cut alpha.11, observe whether the curl step succeeds within seconds and the attestation binds to the registry-served digest.

Refs alpha.9 failure run: https://github.com/jentic/jentic-api-scorecard/actions/runs/26355681874
Refs alpha.10 failure run: https://github.com/jentic/jentic-api-scorecard/actions/runs/26360890215