### PR TITLE
ci(docker-publish): attest image provenance and per-platform SBOMs

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -10,6 +10,11 @@ on:
         required: true
         type: string
   workflow_dispatch:
+    inputs:
+      version:
+        description: Semver tag without v prefix (e.g. 1.0.0-alpha.1). Leave blank to publish unstable.
+        required: false
+        type: string
 
 permissions:
   contents: read
@@ -31,6 +36,11 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write
+      attestations: write
+    env:
+      IMAGE_NAME: ghcr.io/jentic/jentic-api-scorecard
+      IMAGE_TAG: ${{ inputs.version || 'unstable' }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -49,16 +59,88 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
+      # `sbom: true` and `provenance: mode=max` attach in-toto SBOM and SLSA
+      # provenance to the OCI manifest as referrer artifacts (verified via
+      # `docker buildx imagetools inspect`). The post-push attestation steps
+      # below also publish Sigstore-signed equivalents to GitHub's attestation
+      # store (verified via `gh attestation verify`). Both stores are populated
+      # so consumers can use either verification flow.
       - name: Build and push
+        id: build
         uses: docker/build-push-action@v7
         with:
           context: ./docker
           push: true
           platforms: linux/amd64,linux/arm64
-          tags: ghcr.io/jentic/jentic-api-scorecard:${{ inputs.version || 'unstable' }}
+          tags: ${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          sbom: true
+          provenance: mode=max
 
+      # Smoke test runs immediately after push so a Sigstore/Fulcio/Rekor
+      # outage downstream cannot mask a broken image. amd64 only (runner
+      # native); arm64 coverage falls under the per-platform attestation
+      # loop and CI's image-build smoke.
       - name: Smoke test Docker image
-        if: inputs.version
-        run: docker run --rm ghcr.io/jentic/jentic-api-scorecard:${{ inputs.version }} score --help
+        run: docker run --rm ${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }} score --help
+
+      # Per-platform SBOMs: scanning the manifest-list digest with syft on
+      # an amd64 runner only ever produces an amd64 SBOM. Loop the child
+      # manifest digests out of build-push-action's metadata and generate +
+      # attest one SBOM per platform so consumers verifying against either
+      # platform digest get an SBOM that matches the bytes they pulled.
+      - name: Resolve per-platform digests
+        id: platforms
+        run: |
+          metadata='${{ steps.build.outputs.metadata }}'
+          amd64_digest=$(echo "$metadata" | jq -r '."containerimage.descriptor".manifests[]? // empty | select(.platform.architecture == "amd64") | .digest' | head -n1)
+          arm64_digest=$(echo "$metadata" | jq -r '."containerimage.descriptor".manifests[]? // empty | select(.platform.architecture == "arm64") | .digest' | head -n1)
+          if [ -z "$amd64_digest" ] || [ -z "$arm64_digest" ]; then
+            echo "::error::Failed to resolve per-platform digests from build metadata"
+            echo "$metadata"
+            exit 1
+          fi
+          echo "amd64=$amd64_digest" >> "$GITHUB_OUTPUT"
+          echo "arm64=$arm64_digest" >> "$GITHUB_OUTPUT"
+
+      - name: Generate SPDX SBOM (amd64)
+        uses: anchore/sbom-action@v0
+        with:
+          image: ${{ env.IMAGE_NAME }}@${{ steps.platforms.outputs.amd64 }}
+          format: spdx-json
+          output-file: ./image.sbom.amd64.spdx.json
+          upload-artifact: false
+          upload-release-assets: false
+
+      - name: Generate SPDX SBOM (arm64)
+        uses: anchore/sbom-action@v0
+        with:
+          image: ${{ env.IMAGE_NAME }}@${{ steps.platforms.outputs.arm64 }}
+          format: spdx-json
+          output-file: ./image.sbom.arm64.spdx.json
+          upload-artifact: false
+          upload-release-assets: false
+
+      - name: Attest build provenance (index)
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ${{ env.IMAGE_NAME }}
+          subject-digest: ${{ steps.build.outputs.digest }}
+          push-to-registry: true
+
+      - name: Attest SBOM (amd64)
+        uses: actions/attest@v4
+        with:
+          subject-name: ${{ env.IMAGE_NAME }}
+          subject-digest: ${{ steps.platforms.outputs.amd64 }}
+          sbom-path: ./image.sbom.amd64.spdx.json
+          push-to-registry: true
+
+      - name: Attest SBOM (arm64)
+        uses: actions/attest@v4
+        with:
+          subject-name: ${{ env.IMAGE_NAME }}
+          subject-digest: ${{ steps.platforms.outputs.arm64 }}
+          sbom-path: ./image.sbom.arm64.spdx.json
+          push-to-registry: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,3 +108,5 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write
+      attestations: write


### PR DESCRIPTION
## Summary

- Adds dual-store image attestations: buildx-native SBOM/provenance OCI referrers (`sbom: true`, `provenance: mode=max`) plus Sigstore-signed equivalents via `actions/attest-build-provenance@v2` and `actions/attest@v4` with `push-to-registry: true`.
- Per-platform SBOMs: a new `Resolve per-platform digests` step extracts amd64/arm64 manifest digests from build-push-action's metadata, then generates and attests one SPDX SBOM per platform against its own child manifest digest. This avoids the syft-defaults-to-host-arch trap where scanning a manifest-list digest on an amd64 runner produces an amd64-only SBOM that gets bound to the index.
- Smoke test runs immediately after `Build and push`, so a Sigstore/Fulcio/Rekor outage downstream cannot mask a broken image. Smoke now also runs on `unstable` builds (push-to-main path), not just versioned releases.
- `workflow_dispatch` accepts a `version` input so operators can manually rebuild a specific tag to recover from partial release failures.
- `release.yml`'s `publish-docker` caller block adds `id-token: write` and `attestations: write` permissions to match.

## Verification flows post-merge

- **Docker-native**: `docker buildx imagetools inspect ghcr.io/jentic/jentic-api-scorecard:<tag> --format '{{json .SBOM}}'` and `... .Provenance`.
- **GitHub / Sigstore**: `gh attestation verify oci://ghcr.io/jentic/jentic-api-scorecard:<tag> --owner jentic`.

## Test plan

- [ ] Merge → push to main triggers `unstable` build with smoke + per-platform SBOM attestations.
- [ ] Inspect referrers on the published image with `docker buildx imagetools inspect` to confirm both buildkit and Sigstore attestations land.
- [ ] `gh attestation verify oci://ghcr.io/jentic/jentic-api-scorecard:unstable --owner jentic` succeeds.
- [ ] Pull the arm64 platform digest specifically and verify its SBOM attestation describes arm64 packages.
- [ ] Next release run via `release.yml` publishes the versioned tag with attestations attached.