### PR TITLE
ci(docker-publish): skip attestations for :unstable

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -59,12 +59,18 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
-      # `sbom: true` and `provenance: mode=max` attach in-toto SBOM and SLSA
-      # provenance to the OCI manifest as referrer artifacts (verified via
-      # `docker buildx imagetools inspect`). The post-push attestation steps
-      # below also publish Sigstore-signed equivalents to GitHub's attestation
-      # store (verified via `gh attestation verify`). Both stores are populated
-      # so consumers can use either verification flow.
+      # For versioned releases, `sbom: true` and `provenance: mode=max`
+      # attach in-toto SBOM and SLSA provenance to the OCI manifest as
+      # referrer artifacts (verified via `docker buildx imagetools inspect`).
+      # The post-push attestation steps below also publish Sigstore-signed
+      # equivalents to GitHub's attestation store (verified via
+      # `gh attestation verify`). Both stores are populated so consumers
+      # can use either verification flow.
+      #
+      # `:unstable` rolls on every green push to main, so attesting specific
+      # bytes to a tag whose content changes without notice produces
+      # signatures that don't compose. Skip both BuildKit and post-push
+      # attestations for unstable builds — see issue #42.
       - name: Build and push
         id: build
         uses: docker/build-push-action@v7
@@ -84,8 +90,8 @@ jobs:
             index:org.opencontainers.image.licenses=Apache-2.0
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          sbom: true
-          provenance: mode=max
+          sbom: ${{ inputs.version != '' }}
+          provenance: ${{ inputs.version != '' && 'mode=max' || 'false' }}
 
       # Smoke test runs immediately after push so a Sigstore/Fulcio/Rekor
       # outage downstream cannot mask a broken image. amd64 only (runner
@@ -94,6 +100,12 @@ jobs:
       - name: Smoke test Docker image
         run: docker run --rm ${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }} score --help
 
+      # Per-platform SBOMs and attestations only run for versioned releases.
+      # The `:unstable` tag rolls on every green push to main, so attesting
+      # specific bytes there produces signatures that don't compose — the
+      # tag's content changes without notice. Versioned tags (`:1.0.0-alpha.<n>`)
+      # are immutable and worth signing.
+      #
       # Per-platform SBOMs: scanning the manifest-list digest with syft on
       # an amd64 runner only ever produces an amd64 SBOM. Loop the child
       # manifest digests out of build-push-action's metadata and generate +
@@ -105,6 +117,7 @@ jobs:
       # --raw` prints the manifest JSON to stdout without pulling layers.
       - name: Resolve per-platform digests
         id: platforms
+        if: inputs.version != ''
         run: |
           set -euo pipefail
           index_ref="${IMAGE_NAME}@${INDEX_DIGEST}"
@@ -122,6 +135,7 @@ jobs:
           INDEX_DIGEST: ${{ steps.build.outputs.digest }}
 
       - name: Generate SPDX SBOM (amd64)
+        if: inputs.version != ''
         uses: anchore/sbom-action@v0
         with:
           image: ${{ env.IMAGE_NAME }}@${{ steps.platforms.outputs.amd64 }}
@@ -131,6 +145,7 @@ jobs:
           upload-release-assets: false
 
       - name: Generate SPDX SBOM (arm64)
+        if: inputs.version != ''
         uses: anchore/sbom-action@v0
         with:
           image: ${{ env.IMAGE_NAME }}@${{ steps.platforms.outputs.arm64 }}
@@ -140,6 +155,7 @@ jobs:
           upload-release-assets: false
 
       - name: Attest build provenance (index)
+        if: inputs.version != ''
         uses: actions/attest-build-provenance@v2
         with:
           subject-name: ${{ env.IMAGE_NAME }}
@@ -147,6 +163,7 @@ jobs:
           push-to-registry: true
 
       - name: Attest SBOM (amd64)
+        if: inputs.version != ''
         uses: actions/attest@v4
         with:
           subject-name: ${{ env.IMAGE_NAME }}
@@ -155,6 +172,7 @@ jobs:
           push-to-registry: true
 
       - name: Attest SBOM (arm64)
+        if: inputs.version != ''
         uses: actions/attest@v4
         with:
           subject-name: ${{ env.IMAGE_NAME }}

