### PR TITLE
ci(codeql): add codeql workflow for js/ts and python

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,41 @@
+name: "CodeQL"
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '16 4 * * 2'
+
+concurrency:
+  group: codeql-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ 'javascript-typescript', 'python' ]
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v6
+
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v4
+      with:
+        languages: ${{ matrix.language }}
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v4
+      with:
+        category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/codeql.yml` running CodeQL against both source trees in a language matrix: `javascript-typescript` (covers `packages/**/*.ts`) and `python` (covers `docker/src/**/*.py`).
- Triggers on PRs targeting `main`, pushes to `main`, and a weekly cron (`16 4 * * 2`) so CVEs disclosed against our dependencies surface even when no code lands.
- Mirrors `ci.yml` style: unquoted `branches: [main]`, single-digit cron hour, and a `concurrency` group (`codeql-\${{ github.ref }}`) that cancels in-progress runs on non-`main` refs but lets `main` runs through.
- Container-image scanning (Trivy / Grype / Hadolint against the GHCR artifact) is intentionally out of scope here and will be addressed in a follow-up.

## Test plan

- [x] CI passes — both matrix legs (`Analyze (javascript-typescript)` and `Analyze (python)`) succeed on this PR.
- [x] CodeQL findings, if any, appear in the Security tab and not as PR-blocking failures.
- [ ] Subsequent pushes to this branch cancel the previous in-flight CodeQL run (concurrency group works).