### PR TITLE
chore(docker): clear trivy alerts in runtime image

### DIFF
--- a/.github/workflows/docker-security.yml
+++ b/.github/workflows/docker-security.yml
@@ -39,6 +39,10 @@ jobs:
 
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@v0.36.0
+        env:
+          # SARIF output ignores the `severity:` input; gate via env so the
+          # security tab stays aligned with the CRITICAL/HIGH policy below.
+          TRIVY_SEVERITY: 'CRITICAL,HIGH'
         with:
           image-ref: 'jentic-api-scorecard:security-scan'
           format: 'sarif'

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -21,6 +21,13 @@ COPY --from=node:24-slim /usr/local/bin/node /usr/local/bin/node
 COPY --from=node:24-slim /usr/local/lib/node_modules /usr/local/lib/node_modules
 RUN ln -s /usr/local/lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm && \
     ln -s /usr/local/lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx && \
+    # Refresh bundled npm so its transitive deps (ip-address, brace-expansion, …) carry current fixes.
+    npm install -g npm@latest && \
+    npm cache clean --force && \
+    # System pip is unused at runtime — venv ships via uv. Remove it to drop pip CVEs from the scan.
+    rm -rf /usr/local/lib/python3.12/site-packages/pip \
+           /usr/local/lib/python3.12/site-packages/pip-*.dist-info \
+           /usr/local/bin/pip /usr/local/bin/pip3 /usr/local/bin/pip3.12 && \
     groupadd --gid 10001 runner && \
     useradd --uid 10001 --gid 10001 --home-dir /home/runner \
             --create-home --shell /usr/sbin/nologin runner && \


### PR DESCRIPTION
## Summary

Six open Trivy alerts on the security tab — all on tooling shipped by the runtime image's base layers, not on direct deps:

| # | Package | Severity | Fixed in |
|---|---|---|---|
| 6 | `pip 25.0.1` (CVE-2026-1703) | LOW | pip 26.0 |
| 5 | `pip 25.0.1` (CVE-2026-6357) | MEDIUM | pip 26.1 |
| 4 | `pip 25.0.1` (CVE-2026-3219) | MEDIUM | pip 26.1 |
| 3 | `pip 25.0.1` (CVE-2025-8869) | MEDIUM | pip 25.3 |
| 2 | `ip-address 10.1.0` (CVE-2026-42338) | MEDIUM | 10.1.1 |
| 1 | `brace-expansion 5.0.5` (CVE-2026-45149) | MEDIUM | 5.0.6 |

None are reachable in our build path — the runtime image never invokes pip (the venv ships pre-built via `uv sync` in the builder stage), and the npm-internal libs are only consumed by npm itself for its own glob/IP handling. Still, the alerts are noise on the security tab, and dropping pip shrinks the attack surface for free.

Two atomic commits:

- **`chore(docker): drop unused pip and refresh npm in image`** — removes `pip` site-packages dirs and shims (`/usr/local/bin/pip*`), then `npm install -g npm@latest` so the bundled npm tree pulls current `ip-address >= 10.1.1` and `brace-expansion >= 5.0.6`. Verified with `trivy image --ignore-unfixed`: zero fixable vulnerabilities at any severity.
- **`ci(docker-security): filter SARIF to CRITICAL/HIGH`** — `aquasecurity/trivy-action`'s `severity:` input only gates table output; SARIF carries every severity and Code Scanning surfaces all of it. Pass `TRIVY_SEVERITY` via env so SARIF honours the same CRITICAL/HIGH gate the workflow already declares.

The six existing alerts will close automatically on the next scheduled scan (or sooner — the workflow runs on push to `main`).

## Test plan

- [x] `docker build ./docker` succeeds (npm self-update + pip purge + cache-warm score).
- [x] `docker run … sh -c 'command -v pip'` → empty (shims removed).
- [x] `docker run … node -e require('ip-address').version` → `10.2.0`; `brace-expansion` → `5.0.6`.
- [x] `trivy image --ignore-unfixed --vuln-type os,library` → zero findings at any severity.
- [x] `cd docker && uv run poe test` → 25 passed.
- [x] `IMAGE=jentic-api-scorecard:trivy-fix-test uv run poe test tests/test_integration.py` → 9 passed (gate, exit codes, score, JSON output all behave end-to-end inside the hardened image).

Refs alerts 1–6 on https://github.com/jentic/jentic-api-scorecard/security/code-scanning