### PR TITLE
docs(spec): scaffold phase 6 — json-formatter

### DIFF
--- a/specs/2026-05-26-json-formatter/plan.md
+++ b/specs/2026-05-26-json-formatter/plan.md
@@ -1,0 +1,48 @@
+# Phase 6 Plan — JSON formatter (`--format json`)
+
+## Group 1 — Format type module
+
+1. Create `packages/cli/src/format.ts` mirroring `packages/cli/src/detail.ts`'s shape: export `Format = { PRETTY: 'pretty', JSON: 'json' } as const`, derived `type Format = (typeof Format)[keyof typeof Format]`, `FORMATS: readonly Format[] = [Format.PRETTY, Format.JSON]`, `DEFAULT_FORMAT: Format = Format.PRETTY`, and `isFormat(value: string): value is Format`.
+
+## Group 2 — JSON formatter
+
+2. Create `packages/cli/src/formatters/json.ts` exporting `formatJson(result: ScorecardResult): string`. Body returns `JSON.stringify(result, null, 2) + '\n'`. Imports `ScorecardResult` from `../result.ts` (with the `.ts` suffix per `.claude/rules/typescript-code-style.md`).
+
+## Group 3 — Wire the flag
+
+3. In `packages/cli/src/index.ts`, register `--format <fmt>` via `addOption(new Option('--format <fmt>', '<help text>').choices([...FORMATS]).default(DEFAULT_FORMAT))` immediately adjacent to the existing `-d, --detail` block. Import `Format`, `FORMATS`, `DEFAULT_FORMAT` from `./format.ts`.
+4. Widen the action callback's typed `opts` in `index.ts` to include `format: Format`. Pass `opts.format` into `runScore`.
+5. In `packages/cli/src/commands/score.ts`, extend `ScoreOptions` with `format?: Format`. After `filterByDetail(parsed, detail)` (the existing call at `score.ts:154`), branch on `options.format ?? DEFAULT_FORMAT`: `Format.PRETTY` calls `formatPretty(filtered, input, { detail })` (existing behavior); `Format.JSON` calls `formatJson(filtered)`. The single `process.stdout.write(output)` site is unchanged.
+
+## Group 4 — Restore appendHint lines
+
+6. In `packages/cli/src/formatters/pretty.ts` `appendHint()` (around line 303), reintroduce the three lines removed in commit `337b55e`. After the existing `Run with --detail dimensions for the dimension table.` line in the SUMMARY branch, append `  Full report: --format json --detail diagnostics`. After the existing `Run with --detail signals for signal breakdown.` line in the DIMENSIONS branch, append `  Full report: --format json --detail diagnostics`. After the existing `Run with --detail diagnostics for severity counts and a preview of findings.` line in the SIGNALS branch, append `  Full evidence: --format json --detail diagnostics`. All three wrapped in `chalk.dim(...)` consistent with surrounding lines.
+
+## Group 5 — Tests
+
+7. Create `packages/cli/test/formatters/json.test.ts`. Mirror the layout of `packages/cli/test/formatters/pretty.test.ts`: load the fixture from `packages/cli/test/fixtures/scorecard.sample.json` once at module level. `describe('formatJson')` with nested `describe` per detail level. Per level, call `formatJson(filterByDetail(fixture, level))` and assert: (a) `JSON.parse(output)` does not throw; (b) output ends with `\n`; (c) output contains `\n  ` (2-space indent); (d) parsed top-level keys match the per-level field map (`summary`: only `metadata`, `apiMetadata`, `summary` minus `summary.dimensions`; `dimensions`: as above with `summary.dimensions` intact; `signals`: adds `details`; `diagnostics`: adds `diagnostics`); (e) at least one verbatim value-passthrough check (e.g. `parsed.summary.score === 66.52`, `parsed.metadata.engine.version === '0.4.1+jairf.1.0.0'`). Add a small "shape robustness" describe block constructing a minimal `ScorecardResult` (only `summary`) and asserting `formatJson` produces parseable JSON.
+8. In `packages/cli/test/formatters/pretty.test.ts`, extend the existing per-detail-level describe blocks. Inside `describe('default detail (dimensions)')`, `describe('detail = summary')`, and `describe('detail = signals')`, add `it('hints at --format json --detail diagnostics')` asserting `output.includes('--format json --detail diagnostics')`. The DIAGNOSTICS branch unchanged (no hint).
+9. In `packages/cli/test/e2e/score.e2e.test.ts`, add a new `describe('--format json')` block after the existing `--detail summary` block. Reuse the existing `CLI_BIN`, `SAMPLE_SPEC`, and `E2E_TIMEOUT_MS` constants. Cover four cases: (a) `score <sample> --format json` exits 0, stdout is parseable JSON, parsed has `summary.score` (number) and `summary.dimensions` (length 6), no `details`/`diagnostics` at top level. (b) `--format json --detail summary` exits 0, parsed has `summary.score` but no `summary.dimensions`, no `details`/`diagnostics`. (c) `--format json --detail diagnostics` exits 0, parsed has both `details` and `diagnostics` arrays. (d) `--format invalid` exits non-zero with stderr containing `--format` and `invalid`.
+
+## Group 6 — Docs, roadmap completion, Verify
+
+10. Update `docs/architecture.md`: in §5's `--format <fmt>` row at line 163, replace the TTY-aware default language with "Default: `pretty` (unconditional). Values: `pretty`, `json`. `markdown` and `html` are reserved for later phases." Mark `--json` (line 164) as "(deferred — not in Phase 6)". Audit §11 verification recipes (lines 696-703) and remove the `--format json -o report.json` line if present, since `-o` is Phase 8 (or annotate as Phase 8). Leave §7 (lines 527-630) untouched — its engine-verbatim contract is exactly what Phase 6 ships.
+11. Update `.claude/CLAUDE.md`: replace "`--format json --detail diagnostics` will surface it once Phase 6 lands" with "`--format json --detail diagnostics` surfaces the full evidence bundle". In the same paragraph, remove Phase 6 from the "ship in Phases 6 / 8 / 9 / 7" trailer so it reads "ship in Phases 8 / 9 / 7 respectively".
+12. Update `specs/tech-stack.md`: in the "Roadmap, not yet built" section (line 107 area), refresh the "Output formats and CLI surface" bullet so `--format` (pretty + json) is listed as shipped and the rest (`-o`, `--quiet`, `--verbose`, markdown/html formatters) remains deferred.
+13. Update `README.md`: add a short "Machine-readable output" subsection between "Control output depth" and the LLM section, with `npx @jentic/api-scorecard-cli score ./openapi.yaml --format json | jq .summary.score` and `… --format json --detail diagnostics > report.json` as the two canonical recipes.
+14. Append ` ✅` (single space + U+2705) to the Phase 6 heading in `specs/roadmap.md` so it reads `## Phase 6 — JSON formatter (\`--format json\`) ✅`. Leave the rest of the Phase 6 block untouched.
+
+## Group 7 — Verify
+
+15. `npm run lint -w @jentic/api-scorecard-cli` exits 0.
+16. `npm run typescript:check-types -w @jentic/api-scorecard-cli` exits 0.
+17. `npm run build:typescript -w @jentic/api-scorecard-cli` exits 0.
+18. `npm test -w @jentic/api-scorecard-cli` exits 0; the new `json.test.ts`, the extended `pretty.test.ts` hints assertions, and the existing `detail.test.ts` / `exit-codes.test.ts` all pass.
+19. `npm run test:e2e` exits 0; the new `--format json` e2e block plus the existing e2e blocks all pass against the locally-built docker image at the matching CLI tag.
+20. `cd docker && uv run poe lint` exits 0 and `cd docker && uv run poe test` exits 0 (regression guard — Phase 6 does not touch Python, but the CI workflow runs both).
+21. Smoke: `JENTIC_API_KEY=mvp-preview node packages/cli/bin/jentic-api-scorecard.mjs score docker/.build/sample.yaml --format json | jq .summary.score` prints a number and exits 0.
+22. Smoke: `JENTIC_API_KEY=mvp-preview node packages/cli/bin/jentic-api-scorecard.mjs score docker/.build/sample.yaml --format json --detail diagnostics | jq '.diagnostics | length'` prints an integer ≥ 1 and exits 0.
+23. Smoke: `JENTIC_API_KEY=mvp-preview node packages/cli/bin/jentic-api-scorecard.mjs score docker/.build/sample.yaml --format invalid` exits non-zero with stderr containing `--format` and `invalid`.
+24. Smoke (default unchanged): `JENTIC_API_KEY=mvp-preview node packages/cli/bin/jentic-api-scorecard.mjs score docker/.build/sample.yaml` produces pretty-formatted output containing `Full report: --format json --detail diagnostics` in the footer hints.
+25. `grep -F "## Phase 6 — JSON formatter (\`--format json\`) ✅" specs/roadmap.md` exits 0.
+26. `grep -F "format json" README.md` exits 0.

