### PR TITLE
docs(README): tighten enterprise-section claims

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,8 +127,9 @@ verifies an artifact end-to-end before you install it:
 The image is a closed system at scoring time: every Python wheel, Node.js
 binary, and validator tarball it needs is baked in at build time. Scoring does
 not call PyPI, npmjs, a Jentic backend, or any external service. Local-file
-inputs and bundled-URL inputs run fully offline; URL inputs make exactly one
-outbound request — fetching the OpenAPI document itself. Multi-arch images
+inputs and bundled-URL inputs run fully offline; URL inputs reach the network
+only to fetch the OpenAPI document and resolve any external `$ref`s it points
+at. Multi-arch images
 (linux/amd64 + linux/arm64) ship from the same release, so the same guarantees
 hold on Apple Silicon dev machines, ARM CI runners, and x86 servers alike.
 

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ arrives in a future release.
 ## Enterprise-ready by default
 
 For teams that need to know exactly what's running, verify exactly what was
-shipped, and operate without runtime dependencies on us.
+shipped, and run without a runtime dependency on Jentic.
 
 ### Auditable end to end
 


### PR DESCRIPTION
## Summary

Two precision fixes in the **Enterprise-ready by default** section of the README:

1. **Drop "on us" for clearer enterprise framing.** Replace the colloquial *"operate without runtime dependencies on us"* with *"run without a runtime dependency on Jentic"* in the section intro. The previous wording read as chummy and could be misread as "at our expense"; the new phrasing names the entity explicitly and matches the rest of the section, which already says "Jentic backend" and "Jentic public APIs."

2. **Correct the URL-mode network claim.** The README previously said *"URL inputs make exactly one outbound request — fetching the OpenAPI document itself."* That's wrong: the engine bundles via Redocly, which resolves external `$ref`s, so a URL spec with externalized components fans out to N requests. New wording: *"URL inputs reach the network only to fetch the OpenAPI document and resolve any external `$ref`s it points at."* — truthful, keeps the "no Jentic backend, no PyPI, no npmjs" guarantee intact, and doesn't promise a request count we can't deliver.

No code changes.

## Test plan

- [x] Reviewed surrounding paragraphs to confirm both edits fit the section's tone and scope.
- [x] Cross-checked the dereferencing claim against `docs/architecture.md` §5 (`--bundle` paragraph already acknowledges Redocly resolves what the spec points at).