--- a/docs/supply-chain-docker.md
+++ b/docs/supply-chain-docker.md
@@ -11,9 +11,12 @@ architectural context, see [architecture.md §8](./architecture.md#8-versioning-
 
 ## What is published
 
-Every image push (versioned releases like `:1.0.0-alpha.13` and the
-rolling `:unstable` tag) ships **two stores of attestation** for **each
-of two platforms** — amd64 and arm64.
+**Versioned releases only.** Every versioned image push (e.g. `:1.0.0-alpha.13`)
+ships **two stores of attestation** for **each of two platforms** — amd64 and
+arm64. The rolling `:unstable` tag, which mutates on every push to `main`,
+ships **without attestations** by design — pinning a Sigstore signature to a
+moving tag produces verifications that don't compose. Use a versioned tag for
+any environment that runs supply-chain verification.
 
 | Store | Provenance | SBOM | Verified with |
 |---|---|---|---|
@@ -126,12 +129,12 @@ the per-platform child digest for the SBOM matching your runtime arch.
 
 ```bash
 # Provenance: bound to the manifest list (index)
-gh attestation verify oci://ghcr.io/jentic/jentic-api-scorecard:unstable \
+gh attestation verify oci://ghcr.io/jentic/jentic-api-scorecard:1.0.0-alpha.13 \
   --owner jentic
 
 # SBOM: bound to the per-platform child manifest
 # Look up the child digest for your arch first
-INDEX=ghcr.io/jentic/jentic-api-scorecard:unstable
+INDEX=ghcr.io/jentic/jentic-api-scorecard:1.0.0-alpha.13
 ARM64_DIGEST=$(docker buildx imagetools inspect "$INDEX" --raw \
   | jq -r '.manifests[] | select(.platform.architecture == "arm64" and .platform.os == "linux") | .digest')
 
@@ -143,7 +146,7 @@ gh attestation verify oci://ghcr.io/jentic/jentic-api-scorecard@"$ARM64_DIGEST" 
 For stricter verification, pin the signer workflow:
 
 ```bash
-gh attestation verify oci://ghcr.io/jentic/jentic-api-scorecard:unstable \
+gh attestation verify oci://ghcr.io/jentic/jentic-api-scorecard:1.0.0-alpha.13 \
   --owner jentic \
   --signer-workflow jentic/jentic-api-scorecard/.github/workflows/docker-publish.yml
 ```
@@ -155,13 +158,13 @@ The OCI referrer attestations are attached as additional manifests with
 
 ```bash
 # Show the full referrer set
-docker buildx imagetools inspect ghcr.io/jentic/jentic-api-scorecard:unstable \
+docker buildx imagetools inspect ghcr.io/jentic/jentic-api-scorecard:1.0.0-alpha.13 \
   --format '{{json .Manifest}}'
 
 # Pull a specific referrer's content
-docker buildx imagetools inspect ghcr.io/jentic/jentic-api-scorecard:unstable \
+docker buildx imagetools inspect ghcr.io/jentic/jentic-api-scorecard:1.0.0-alpha.13 \
   --format '{{json .SBOM}}' | jq .
-docker buildx imagetools inspect ghcr.io/jentic/jentic-api-scorecard:unstable \
+docker buildx imagetools inspect ghcr.io/jentic/jentic-api-scorecard:1.0.0-alpha.13 \
   --format '{{json .Provenance}}' | jq .
 ```
 
@@ -174,7 +177,7 @@ To save the SPDX document for downstream SCA tooling:
 
 ```bash
 # Via Sigstore — one platform at a time
-INDEX=ghcr.io/jentic/jentic-api-scorecard:unstable
+INDEX=ghcr.io/jentic/jentic-api-scorecard:1.0.0-alpha.13
 AMD64_DIGEST=$(docker buildx imagetools inspect "$INDEX" --raw \
   | jq -r '.manifests[] | select(.platform.architecture == "amd64" and .platform.os == "linux") | .digest')
 


### PR DESCRIPTION
## Summary

Stop generating SBOMs and pushing attestations for the rolling `:unstable` GHCR tag. The `:unstable` tag mutates on every green push to `main`, so attesting specific bytes there produces signatures that don't compose into anything trustworthy — the SBOM attested yesterday is for a digest no one can pull today, and Sigstore's Rekor transparency log is append-only, so the records can't be cleaned up.

After this PR:
- **Versioned releases** (`:1.0.0-alpha.<n>`, dispatched via `release.yml` or manual `workflow_dispatch` with a `version` input) keep the full pipeline: BuildKit-side `sbom: true` / `provenance: mode=max`, plus the post-push per-platform SPDX SBOMs and dual-store (OCI referrers + Sigstore) attestations.
- **`:unstable` builds** (every push to `main`) only run build + multi-arch push + smoke test. No SBOMs, no Sigstore writes, no Rekor noise.

## Implementation

Single guard, applied uniformly: `if: inputs.version != ''` on every step that emits or pushes attestations.

- `Build and push` keeps `sbom: ${{ inputs.version != '' }}` and `provenance: ${{ inputs.version != '' && 'mode=max' || 'false' }}` so even BuildKit-native OCI referrers are skipped on `:unstable`.
- `Resolve per-platform digests`, `Generate SPDX SBOM (amd64/arm64)`, `Attest build provenance (index)`, and both `Attest SBOM` steps are gated on the same condition.

## Documentation

`docs/supply-chain-docker.md` updated to:
- Open with **"Versioned releases only"** so a reader doesn't expect verifiable bytes from `:unstable`.
- Switch every `gh attestation verify` / `docker buildx imagetools inspect` example from `:unstable` to `:1.0.0-alpha.13`, since the prior examples will no longer succeed against the registry after this PR.

## Test plan

- [x] `actionlint` clean against the updated workflow.
- [ ] Real validation lands when this merges and the next push to `main` builds `:unstable`. Watch for: build + smoke-test only, zero attestation steps run.
- [ ] Next versioned alpha (via `release.yml`) should run the full pipeline unchanged.

Closes #42