### PR TITLE
fix(ci): strip devDependencies before SBOM generation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -155,7 +155,8 @@ jobs:
       - name: Generate SPDX SBOM for CLI
         run: |
           mkdir -p ./artifacts/sbom-staging
-          cp packages/cli/package.json ./artifacts/sbom-staging/
+          jq 'del(.devDependencies)' packages/cli/package.json \
+            > ./artifacts/sbom-staging/package.json
           (cd ./artifacts/sbom-staging \
             && npm install --omit=dev --no-audit --no-fund --ignore-scripts \
             && npm sbom --sbom-format=spdx --sbom-type=application --omit=dev \


### PR DESCRIPTION
## Summary

- The "Generate SPDX SBOM for CLI" step in the release workflow fails with `ESBOMPROBLEMS` because `npm sbom --omit=dev` still validates that all `devDependencies` listed in `package.json` are present in `node_modules`, even when they were intentionally skipped by `npm install --omit=dev`.
- Fix: use `jq del(.devDependencies)` to strip the field from the staged `package.json` before running `npm install` + `npm sbom`, so npm never sees the dev deps it can't find.

## Test plan

- [ ] Re-run the release workflow and verify the SBOM step passes
- [ ] Verify the generated `cli.sbom.spdx.json` is valid (the existing `jq empty` assertion covers this)

Closes #25