### PR TITLE
fix(release): widen tarball retry to handle slow CDN writes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,21 +66,27 @@ jobs:
       #
       # We curl the tarball URL directly instead of `npm pack <pkg>@<ver>`
       # because npm's package-metadata CDN (the JSON document at /<pkg>)
-      # propagates separately and slowly — observed >5min lag on alpha.9
-      # and alpha.10. The tarball CDN at /<pkg>/-/<pkg>-<ver>.tgz is
-      # available within ~1s of publish (alpha.10 evidence:
-      # `last-modified: 12:12:26 GMT`, `npm publish` ACK at 12:12:25).
-      # Retry covers the rare case of a missed CDN write.
+      # propagates separately and slowly. The tarball CDN at
+      # /<pkg>/-/<pkg>-<ver>.tgz is *usually* available within ~1s of
+      # publish (alpha.10: tarball last-modified 12:12:26, publish ACK
+      # 12:12:25), but propagation can stall for 10+ minutes when npm's
+      # anti-abuse path is engaged — observed on alpha.12 where the
+      # tarball blob 404'd for >10 min after a successful `lerna publish`
+      # while the metadata document had already propagated. Budget the
+      # retry loop for the worst case so a healthy publish is never
+      # short-circuited by a slow CDN write.
       - name: Download published CLI tarball from registry
         uses: nick-fields/retry@v3
         with:
-          max_attempts: 5
-          retry_wait_seconds: 6
-          timeout_minutes: 2
+          max_attempts: 60
+          retry_wait_seconds: 30
+          timeout_minutes: 35
           retry_on: error
           command: |
             mkdir -p ./artifacts
             curl --fail --silent --show-error --location \
+              --header "Cache-Control: no-cache" \
+              --header "Pragma: no-cache" \
               --output "./artifacts/jentic-api-scorecard-cli-${VERSION}.tgz" \
               "https://registry.npmjs.org/@jentic/api-scorecard-cli/-/api-scorecard-cli-${VERSION}.tgz"
         env:


### PR DESCRIPTION
## Summary

The alpha.12 release run failed because the npm tarball blob at `registry.npmjs.org/.../api-scorecard-cli-1.0.0-alpha.12.tgz` returned HTTP 404 for over 10 minutes after `lerna publish` succeeded — even though the package metadata document propagated normally and the version showed up under `npm view`. The previous retry budget (5 attempts × 6s wait, ~30s total) was tuned for the typical ~1s propagation observed on alpha.9/.10 and gave up far too early.

This PR widens the budget to 60 attempts × 30s (~30 min wall clock) so the workflow tolerates worst-case CDN propagation, and adds `Cache-Control: no-cache` / `Pragma: no-cache` headers so Cloudflare bypasses any stale negative-cache entry on retry.

Failed run that motivated this: https://github.com/jentic/jentic-api-scorecard/actions/runs/26362003073/job/77599058648

## Test plan

- [ ] Next release run completes the tarball download cleanly.
- [ ] If a future run hits a slow CDN write, the loop polls until the blob appears rather than failing in 30s.