### PR TITLE
feat(dockerfile): split build/runtime, drop uv from runtime

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -53,7 +53,7 @@ The allowlist regex lives in `gate.py` as `_ALLOWLIST_PATTERN`. The placeholder 
 
 ### Image build (`docker/Dockerfile`)
 
-Multi-stage `python:3.12-slim` + `node:24-slim` (engine spawns Redocly / Spectral / Speclynx via `npx`). `uv sync --frozen --no-dev --no-install-project` installs the engine. The build runs a real score against `docker/.build/sample.yaml` to warm the npm cache so the first user-facing run doesn't pay validator-download cost. Entrypoint: `uv run python -m jentic_scorecard_runner`.
+Multi-stage `python:3.12-slim` + `node:24-slim` (engine spawns Redocly / Spectral / Speclynx via `npx`). The builder stage runs `uv sync --frozen --no-dev --no-install-project` to materialize `/app/.venv`; the runtime stage copies the venv and prepends `/app/.venv/bin` to `PATH`, so uv is not present in the final image. The build runs a real score against `docker/.build/sample.yaml` to warm the npm cache so the first user-facing run doesn't pay validator-download cost. Entrypoint: `python -m jentic_scorecard_runner`.
 
 ## Common commands
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,3 +1,13 @@
+FROM python:3.12-slim AS builder
+
+COPY --from=ghcr.io/astral-sh/uv:0.8.5 /uv /usr/local/bin/uv
+
+WORKDIR /app
+
+COPY pyproject.toml uv.lock ./
+RUN uv sync --frozen --no-dev --no-install-project
+
+
 FROM python:3.12-slim
 
 LABEL maintainer="vladimir@jentic.com" \
@@ -12,14 +22,10 @@ COPY --from=node:24-slim /usr/local/lib/node_modules /usr/local/lib/node_modules
 RUN ln -s /usr/local/lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm && \
     ln -s /usr/local/lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx
 
-# uv for fast Python dependency management
-COPY --from=ghcr.io/astral-sh/uv:0.8.5 /uv /uvx /usr/local/bin/
-
 WORKDIR /app
 
-# Install Python dependencies via uv
-COPY pyproject.toml uv.lock ./
-RUN uv sync --frozen --no-dev --no-install-project
+COPY --from=builder /app/.venv /app/.venv
+ENV PATH="/app/.venv/bin:$PATH"
 
 COPY src/ ./src/
 ENV PYTHONPATH=/app/src
@@ -27,7 +33,7 @@ ENV PYTHONPATH=/app/src
 # Warm npm cache: run a real score so npx-invoked validators get cached
 ENV NPM_CONFIG_CACHE=/var/cache/npm
 COPY .build/sample.yaml /tmp/sample.yaml
-RUN uv run jentic-apitools score /tmp/sample.yaml --format json --quiet > /dev/null && \
+RUN jentic-apitools score /tmp/sample.yaml --format json --quiet > /dev/null && \
     rm /tmp/sample.yaml
 
-ENTRYPOINT ["uv", "run", "python", "-m", "jentic_scorecard_runner"]
+ENTRYPOINT ["python", "-m", "jentic_scorecard_runner"]

