### PR TITLE
ci(docker-publish): prune orphan GHCR versions on :unstable push

### DIFF
--- a/.github/scripts/docker-prune-unstable-orphans.sh
+++ b/.github/scripts/docker-prune-unstable-orphans.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+# Prune GHCR package versions that are no longer reachable from any current
+# image tag. Intended to run at the end of every `:unstable` publish, since
+# rolling `:unstable` to a new digest is what produces orphans (the old
+# `:unstable` index loses its tag; if its bytes differ from the new build,
+# its per-platform children become unreachable too).
+#
+# Algorithm:
+#   1. List all package versions via GitHub Packages REST.
+#   2. For every version with a human-meaningful tag (i.e. NOT a `sha256-<hex>`
+#      OCI referrer wrapper), fetch its manifest from the registry and collect
+#      every `.manifests[].digest` it points at. Union those into a keep-set
+#      of digests + the parent digests themselves.
+#   3. Delete every untagged version whose digest is not in the keep-set.
+#   4. Delete every `sha256-<hex>` referrer wrapper whose `<hex>` is not the
+#      digest of a current human-tagged manifest.
+#
+# Failures are logged and counted; the script exits 0 even on partial failure
+# so the publish job is never broken by a transient API hiccup. Surviving
+# orphans get cleaned up on the next push.
+#
+# Required env:
+#   GH_TOKEN   - PAT or GITHUB_TOKEN with `packages: write` on the package
+#   ORG        - GitHub org/owner that owns the package (e.g. `jentic`)
+#   PACKAGE    - container package name (e.g. `jentic-api-scorecard`)
+#   IMAGE_REPO - registry path for manifest reads (e.g. `jentic/jentic-api-scorecard`)
+
+set -euo pipefail
+
+: "${GH_TOKEN:?GH_TOKEN is required}"
+: "${ORG:?ORG is required}"
+: "${PACKAGE:?PACKAGE is required}"
+: "${IMAGE_REPO:?IMAGE_REPO is required}"
+
+API="https://api.github.com/orgs/${ORG}/packages/container/${PACKAGE}/versions"
+REG_TOKEN_URL="https://ghcr.io/token?scope=repository:${IMAGE_REPO}:pull"
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+echo "::group::Listing package versions"
+gh_api() {
+  curl --fail --silent --show-error \
+       -H "Accept: application/vnd.github+json" \
+       -H "Authorization: Bearer ${GH_TOKEN}" \
+       -H "X-GitHub-Api-Version: 2022-11-28" \
+       "$@"
+}
+
+# Paginate; GitHub caps per_page at 100. 1000 versions covers any realistic case.
+: > "$WORK/versions.json"
+echo "[]" > "$WORK/versions.json"
+for page in 1 2 3 4 5 6 7 8 9 10; do
+  resp="$(gh_api "${API}?per_page=100&page=${page}")"
+  count=$(echo "$resp" | jq 'length')
+  if [ "$count" -eq 0 ]; then
+    break
+  fi
+  jq -s '.[0] + .[1]' "$WORK/versions.json" <(echo "$resp") > "$WORK/versions.json.tmp"
+  mv "$WORK/versions.json.tmp" "$WORK/versions.json"
+done
+total=$(jq 'length' "$WORK/versions.json")
+echo "Total versions: $total"
+echo "::endgroup::"
+
+echo "::group::Fetching anonymous registry token"
+REG_TOKEN=$(curl --fail --silent --show-error "$REG_TOKEN_URL" | jq -r .token)
+[ -n "$REG_TOKEN" ] && [ "$REG_TOKEN" != "null" ] || { echo "Failed to obtain registry token"; exit 0; }
+echo "::endgroup::"
+
+echo "::group::Walking real-tagged manifests to build keep-set"
+# Real tags = anything whose tag is NOT of the form sha256-<hex>
+jq -r '[.[] | select(.metadata.container.tags | any(test("^sha256-") | not))]
+       | .[] | "\(.metadata.container.tags | map(select(test("^sha256-") | not)) | .[0])\t\(.name)"' \
+   "$WORK/versions.json" > "$WORK/real-tags.tsv"
+
+real_tag_count=$(wc -l < "$WORK/real-tags.tsv")
+echo "Real tags found: $real_tag_count"
+
+# Keep-set: all parent digests + all manifest children
+: > "$WORK/keep-digests.txt"
+while IFS=$'\t' read -r tag parent_digest; do
+  echo "$parent_digest" >> "$WORK/keep-digests.txt"
+  # Fetch manifest list. Accept all common index/manifest media types.
+  manifest=$(curl --fail --silent --show-error \
+    -H "Authorization: Bearer ${REG_TOKEN}" \
+    -H "Accept: application/vnd.oci.image.index.v1+json,application/vnd.docker.distribution.manifest.list.v2+json,application/vnd.oci.image.manifest.v1+json,application/vnd.docker.distribution.manifest.v2+json" \
+    "https://ghcr.io/v2/${IMAGE_REPO}/manifests/${tag}" 2>/dev/null) || {
+    echo "::warning::Failed to fetch manifest for tag '$tag'; skipping its children"
+    continue
+  }
+  echo "$manifest" | jq -r '.manifests[]?.digest // empty' >> "$WORK/keep-digests.txt"
+done < "$WORK/real-tags.tsv"
+
+sort -u "$WORK/keep-digests.txt" -o "$WORK/keep-digests.txt"
+keep_count=$(wc -l < "$WORK/keep-digests.txt")
+echo "Keep-set size: $keep_count digests"
+echo "::endgroup::"
+
+# Build keep-set for sha256-<hex> referrer wrappers: convert keep-digests to "sha256-<hex>" form
+sed 's|sha256:|sha256-|' "$WORK/keep-digests.txt" > "$WORK/keep-referrer-tags.txt"
+
+echo "::group::Classifying versions"
+# Untagged-prune: tagless versions whose digest isn't in keep-set
+jq -r '[.[] | select((.metadata.container.tags | length) == 0)]
+       | .[] | "\(.id)\t\(.name)"' "$WORK/versions.json" > "$WORK/untagged-all.tsv"
+
+: > "$WORK/prune.tsv"
+while IFS=$'\t' read -r id digest; do
+  if ! grep -qFx "$digest" "$WORK/keep-digests.txt"; then
+    echo -e "${id}\t${digest}\torphan-untagged" >> "$WORK/prune.tsv"
+  fi
+done < "$WORK/untagged-all.tsv"
+
+# Referrer-prune: sha256-<hex> wrappers whose <hex> isn't a current parent digest
+jq -r '[.[] | select(.metadata.container.tags | any(test("^sha256-")))]
+       | .[] | "\(.id)\t\(.name)\t\(.metadata.container.tags | map(select(test("^sha256-"))) | .[0])"' \
+   "$WORK/versions.json" > "$WORK/referrers-all.tsv"
+
+while IFS=$'\t' read -r id digest tag; do
+  if ! grep -qFx "$tag" "$WORK/keep-referrer-tags.txt"; then
+    echo -e "${id}\t${digest}\torphan-referrer($tag)" >> "$WORK/prune.tsv"
+  fi
+done < "$WORK/referrers-all.tsv"
+
+prune_count=$(wc -l < "$WORK/prune.tsv")
+echo "Versions to prune: $prune_count"
+[ "$prune_count" -gt 0 ] && cat "$WORK/prune.tsv"
+echo "::endgroup::"
+
+if [ "$prune_count" -eq 0 ]; then
+  echo "Nothing to prune."
+  exit 0
+fi
+
+echo "::group::Deleting orphans"
+deleted=0
+failed=0
+while IFS=$'\t' read -r id digest reason; do
+  if curl --fail --silent --show-error \
+       -X DELETE \
+       -H "Accept: application/vnd.github+json" \
+       -H "Authorization: Bearer ${GH_TOKEN}" \
+       -H "X-GitHub-Api-Version: 2022-11-28" \
+       "${API}/${id}" >/dev/null 2>&1; then
+    deleted=$((deleted + 1))
+  else
+    echo "::warning::Failed to delete version ${id} (${digest}, ${reason})"
+    failed=$((failed + 1))
+  fi
+done < "$WORK/prune.tsv"
+echo "Deleted: ${deleted}/${prune_count}, failed: ${failed}"
+echo "::endgroup::"
+
+# Always exit 0 — orphan cleanup is best-effort; the publish job must not fail
+# because of a transient packages-API hiccup. Survivors get cleaned up next push.
+exit 0

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -179,3 +179,18 @@ jobs:
           subject-digest: ${{ steps.platforms.outputs.arm64 }}
           sbom-path: ./image.sbom.arm64.spdx.json
           push-to-registry: true