--- a/specs/2026-05-26-json-formatter/requirements.md
+++ b/specs/2026-05-26-json-formatter/requirements.md
@@ -1,0 +1,70 @@
+# Phase 6 Requirements — JSON formatter (`--format json`)
+
+## Scope
+
+Phase 6 reintroduces machine-readable JSON output to the npm CLI through a new `--format <pretty|json>` flag. `pretty` stays the unconditional default; `--format json` produces engine-verbatim JSON, pretty-printed with 2-space indentation, filtered by the existing `--detail` level so a CI integrator can pipe `score … --format json | jq .summary.score` and gate on the result.
+
+The phase also restores the `--format json --detail diagnostics` footer hint that was removed from the pretty formatter's `appendHint()` in commit `337b55e` (a deliberate Phase 5 stop-gap so the formatter never recommended an unimplemented flag). Once Phase 6 ships the flag, the hint becomes a live, working recommendation again — restoring the canonical sample output documented at `docs/architecture.md:34`.
+
+## Out of Scope
+
+- **TTY-aware default switching.** `docs/architecture.md` §5 currently says "json is the default when stdout is not a TTY (piped/redirected)"; the roadmap bullet says "Default stays `pretty`." This phase honors the roadmap-literal reading: `pretty` is the default regardless of stdout TTY status. The architecture-doc text is dialed back in this same PR to match.
+- **`--json` convenience alias.** `docs/architecture.md` §5 line 164 documents `--json` as an alias for `--format json`. The roadmap bullet does not mention it. Deferred; the architecture doc is updated in this PR to mark `--json` as deferred.
+- **`-f` short flag.** Same rationale as `--json` — documented in architecture §5 but not in the roadmap bullet. Deferred to a later doc-alignment phase.
+- **`-o FILE`.** Phase 8.
+- **`--quiet` / `--verbose`.** Phases 9 / 7.
+- **`--format markdown`.** Listed under Later Phases in `specs/roadmap.md:222`. Commander rejects it as an invalid choice.
+- **`--format html`.** Phase 14. Commander rejects it as an invalid choice.
+- **`--min-score N` and any new exit code.** Later Phases. Phase 6 unblocks manual `jq`-based gating but does not implement a built-in gate.
+- **Container-side changes.** Phase 6 is host-CLI-only. The container already emits engine-verbatim JSON via `jentic-apitools score --format json --include-diagnostics --quiet` (`docs/architecture.md:510`). No image rebuild.
+- **JSON schema validation in the CLI.** `docs/architecture.md` §10 explicitly defers this. The formatter is `JSON.stringify(filtered, null, 2)` — no validation.
+- **Snapshot tests of the entire JSON byte-stream.** Engine version drift would break a strict-snapshot test on every engine bump. Tests assert *shape* (top-level keys, projection rules) and a small set of *verbatim values* (engine version string, fixture's `summary.score`, dimension `kind`s) — not bit-for-bit equality.
+
+## Decisions
+
+### Roadmap-literal interpretation of the default
+
+`pretty` is the unconditional default for `--format`. There is no TTY-aware fallback to `json`. The rationale: the roadmap bullet states "Default stays `pretty`" plainly, and matching `--detail`'s commander-driven default keeps the CLI surface uniform — both flags use `Option.choices([...]).default(<constant>)` and neither inspects `process.stdout.isTTY`. Users who pipe to `jq` pass `--format json` explicitly. The architecture doc's TTY-aware language at `docs/architecture.md:163` is updated in this PR to say `pretty` is the unconditional default.
+
+### Restore all three `appendHint()` lines
+
+Commit `337b55e` removed three lines from `appendHint()` — one per non-DIAGNOSTICS detail level (`SUMMARY`, `DIMENSIONS`, `SIGNALS`). All three are restored verbatim, including the `Full evidence:` wording on the SIGNALS branch (the other two read `Full report:`). This restores the canonical samples in `docs/architecture.md:34` and `:321` and is the symmetric inverse of `337b55e`. Restoring only one line would leave two of the three pre-regression sample positions empty.
+
+### `Format` lives in its own module
+
+A new `packages/cli/src/format.ts` mirrors the shape of `packages/cli/src/detail.ts`: `Format = { PRETTY: 'pretty', JSON: 'json' } as const`, derived `type Format`, `FORMATS` readonly array, `DEFAULT_FORMAT`, and an `isFormat()` narrower. This is co-pattern with `detail.ts` (and `exit-codes.ts`) and matches `.claude/rules/typescript-code-style.md`'s ban on `enum`. Inlining in `index.ts` would diverge from the established layering.
+
+### JSON formatter is a single TS module under `packages/cli/src/formatters/`
+
+`packages/cli/src/formatters/json.ts` exports `formatJson(result: ScorecardResult): string`. Body is `JSON.stringify(result, null, 2) + '\n'`. The architecture decision rule at `docs/architecture.md:151` mandates that string-projection formatters live inside `packages/cli/src/formatters/`; only `formatter-html` (Phase 14) earns its own package because of the React + bundler weight. JSON imposes none of that weight, so a separate package would be unjustified abstraction.
+
+### Filtering happens once, upstream of every formatter
+
+`commands/score.ts:154` already calls `filterByDetail(parsed, detail)` and passes the result to `formatPretty`. Phase 6 inserts a format-dispatch branch at the formatter call site (`score.ts:155`) that picks `formatJson` or `formatPretty` based on `options.format`. The JSON formatter consumes the same already-filtered `ScorecardResult` — it does not re-filter. This is the invariant the roadmap framing for Phase 5 explicitly preserved (`specs/roadmap.md:90`).
+
+## Constraints
+
+- **Engine-verbatim — no key renames or restructuring.** `specs/mission.md:42`; `specs/tech-stack.md:86`; `docs/architecture.md:529` (§7). The formatter must be pure projection: `JSON.stringify` of the already-filtered result, no additional fields, no envelope keys, no rename of engine keys.
+- **Stable result JSON for automation.** `specs/mission.md:42`. CI integrators must be able to `jq .summary.score` without paying attention to CLI version. Phase 6's output must keep the field stable.
+- **Engine signal stability tolerance.** `specs/tech-stack.md:114-115`. The engine is alpha (`1.0.0a16`); signal names and metadata shapes may change in breaking ways. `JSON.stringify` is structurally tolerant of unknown keys; tests must assert *shape and known verbatim values*, not strict snapshots.
+- **Exit codes are public CLI contract.** `specs/tech-stack.md:87`; `docs/architecture.md` §6. Phase 6 introduces no new exit codes. Invalid `--format` value is rejected by commander at parse time and exits 1 (the existing commander-rejection path).
+- **Stdout/stderr discipline.** `docs/architecture.md:348` — stdout stays clean so `--format json | jq` works without filtering. The spinner remains on stderr; Phase 6 does not silence it (`--quiet` is Phase 9). Phase body bullet 3 explicitly preserves stdout-on-TTY emission so users can pipe interactively.
+- **No deep relative imports across packages; `.ts` extension on relative imports inside the package.** `.claude/rules/typescript-code-style.md`. `format.ts` and `formatters/json.ts` import `result.ts`, `detail.ts` etc. with explicit `.ts` suffixes.
+- **No mocking in tests.** `specs/tech-stack.md:90`; `.claude/rules/testing.md`. JSON formatter unit tests consume the real fixture (`packages/cli/test/fixtures/scorecard.sample.json`) captured from a real engine run. e2e tests spawn the real CLI against a real Docker image.
+- **Lerna fixed-version invariant.** `specs/tech-stack.md`; `docs/architecture.md` §2. Phase 6 implementation does NOT bump `package.json` versions; the alpha-release CI flow (Phase 12) cuts the next prerelease at tag time.
+
+## Context
+
+Phase 4 made `pretty` the unconditional default and dropped engine-verbatim JSON from the npm CLI's stdout. Phase 5 introduced `--detail` filtering and made `filterByDetail()` engine-verbatim by construction. Both phases shipped knowing Phase 6 would eventually reintroduce JSON; commit `337b55e` even removed forward-references to `--format json` from the pretty formatter's footer hints once Copilot review on PR #14 noted that recommending an unimplemented flag would error with "unknown option". Phase 6 closes that loop.
+
+The named secondary persona in `specs/mission.md:30` is "CI integrators" — teams that want to gate merges on JAIRF score thresholds. Until Phase 6 lands, the npm CLI cannot serve that persona end-to-end: there is no documented way to get machine-readable output through `npx @jentic/api-scorecard-cli score …`. Users who need JSON have to bypass the CLI and run `docker run …` directly, which is exactly the UX the architecture wants to avoid (`docs/architecture.md` §1). Once `--format json` ships, the canonical recipe `score --format json | jq .summary.score` becomes live and the deferred `--min-score N` flag (Later Phases) becomes optional sugar rather than a blocker.
+
+The `--format json --detail diagnostics` recipe in particular is load-bearing for diagnostics evidence: pretty's diagnostics rendering is intentionally a small severity tally + top-5 preview because the full evidence bundle isn't useful in a terminal (`.claude/CLAUDE.md` line 13). Users who actually need the full bundle — e.g. for archival, CI artifacts, or LLM-assisted review — must go through `--format json --detail diagnostics`. Restoring the `appendHint()` footer makes the path discoverable from the default invocation.
+
+This is the second SDD-scaffolded feature spec in the project (after `specs/2026-05-25-with-llm-plumbing/` for Phase 10). Scope and validation conventions follow that precedent.
+
+## Stakeholder Notes
+
+- **CI integrators** — get a stable, documented `score … --format json` channel they can `jq` without depending on CLI version. Manual gating via `jq '.summary.score < N' && exit 1` becomes possible immediately; the Later-Phases `--min-score N` becomes additive, not foundational.
+- **OpenAPI spec authors / maintainers** — the pretty default is unchanged. They benefit indirectly: the restored `appendHint()` footer points them at `--format json --detail diagnostics` when they want the full evidence bundle.
+- **Future formatter authors (HTML — Phase 14; Markdown — Later)** — Phase 6 finalizes the format-dispatch shape in `commands/score.ts` and the `packages/cli/src/formatters/<name>.ts` co-located convention. New formatters slot into this dispatch with one branch each.

--- a/specs/2026-05-26-json-formatter/validation.md
+++ b/specs/2026-05-26-json-formatter/validation.md
@@ -1,0 +1,118 @@
+# Phase 6 Validation — JSON formatter (`--format json`)
+
+## Definition of Done
+
+All of the following must be true before this branch is merged.
+
+### 1. CI: lint and type-check pass
+
+```
+npm run lint -w @jentic/api-scorecard-cli
+npm run typescript:check-types -w @jentic/api-scorecard-cli
+npm run build:typescript -w @jentic/api-scorecard-cli
+```
+
+All three exit 0. The `typescript-lint` and `typescript-build` jobs in `.github/workflows/ci.yml` go green on the PR.
+
+### 2. CI: unit tests pass
+
+```
+npm test -w @jentic/api-scorecard-cli
+```
+
+Exits 0. `packages/cli/test/formatters/json.test.ts` (new), the extended `packages/cli/test/formatters/pretty.test.ts` (with `--format json --detail diagnostics` hint assertions across SUMMARY / DIMENSIONS / SIGNALS branches), and the unchanged `detail.test.ts` / `exit-codes.test.ts` all pass. The `typescript-test` job in `.github/workflows/ci.yml` goes green on the PR.
+
+### 3. CI: e2e tests pass
+
+```
+npm run test:e2e
+```
+
+Exits 0. The new `describe('--format json')` block in `packages/cli/test/e2e/score.e2e.test.ts` covers: default-detail JSON (parseable, has `summary.dimensions` length 6, no `details`/`diagnostics`); `--detail summary` (parseable, no `summary.dimensions`); `--detail diagnostics` (parseable, has `details` and `diagnostics` arrays); `--format invalid` (exits non-zero, stderr mentions `--format` and `invalid`). The `test-e2e` job in `.github/workflows/ci.yml` goes green on the PR.
+
+### 4. CI: Python regression guards pass
+
+```
+cd docker && uv run poe lint
+cd docker && uv run poe test
+```
+
+Both exit 0. Phase 6 does not modify `docker/`, but `python-lint` and `python-test` jobs run unconditionally on PR per `.claude/rules/testing.md`.
+
+### 5. Smoke: `--format json` emits parseable engine-verbatim JSON
+
+```
+JENTIC_API_KEY=mvp-preview node packages/cli/bin/jentic-api-scorecard.mjs \
+  score docker/.build/sample.yaml --format json | jq .summary.score
+```
+
+Exits 0; stdout (after `jq`) is a number. Without the `jq` pipe, stdout is parseable JSON with top-level keys `metadata`, `apiMetadata`, `summary`, no `details`, no `diagnostics`, and `summary.dimensions` is an array of length 6.
+
+### 6. Smoke: `--detail` filtering applies to JSON
+
+```
+JENTIC_API_KEY=mvp-preview node packages/cli/bin/jentic-api-scorecard.mjs \
+  score docker/.build/sample.yaml --format json --detail diagnostics \
+  | jq '.diagnostics | length'
+```
+
+Exits 0; output is an integer ≥ 1. With `--detail summary`, `jq '.summary | has("dimensions")'` returns `false` and `jq 'has("details") or has("diagnostics")'` returns `false`. With `--detail signals`, `jq 'has("details")'` returns `true` and `jq 'has("diagnostics")'` returns `false`.
+
+### 7. Smoke: invalid format value rejected by commander
+
+```
+JENTIC_API_KEY=mvp-preview node packages/cli/bin/jentic-api-scorecard.mjs \
+  score docker/.build/sample.yaml --format invalid
+```
+
+Exits non-zero. Stderr contains both `--format` and `invalid`. (Commander's `Option.choices()` rejection at parse time, no new exit code introduced.)
+
+### 8. Pretty default unchanged; appendHint footer restored
+
+```
+JENTIC_API_KEY=mvp-preview node packages/cli/bin/jentic-api-scorecard.mjs \
+  score docker/.build/sample.yaml
+```
+
+Exits 0; stdout contains the dimension table; stderr contains `Full report: --format json --detail diagnostics` (or `Full evidence: ...` when run with `--detail signals`). Asserts the regression `337b55e` introduced is undone and the canonical sample at `docs/architecture.md:34` reads true.
+
+### 9. Roadmap completion marker present
+
+```
+grep -F "## Phase 6 — JSON formatter (\`--format json\`) ✅" specs/roadmap.md
+```
+
+Exits 0. The leading space before ✅ is load-bearing per `specs/roadmap.md:19`. The em dash `—` (U+2014) and ✅ (U+2705) must be exact.
+
+### 10. README updated with JSON recipe
+
+```
+grep -F "format json" README.md
+```
+
+Exits 0. The "Machine-readable output" subsection between "Control output depth" and the LLM section contains a `--format json` recipe.
+
+### 11. Architecture doc updated to match shipped surface
+
+`docs/architecture.md` §5's `--format <fmt>` row (line 163 area) reads "Default: `pretty` (unconditional). Values: `pretty`, `json`. `markdown` and `html` are reserved for later phases." The TTY-aware-default language is removed. The `--json` row is annotated "(deferred — not in Phase 6)".
+
+### 12. CLAUDE.md and tech-stack.md updated
+
+- `.claude/CLAUDE.md` no longer claims "`--format json --detail diagnostics` will surface it once Phase 6 lands"; the "ship in Phases 6 / 8 / 9 / 7" trailer no longer mentions Phase 6.
+- `specs/tech-stack.md`'s "Roadmap, not yet built" entry for output formats lists `--format` (pretty + json) as shipped and keeps the rest deferred.
+
+## Not Required
+
+- **HTML formatter implementation.** Phase 14.
+- **Markdown formatter.** Later Phases (`specs/roadmap.md:222`).
+- **`--json` convenience alias.** Deferred; architecture doc updated to flag deferral.
+- **`-f` short flag for `--format`.** Deferred; same rationale as `--json`.
+- **`-o FILE` interaction tests.** Phase 8.
+- **`--quiet` / `--verbose` interaction tests.** Phases 9 / 7.
+- **TTY-aware default switching.** Out of scope per the roadmap-literal Decision.
+- **`--min-score N` or new exit code.** Later Phases.
+- **Container-side or Dockerfile changes.** Phase 6 is host-CLI-only.
+- **Snapshot test of the entire JSON byte-stream.** Engine version drift would break it on every engine bump; tests assert shape and a small set of verbatim values instead.
+- **JSON schema validation in the CLI.** `docs/architecture.md` §10 explicitly defers it.
+- **Anonymous-allowlist negative test for `--format json`.** Already covered by `score.e2e.test.ts:82–93` in the existing e2e suite; redundant in this phase.
+- **`package.json` version bumps.** Lerna fixed-version is bumped at alpha-release time (Phase 12 flow), not in implementation PRs.

--- a/specs/2026-05-26-json-formatter/validation.md
+++ b/specs/2026-05-26-json-formatter/validation.md
@@ -74,7 +74,7 @@ JENTIC_API_KEY=mvp-preview node packages/cli/bin/jentic-api-scorecard.mjs \
   score docker/.build/sample.yaml
 ```
 
-Exits 0; stdout contains the dimension table; stderr contains `Full report: --format json --detail diagnostics` (or `Full evidence: ...` when run with `--detail signals`). Asserts the regression `337b55e` introduced is undone and the canonical sample at `docs/architecture.md:34` reads true.
+Exits 0; stdout contains the dimension table and the footer hint `Full report: --format json --detail diagnostics` (or `Full evidence: ...` when run with `--detail signals`). The footer hint is part of the formatted report payload — `appendHint()` pushes into the same `lines[]` array that `score.ts:156` writes to `process.stdout`; stderr carries only the spinner. Asserts the regression `337b55e` introduced is undone and the canonical sample at `docs/architecture.md:34` reads true.
 
 ### 9. Roadmap completion marker present
 


### PR DESCRIPTION
## Summary

Spec scaffold for **Phase 6: JSON formatter (`--format json`)** from `specs/roadmap.md`.

This PR adds **spec files only** — no code changes. Implementation follows in a separate PR once this spec is approved.

### Scope

Reintroduce machine-readable JSON output to the npm CLI through a new `--format <pretty|json>` flag. `pretty` stays the unconditional default; `--format json` produces engine-verbatim JSON, pretty-printed with 2-space indentation, filtered by the existing `--detail` level so a CI integrator can pipe `score … --format json | jq .summary.score` and gate on the result. The phase also restores the `--format json --detail diagnostics` footer hint that commit `337b55e` removed from the pretty formatter's `appendHint()`.

### Out of Scope

- TTY-aware default switching (roadmap says `pretty` is the unconditional default — architecture doc updated in same PR to match).
- `--json` convenience alias and `-f` short flag (deferred; doc updated to mark deferred).
- `-o FILE`, `--quiet`, `--verbose`, `--format markdown`, `--format html` (Phases 8 / 9 / 7 / Later / 14).
- `--min-score N` and any new exit code.
- Container-side / Dockerfile changes (Phase 6 is host-CLI-only).
- JSON schema validation; full byte-snapshot tests.

### Key decisions

- **Roadmap-literal default** — `pretty` is unconditional; no TTY-aware fallback. Architecture doc §5 dialed back in same PR to match.
- **Restore all three `appendHint()` lines** — symmetric inverse of commit `337b55e` (SUMMARY / DIMENSIONS / SIGNALS branches; `Full report:` on first two, `Full evidence:` on SIGNALS).
- **`Format` lives in its own module** — `packages/cli/src/format.ts` mirrors `detail.ts` shape (`as const` record + derived type + readonly array + `isFormat()` narrower).
- **JSON formatter is a single TS module under `packages/cli/src/formatters/`** — co-located with `pretty.ts`; the architecture decision rule at `docs/architecture.md:151` reserves separate packages for formatters with toolchain weight (HTML / Phase 14).
- **Filtering happens once, upstream of every formatter** — `formatJson` consumes the same already-filtered `ScorecardResult` that `formatPretty` does; no re-filtering in the formatter.

## Files

- `specs/2026-05-26-json-formatter/requirements.md`
- `specs/2026-05-26-json-formatter/plan.md`
- `specs/2026-05-26-json-formatter/validation.md`

## Review guidance

Reviewers should verify:
- The phase goal is captured faithfully (see `specs/roadmap.md` Phase 6).
- Scope, constraints, and decisions match intent — especially the roadmap-literal-vs-architecture-canonical reconciliation around the default and the `--json` alias.
- The plan's task groups are appropriately granular (skeleton-first, 7 groups including a dedicated Verify group).
- Validation gates are realistic — CI green on all 7 jobs, e2e against real Docker, smoke recipes verified, doc sync gates included.

Refs: `specs/roadmap.md` Phase 6.