### PR TITLE
ci(dependabot): add docker ecosystem and fix package paths

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,42 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: "daily"
+      time: "23:00"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    open-pull-requests-limit: 3
+
+  - package-ecosystem: uv
+    directory: "/docker"
+    schedule:
+      interval: "daily"
+      time: "23:00"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    open-pull-requests-limit: 3
+
+  - package-ecosystem: docker
+    directory: "/docker"
+    schedule:
+      interval: "daily"
+      time: "23:00"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    open-pull-requests-limit: 3
+
+  - package-ecosystem: "github-actions"
+    target-branch: "main"
+    directory: "/"
+    schedule:
+      interval: "daily"
+      time: "23:00"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    open-pull-requests-limit: 3


### PR DESCRIPTION
## Summary

- Add `docker` ecosystem at `/docker` so `Dockerfile` FROM pins (`python:3.12-slim`, `node:24-slim`, `ghcr.io/astral-sh/uv`) get the same daily Dependabot cadence as the other ecosystems.
- Fix the `npm` entry: `/ui` → `/`. There is no `/ui` directory; the npm workspaces root with `package-lock.json` is `/`. The previous path silently no-op'd.
- Fix the `uv` entry: `/` → `/docker`. `pyproject.toml` and `uv.lock` live under `docker/`. Same silent-no-op problem.
- `github-actions` entry unchanged.

## Test plan

- [x] CI passes (no workflow changes; this is config-only).
- [x] After merge, confirm Dependabot opens PRs against the correct directories on the next daily run (npm at root, uv + docker under `/docker`).