+
+      # `:unstable` rolls on every green push to main, so the previous index
+      # loses its tag and (if its bytes differ) its per-platform children
+      # become orphan. Walk every current real tag's manifest list, build a
+      # keep-set of reachable digests, and delete anything else. Best-effort:
+      # the script always exits 0 so a transient packages-API hiccup never
+      # fails the publish job — survivors are cleaned up on the next push.
+      - name: Prune orphan GHCR versions
+        if: inputs.version == ''
+        run: bash .github/scripts/docker-prune-unstable-orphans.sh
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ORG: jentic
+          PACKAGE: jentic-api-scorecard
+          IMAGE_REPO: jentic/jentic-api-scorecard


### PR DESCRIPTION
## Summary

Every `:unstable` push rolls the tag to a new digest; the previous index loses its tag, and if its bytes differ from the new build, its per-platform children become unreachable too. Without cleanup, GHCR's versions list grows by ~3 untagged digests per merge to `main` — the repo accumulated **205 orphan versions** before a manual cleanup brought it down to a 60-version steady state.

This PR makes the cleanup automatic.

## How it works

New file: `.github/scripts/docker-prune-unstable-orphans.sh`. Algorithm:

1. List every package version via the GitHub Packages REST API.
2. For every version with a human-meaningful tag (not a `sha256-<hex>` OCI referrer wrapper), fetch its manifest from the registry and union every `.manifests[].digest` it points at into a **keep-set** of reachable digests, alongside the parent digest itself.
3. Delete every untagged version whose digest isn't in the keep-set.
4. Delete every `sha256-<hex>` referrer wrapper whose `<hex>` is not the digest of a current human-tagged manifest.

