### PR TITLE
fix(docker-publish): annotate index with OCI metadata

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -73,6 +73,15 @@ jobs:
           push: true
           platforms: linux/amd64,linux/arm64
           tags: ${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}
+          # Annotate the multi-arch manifest index. Dockerfile LABELs only
+          # land on per-platform image configs, so GHCR's package UI (which
+          # reads from the index) shows "No description" without these.
+          annotations: |
+            index:org.opencontainers.image.authors=vladimir@jentic.com
+            index:org.opencontainers.image.url=https://github.com/jentic/jentic-api-scorecard
+            index:org.opencontainers.image.source=https://github.com/jentic/jentic-api-scorecard
+            index:org.opencontainers.image.description=Jentic API Scorecard Docker image
+            index:org.opencontainers.image.licenses=Apache-2.0
           cache-from: type=gha
           cache-to: type=gha,mode=max
           sbom: true


### PR DESCRIPTION
## Summary
- Annotate the multi-arch manifest index with `org.opencontainers.image.*` so GHCR's package UI shows the description, source, URL, authors, and license.
- Dockerfile `LABEL`s (added in #36) land on per-platform image configs only — the GHCR UI reads from the index, which is why the alpha.14 release page still says "No description provided".
- Annotation set mirrors the Dockerfile labels (authors, url, source, description, licenses); `maintainer` is intentionally omitted because it isn't an OCI annotation key — `org.opencontainers.image.authors` is the OCI equivalent.

## Test plan
- [ ] Trigger `Publish Docker Image` (push to main or manual dispatch with a version) and confirm the new package version on GHCR shows the description and links.
- [ ] `docker buildx imagetools inspect ghcr.io/jentic/jentic-api-scorecard:<tag> --format '{{json .Manifest.Annotations}}'` shows the new annotations on the index.