### PR TITLE
docs(README): explain attestations and add SBOM-download recipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,25 +95,60 @@ export JENTIC_API_KEY=mvp-preview
 This is a documented public placeholder for the alpha preview — not a secret. Real key issuance
 arrives in a future release.
 
-## Verifying releases
+## Supply-chain attestations
 
-`@jentic/api-scorecard-cli` alpha tarballs ship with two Sigstore-signed attestations:
-npm provenance (where and how the tarball was built) and an SPDX 2.3 SBOM (the runtime
-dependency closure). Both are present from `1.0.0-alpha.7` onward; earlier alphas carry only
-provenance. Verify with the GitHub CLI:
+Each `@jentic/api-scorecard-cli` alpha release ships with two independent
+[Sigstore](https://www.sigstore.dev/)-signed attestations bound to the published tarball's
+SHA-256 digest. Both are produced inside the GitHub Actions release workflow (no human
+keyholder, no long-lived secrets) and are verifiable with the [GitHub CLI](https://cli.github.com/)
+≥ 2.49.
+
+| Attestation | Predicate type | What it claims | Where it lives |
+|---|---|---|---|
+| **npm provenance** | `https://slsa.dev/provenance/v1` | Where and how the tarball was built (workflow run, commit SHA, builder identity) | npm registry record + GitHub attestations index |
+| **SPDX SBOM** | `https://spdx.dev/Document/v2.3` | The runtime dependency closure of the published tarball, in [SPDX 2.3](https://spdx.github.io/spdx-spec/v2.3/) form | GitHub attestations index |
+
+Both attestations are present from **`1.0.0-alpha.11`** onward; earlier alphas have provenance
+only (the SBOM attestation pipeline reached parity with the registry-served bytes in alpha.11).
+
+### Verify a release
 
 ```bash
+# 1. Download the published tarball
 npm pack @jentic/api-scorecard-cli@alpha
 
-# Verify provenance (gh's default predicate)
+# 2. Verify the npm provenance (gh's default predicate type)
 gh attestation verify ./jentic-api-scorecard-cli-*.tgz --owner jentic
 
-# Verify the SBOM (non-default predicate, must be requested explicitly)
+# 3. Verify the SPDX SBOM (non-default predicate type, must be requested explicitly)
 gh attestation verify ./jentic-api-scorecard-cli-*.tgz --owner jentic \
   --predicate-type https://spdx.dev/Document/v2.3
 ```
 
-Each successful run reports `Loaded digest sha256:…` and lists the matching attestation.
+Each successful run reports `Loaded digest sha256:…` and lists the matched attestation.
+
+### Download the SBOM
+
+`gh attestation verify` proves authenticity but doesn't print the SPDX document itself. The
+SBOM is embedded as the `predicate` of the verified in-toto statement; extract it with
+`--format json` and pipe through `jq`:
+
+```bash
+gh attestation verify ./jentic-api-scorecard-cli-*.tgz --owner jentic \
+  --predicate-type https://spdx.dev/Document/v2.3 \
+  --format json \
+  | jq '.[0].verificationResult.statement.predicate' \
+  > sbom.spdx.json
+```
+
+`sbom.spdx.json` is a complete SPDX 2.3 document — the document root carries the published
+package's purl (`pkg:npm/@jentic/api-scorecard-cli@<version>`) and the `packages` array
+enumerates every runtime dependency with its exact resolved version. Feed it directly to any
+SPDX-aware tool ([Trivy](https://trivy.dev/), [Grype](https://github.com/anchore/grype),
+[OSV-Scanner](https://github.com/google/osv-scanner)).
+
+Tying download to verification is deliberate: the recipe above succeeds only if the signature
+checks out, so you never end up with bytes that didn't pass the trust check.
 
 ## Status
 


### PR DESCRIPTION
## Summary

Restructures the "Verifying releases" section into "Supply-chain attestations" and adds the missing piece readers were asking for: how to **download** the SBOM after verifying it.

Specifically:

- A table distinguishing the two attestations: npm provenance (registered with the npm registry record + GitHub attestations index) vs SPDX SBOM (GitHub attestations index only).
- Explicit statement of the gh CLI ≥ 2.49 requirement (older gh has no \`attestation\` subcommand).
- Corrects the "from alpha.7 onward" claim. Alphas 7-10 had attestations, but they were bound to digests that didn't match the registry-served tarball (lerna's gitHead injection broke our locally-packed bytes). **Alpha.11 is the first version where verification actually succeeds end-to-end** against an \`npm install\`'d tarball.
- A recipe to extract the SBOM file from the verified attestation using \`gh attestation verify --format json | jq '.[0].verificationResult.statement.predicate'\`. Verified against the live alpha.11 attestation: extracts a 49 KB SPDX 2.3 document with 45 packages, root \`@jentic/api-scorecard-cli@1.0.0-alpha.11\`, dataLicense \`CC0-1.0\`.
- Mentions concrete SPDX-aware downstream tools (Trivy, Grype, OSV-Scanner) so readers know what the file is good for.

## Why tying download to verification

The recipe pipes through \`gh attestation verify --format json\` rather than \`gh api .../attestations/sha256:<digest>\` because the former runs the Sigstore signature check before printing the statement. So a reader following the recipe never ends up with SBOM bytes that didn't pass the trust check. README spells this out so users don't go off and write their own \`gh api\` recipe and skip the verification.

## Test plan

- [x] jq path \`.[0].verificationResult.statement.predicate\` confirmed against the gh CLI source (\`AttestationProcessingResult.VerificationResult.Statement.Predicate\` — Statement is in-toto v1, predicate IS the SPDX body, no double nesting).
- [x] Recipe executed against live alpha.11 attestation; produces valid SPDX 2.3 document.
- [x] Table verified: \`npm view @jentic/api-scorecard-cli@1.0.0-alpha.11 dist.attestations\` returns provenance only (no SBOM), confirming the SBOM lives in the GitHub attestations index alone.