Why this is needed (vs. just using `actions/delete-package-versions`): the stock action is reachability-blind. With `delete-only-untagged-versions: true` + any `min-versions-to-keep` value, it would delete the legitimate untagged children of older versioned releases (per-platform manifests, BuildKit attestation referrers) before it touched the actual orphan `:unstable` snapshots. A manifest-aware walk is the only way to prune safely.

Wired into `docker-publish.yml` as a final step gated `if: inputs.version == ''` — runs on `:unstable` pushes only. Versioned releases (`inputs.version != ''`) skip it: their tags are unique and never displaced, so they don't create orphans.

## Robustness

- **Best-effort.** The script always exits 0 so a transient packages-API hiccup or registry rate-limit never fails the publish job; survivors clean up on the next run.
- **Per-delete failure tolerance.** If one DELETE fails, the others continue; the failure is logged with `::warning::` and counted in the summary.
- **Manifest-fetch failure tolerance.** If a tag's manifest can't be fetched (network blip), the script logs a warning and skips just that tag's children — the delete loop only acts on the keep-set we *did* successfully resolve, so an incomplete walk results in *fewer* deletes, not over-deletion.

## Verification

Ran the script locally against the live GHCR state (post-manual-cleanup):

```
Total versions: 60
Real tags found: 13
Keep-set size: 45 digests
Versions to prune: 0
Nothing to prune.
```

Matches the steady state I established by hand earlier — 60 reachable versions, 13 real tags (`unstable` + 12 alpha versions), 45-digest keep-set covering parents + per-platform children + attestation children.

Linted with `shellcheck` (clean) and `actionlint` (clean).

## Test plan

- [x] Script lints clean (shellcheck, actionlint).
- [x] Script live-tested against current GHCR state — correctly identifies zero orphans.
- [ ] First real exercise: next merge to `main`. Expected: `:unstable` rolls, prior `:unstable` index + children become orphan, prune step deletes them, GHCR steady state stays at ~60 versions instead of growing.
- [ ] Versioned release path unaffected (next alpha bump should skip the prune step).