### PR TITLE
chore(dockerfile): run as unprivileged user (uid 10001)

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -20,9 +20,8 @@ LABEL maintainer="vladimir@jentic.com" \
 COPY --from=node:24-slim /usr/local/bin/node /usr/local/bin/node
 COPY --from=node:24-slim /usr/local/lib/node_modules /usr/local/lib/node_modules
 RUN ln -s /usr/local/lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm && \
-    ln -s /usr/local/lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx
-
-RUN groupadd --gid 10001 runner && \
+    ln -s /usr/local/lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx && \
+    groupadd --gid 10001 runner && \
     useradd --uid 10001 --gid 10001 --home-dir /home/runner \
             --create-home --shell /usr/sbin/nologin runner && \
     mkdir -p /var/cache/npm && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -34,9 +34,9 @@ COPY --from=builder /app/.venv /app/.venv
 ENV PATH="/app/.venv/bin:$PATH"
 
 COPY src/ ./src/
-ENV PYTHONPATH=/app/src
-ENV HOME=/home/runner
-ENV NPM_CONFIG_CACHE=/var/cache/npm
+ENV PYTHONPATH=/app/src \
+    HOME=/home/runner \
+    NPM_CONFIG_CACHE=/var/cache/npm
 
 USER runner
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -31,10 +31,9 @@ RUN groupadd --gid 10001 runner && \
 WORKDIR /app
 
 COPY --from=builder /app/.venv /app/.venv
-ENV PATH="/app/.venv/bin:$PATH"
-
 COPY src/ ./src/
-ENV PYTHONPATH=/app/src \
+ENV PATH="/app/.venv/bin:$PATH" \
+    PYTHONPATH=/app/src \
     HOME=/home/runner \
     NPM_CONFIG_CACHE=/var/cache/npm
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -22,6 +22,12 @@ COPY --from=node:24-slim /usr/local/lib/node_modules /usr/local/lib/node_modules
 RUN ln -s /usr/local/lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm && \
     ln -s /usr/local/lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx
 
+RUN groupadd --gid 10001 runner && \
+    useradd --uid 10001 --gid 10001 --home-dir /home/runner \
+            --create-home --shell /usr/sbin/nologin runner && \
+    mkdir -p /var/cache/npm && \
+    chown runner:runner /var/cache/npm
+
 WORKDIR /app
 
 COPY --from=builder /app/.venv /app/.venv
@@ -29,10 +35,13 @@ ENV PATH="/app/.venv/bin:$PATH"
 
 COPY src/ ./src/
 ENV PYTHONPATH=/app/src
+ENV HOME=/home/runner
+ENV NPM_CONFIG_CACHE=/var/cache/npm
+
+USER runner
 
 # Warm npm cache: run a real score so npx-invoked validators get cached
-ENV NPM_CONFIG_CACHE=/var/cache/npm
-COPY .build/sample.yaml /tmp/sample.yaml
+COPY --chown=runner:runner .build/sample.yaml /tmp/sample.yaml
 RUN jentic-apitools score /tmp/sample.yaml --format json --quiet > /dev/null && \
     rm /tmp/sample.yaml
 


### PR DESCRIPTION
## Summary

- Runs the GHCR image as a non-root `runner` user (uid/gid 10001) instead of root.
- Switches to `USER runner` before the build-time npm-cache warming step so the cache layer is owned by the runtime user, with no `chown -R` pass and no extra image bloat.
- Sets `HOME=/home/runner` and `NPM_CONFIG_CACHE=/var/cache/npm` so npm/npx never try to write into `/` at runtime; sample spec is `--chown`ed so the warm-RUN can `rm` it from sticky `/tmp`.

Lets the image satisfy security policies that forbid root in containers — Kubernetes Pod Security Standards `restricted`, `runAsNonRoot: true`, common org-level policies that enforce `runAsUser >= 1000` (or `>= 10000`). The uid is intentionally high so it clears the strictest of those.

Comparable to the pattern in [`jentic/jentic-mini`'s Dockerfile](https://github.com/jentic/jentic-mini/blob/main/Dockerfile), with two deliberate differences:
- High uid (`10001`) instead of `useradd -r`'s system uid, to clear high-uid runAsUser policies.
- No `chown -R /app/data` — this image has no app-writable state; `/tmp` is the only writable surface and is already world-writable with sticky bit.

## Test plan

- [x] `docker build -t jentic-api-scorecard:dev ./docker` — clean build, no warnings.
- [x] `docker run --rm jentic-api-scorecard:dev id` → `uid=10001(runner) gid=10001(runner)`.
- [x] Allowlisted-URL smoke (anonymous mode): scored a real `jentic-public-apis` spec successfully.
- [x] Stdin smoke with `JENTIC_API_KEY=mvp-preview` against the petstore JSON: scored successfully.
- [x] `cd docker && uv run poe test` — all 25 tests pass, including the 9 integration tests that exercise the image end-to-end.