--- a/specs/tech-stack.md
+++ b/specs/tech-stack.md
@@ -28,8 +28,8 @@ The current state, grounded in repository evidence. Planned-but-not-built items 
 | Runtime (host) | Docker | `docker/Dockerfile`; `ghcr.io/jentic/jentic-api-scorecard` is the deliverable |
 | Runtime (in image) | Python 3.12 + Node 24 LTS | `docker/Dockerfile:1, 3-6` (Node copied from `node:24-slim` for engine's `npx` dispatch) |
 | Scoring engine | `jentic-apitools-cli` (PyPI) | `docker/pyproject.toml:7` (pinned exactly); shells out to `npx`-launched Redocly / Spectral / Speclynx validators |
-| Dependency manager | uv | `docker/uv.lock`; `docker/Dockerfile:9` pins `ghcr.io/astral-sh/uv:0.8.5`; `[tool.uv]` in `docker/pyproject.toml:17-18` |
-| Build / packaging | Docker multi-stage | `docker/Dockerfile`; build-time `npx` cache warming via `docker/.build/sample.yaml` (`docker/Dockerfile:20-24`) |
+| Dependency manager | uv (build-time only) | `docker/uv.lock`; `docker/Dockerfile` builder stage pins `ghcr.io/astral-sh/uv:0.8.5`; `[tool.uv]` in `docker/pyproject.toml:17-18` |
+| Build / packaging | Docker multi-stage | `docker/Dockerfile`; builder stage materializes `.venv` via `uv sync`, runtime stage copies it and runs plain `python`; build-time `npx` cache warming via `docker/.build/sample.yaml` |
 | Test framework | pytest | `docker/pyproject.toml:12, 51`; tests in `docker/tests/` |
 | Lint / format (Python) | ruff | `docker/pyproject.toml:13, 20-31`; PostToolUse hook `.claude/hooks/ruff-fix.sh` runs on every Python edit |
 | Lint / format (JS/TS) | ESLint 9 (flat config) + Prettier 3 | `eslint.config.js`, `.prettierrc` at repo root; `eslint-plugin-import-x`, `typescript-eslint`, `eslint-plugin-prettier` recommended |
@@ -40,8 +40,8 @@ The current state, grounded in repository evidence. Planned-but-not-built items 
 ## Key Libraries and Frameworks
 
 - **`jentic-apitools-cli`** — the JAIRF scoring engine. Invoked as `jentic-apitools score <target> --format json --include-diagnostics --quiet [--enable-llm-analysis]`. Pinned exactly in `docker/pyproject.toml`; reproducibility is "pin one CLI version → pin one image tag → pin one engine version" (see `docs/architecture.md` §8).
-- **uv** — fast Python resolver/installer; lockfile (`docker/uv.lock`) is the source of truth for dependency versions. `uv sync --frozen --no-dev --no-install-project` runs at image build time. `[tool.uv]` declares `package = false` because the runner is image-internal, never published to PyPI.
-- **Docker (multi-stage build)** — base `python:3.12-slim`; binaries copied from `node:24-slim` and `ghcr.io/astral-sh/uv:0.8.5`. `ENTRYPOINT ["uv", "run", "python", "-m", "jentic_scorecard_runner"]` is fixed; every `docker run` appends arguments.
+- **uv** — fast Python resolver/installer; lockfile (`docker/uv.lock`) is the source of truth for dependency versions. `uv sync --frozen --no-dev --no-install-project` runs in the Dockerfile's builder stage only — uv is not present in the runtime image. `[tool.uv]` declares `package = false` because the runner is image-internal, never published to PyPI.
+- **Docker (multi-stage build)** — builder stage on `python:3.12-slim` runs `uv sync` to materialize `/app/.venv`; runtime stage on `python:3.12-slim` copies the venv plus binaries from `node:24-slim`, prepends `/app/.venv/bin` to `PATH`, and runs plain `python` (no `uv run` wrapper). `ENTRYPOINT ["python", "-m", "jentic_scorecard_runner"]` is fixed; every `docker run` appends arguments.
 
 ## Data and Storage
 


### PR DESCRIPTION
## Summary
- Split `docker/Dockerfile` into a `builder` stage (runs `uv sync` to materialize `/app/.venv`) and a runtime stage that copies just the venv. uv and the lockfile are no longer present in the published image.
- Runtime stage prepends `/app/.venv/bin` to `PATH`, so the cache-warm step calls `jentic-apitools` directly and the entrypoint is a plain `python -m jentic_scorecard_runner` — no `uv run` wrapper per container start.
- Updated `specs/tech-stack.md` (uv reframed as build-time only; entrypoint description) and the matching paragraph in `.claude/CLAUDE.md`.

## Test plan
- [x] `docker build -t jentic-api-scorecard:dev ./docker` succeeds with the new multi-stage layout.
- [x] `cd docker && uv run poe test` — full 25-test suite passes (includes `test_integration.py` which shells out to `docker run` against the rebuilt image).
- [x] Smoke: stdin path with `JENTIC_API_KEY=mvp-preview` returns a full JSON scorecard at exit 0.
- [x] Smoke: anonymous `--url` to a non-existent allowlisted-prefix URL exits 6 (`ENGINE_FAILURE`) — exit-code mapping unaffected.