### PR TITLE
ci(dependabot-merge): add auto-merge workflow for non-major updates

### DIFF
--- a/.github/workflows/dependabot-merge.yml
+++ b/.github/workflows/dependabot-merge.yml
@@ -1,0 +1,55 @@
+name: Dependabot auto-merge
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+    branches: [main]
+
+concurrency:
+  group: dependabot-merge-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+# GITHUB_TOKEN needs no permissions: every API call in this workflow
+# goes through the GitHub App token minted below.
+permissions: {}
+
+jobs:
+  dependabot-auto-merge:
+    name: Auto-merge non-major updates
+    runs-on: ubuntu-latest
+    # Use pull_request.user.login (PR author, immutable) rather than
+    # github.actor — actor flips to whoever pushed the latest commit on
+    # `synchronize`, which would skip this job if a maintainer pushed a
+    # fixup to the dependabot branch.
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    steps:
+      # Mint an App token instead of relying on GITHUB_TOKEN: branch
+      # protection on `main` requires an approving review from a non-author,
+      # which GITHUB_TOKEN can't satisfy when the workflow is triggered by
+      # the dependabot[bot] PR. The App acts as a distinct identity.
+      - name: Create GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.ARAZZO_BUILDER_APP_ID }}
+          private-key: ${{ secrets.ARAZZO_BUILDER_PRIVATE_KEY }}
+
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v3
+        with:
+          github-token: "${{ steps.app-token.outputs.token }}"
+
+      - name: Approve PR
+        if: steps.metadata.outputs.update-type != 'version-update:semver-major'
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+
+      - name: Enable auto-merge for non-major updates
+        if: steps.metadata.outputs.update-type != 'version-update:semver-major'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/dependabot-merge.yml` to auto-approve and enable auto-merge on Dependabot PRs whose `update-type` is not `version-update:semver-major`.
- Authenticates via a GitHub App token (`ARAZZO_BUILDER_APP_ID`) so the approving review counts as a non-author reviewer under branch protection on `main`. Workflow-level `GITHUB_TOKEN` permissions are `{}` — every write goes through the App token.
- Filters by `github.event.pull_request.user.login == 'dependabot[bot]'` (immutable PR author) rather than `github.actor`, so a maintainer pushing a fixup to a Dependabot branch doesn't skip the job on `synchronize`.
- Adds a concurrency group consistent with the other workflows in `.github/workflows/`.

## Operational prerequisites

For this workflow to actually merge PRs, the repository must have:

- *Allow auto-merge* enabled in repo settings.
- Branch protection on `main` with required status checks — otherwise `gh pr merge --auto` merges immediately on approval.
- A `.github/dependabot.yml` config (planned in a follow-up PR) so Dependabot opens PRs at all.
- Confirmation that the squash-merge commit message satisfies DCO (Dependabot's per-commit messages are not signed off).

## Test plan

- [ ] Workflow YAML parses (validated by GitHub on push).
- [ ] After `.github/dependabot.yml` lands, watch the first Dependabot PR: confirm the job runs, the App token mints, the PR is approved, and auto-merge is enabled.
- [ ] Verify a `version-update:semver-major` PR is left open without approval.