### PR TITLE
fix(dockerfile): add OCI image labels

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,12 @@
 FROM python:3.12-slim
 
+LABEL maintainer="vladimir@jentic.com" \
+      org.opencontainers.image.authors="vladimir@jentic.com" \
+      org.opencontainers.image.url="https://github.com/jentic/jentic-api-scorecard" \
+      org.opencontainers.image.source="https://github.com/jentic/jentic-api-scorecard" \
+      org.opencontainers.image.description="Jentic API Scorecard Docker image" \
+      org.opencontainers.image.licenses="Apache-2.0"
+
 COPY --from=node:24-slim /usr/local/bin/node /usr/local/bin/node
 COPY --from=node:24-slim /usr/local/lib/node_modules /usr/local/lib/node_modules
 RUN ln -s /usr/local/lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm && \


### PR DESCRIPTION
## Summary
- Add OCI image labels (`org.opencontainers.image.*`) to `docker/Dockerfile` so the GHCR image self-describes its source repo, license, description, and authors.
- URLs and description point at this repo (`jentic/jentic-api-scorecard`); `org.opencontainers.image.version` is intentionally omitted because the image tag already encodes the version (`ghcr.io/jentic/jentic-api-scorecard:<cli-version>`).

## Test plan
- [x] `docker build -t jentic-api-scorecard:dev ./docker` succeeds.
- [x] `docker inspect jentic-api-scorecard:dev --format '{{json .Config.Labels}}'` shows the new labels populated.