### PR TITLE
ci(release): gate release on full ci suite

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,9 +11,8 @@ jobs:
   # registry. Gating release-prepare on this means a failing lint /
   # test / build short-circuits the release with no version bump, no
   # tag, no GitHub release, and no artifacts to roll back. Without
-  # this gate, release-prepare runs only `npm run build` +
-  # `typescript:check-types` and skips python-lint, typescript-lint,
-  # and (critically) the python-test suite — see issue #23.
+  # this gate, nothing else in release-prepare runs lint or tests —
+  # see issue #23.
   ci:
     if: github.ref == 'refs/heads/main'
     uses: ./.github/workflows/ci.yml
@@ -46,8 +45,6 @@ jobs:
           node-version: 24.10.0
       - name: Install monorepo dependencies
         run: npm ci --engine-strict=false
-      - name: Build monorepo
-        run: npm run build
       - name: Version bump & GitHub release
         run: |
           git config user.name "github-actions[bot]"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,8 +48,6 @@ jobs:
         run: npm ci --engine-strict=false
       - name: Build monorepo
         run: npm run build
-      - name: Check TypeScript types
-        run: npm run typescript:check-types
       - name: Version bump & GitHub release
         run: |
           git config user.name "github-actions[bot]"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,12 +7,24 @@ env:
   HUSKY: 0
 
 jobs:
+  # Step 0: run the full CI suite before anything mutates the repo or
+  # registry. Gating release-prepare on this means a failing lint /
+  # test / build short-circuits the release with no version bump, no
+  # tag, no GitHub release, and no artifacts to roll back. Without
+  # this gate, release-prepare runs only `npm run build` +
+  # `typescript:check-types` and skips python-lint, typescript-lint,
+  # and (critically) the python-test suite — see issue #23.
+  ci:
+    if: github.ref == 'refs/heads/main'
+    uses: ./.github/workflows/ci.yml
+
   # Step 1: bump version, tag, create GitHub release, push to main.
   # No artifacts shipped yet — that happens in publish-docker and
   # release-publish below. Keeping the version bump and "latest"
   # flag here matches the previous workflow's behavior.
   release-prepare:
     name: Prepare release (version bump)
+    needs: [ci]
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     outputs:


### PR DESCRIPTION
## Summary

- Add a `ci` reusable-workflow job at the top of `release.yml` that calls `ci.yml`, and gate `release-prepare` on it via `needs: [ci]`.
- Without this gate, the manual release path ran only `npm run build` + `typescript:check-types` and silently skipped `python-lint`, `typescript-lint`, and (critically) the `python-test` suite — the only test suite in the repo.
- Failing CI now short-circuits the release before any version bump, tag, GitHub release, or registry artifacts are created.
- Drop the now-redundant `typescript:check-types` and `npm run build` steps from `release-prepare`. Both are covered by `ci.yml`'s `typescript-build`, and `release-prepare` doesn't consume the dist/ output (lerna version reads package.json/lerna.json; `release-publish` re-runs the build on its own checkout).

Closes #23

## Why `workflow_call` instead of inlining the four jobs?

The bug exists because `ci.yml` and the release path drifted. Duplicating the jobs into `release.yml` recreates the same drift hazard at the next CI change. Reusing `ci.yml` means there is one definition to keep in sync. `release.yml` already calls `docker-publish.yml` via `workflow_call`, so this is not a new pattern in the repo.

`lint-commit-messages` self-skips on `workflow_call` because its `if:` requires `github.event_name == 'pull_request'`, so we get exactly the four jobs we want (`python-lint`, `typescript-lint`, `typescript-build`, `python-test`).

## Test plan

The release workflow is `workflow_dispatch` only, gated on `refs/heads/main`. Validation options:

- [ ] Wait for the next real release dispatch and confirm:
  - [ ] `ci` job runs first and contains the four expected child jobs (`python-lint`, `typescript-lint`, `typescript-build`, `python-test`).
  - [ ] `release-prepare` waits on `ci` and only starts after it succeeds.
- [ ] Pre-merge: this PR's own CI run exercises the same `ci.yml` the gate now invokes, so a green PR is evidence the call surface resolves correctly.