### PR TITLE
docs: per-command CLI reference + exit-code drift fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,63 @@ export JENTIC_API_KEY=mvp-preview
 This is a documented public placeholder for the alpha preview — not a secret. Real key issuance
 arrives in a future release.
 
+## CLI reference
+
+```
+jentic-api-scorecard [-V | --version] [-h | --help]
+jentic-api-scorecard <command> [options]
+```
+
+### Commands
+
+| Command | Description |
+|---|---|
+| [`score <input>`](#score) | Score an OpenAPI document by URL or local file path. |
+
+### `score`
+
+Score an OpenAPI document by URL or local file path.
+
+```
+jentic-api-scorecard score <input> [options]
+```
+
+#### Arguments
+
+| Name | Description |
+|---|---|
+| `<input>` | `https://` URL or local file path to an OpenAPI document. Required. |
+
+#### Options
+
+| Flag | Default | Choices | Description |
+|---|---|---|---|
+| `--with-llm` | off | — | Enable LLM-backed analysis. Requires an LLM provider (see [LLM analysis](#llm-analysis)). |
+| `-d, --detail <level>` | `dimensions` | `summary`, `dimensions`, `signals`, `diagnostics` | Payload depth (see [Control output depth](#control-output-depth)). |
+| `-f, --format <fmt>` | `pretty` | `pretty`, `json` | Output encoding (see [Machine-readable output](#machine-readable-output)). |
+| `-o, --output <file>` | stdout | — | Write the formatted report to `<file>`. The spinner stays on stderr. |
+| `-q, --quiet` | off | — | Suppress the stderr spinner regardless of TTY. |
+| `-h, --help` | — | — | Show usage for `score`. |
+
+#### Environment
+
+| Variable | When | Purpose |
+|---|---|---|
+| `JENTIC_API_KEY` | URLs outside OAK and local files | Set to `mvp-preview` during alpha (see [Anonymous vs keyed access](#anonymous-vs-keyed-access)). |
+| LLM provider + routing vars | With `--with-llm` | The CLI auto-detects credentials (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GEMINI_API_KEY`, AWS keys) and routing (`LLM_PROVIDER`, `LIGHT_LLM_PROVIDER`, `LLM_MODEL`, `LLM_LIGHT_MODEL`, `*_API_URL`, `LLM_MAX_TOKENS`) and forwards them to the container; loopback URLs are rewritten so a host-side Ollama is reachable. Full reference: [LLM Signals guide](https://github.com/jentic/jentic-api-scorecard/blob/main/docs/llm-signals.md). |
+
+#### Exit codes
+
+| Code | Meaning |
+|---|---|
+| 0 | Scoring completed (regardless of the score itself). |
+| 1 | Generic error (bad input, bundling failure, unexpected container failure). |
+| 2 | Auth: `JENTIC_API_KEY` is set to an unrecognized value, or a local file / stdin input was used without the key set. |
+| 3 | Anonymous gate rejected: URL outside the OAK allowlist and no key set. |
+| 4 | Docker not installed or daemon unreachable. |
+| 5 | Spec fetch or parse failure. |
+| 6 | Engine invocation failure. |
+
 ## Prefer a browser?
 
 [**jentic.com/scorecard**](https://jentic.com/scorecard) offers the same scoring in a web UI —

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -352,25 +352,28 @@ stdout stays clean so `--format json | jq` works without filtering.
 |---|---|
 | 0 | Scoring completed (regardless of the score itself). |
 | 1 | Generic error (input not found, bundling failed, container failed, etc.). |
-| 2 | Auth required: key missing for an input that needs one. Message includes signup link. |
+| 2 | Auth: `JENTIC_API_KEY` is set to an unrecognized value, or a local file / stdin input was used without the key set. Message points at `mvp-preview`. |
 | 3 | Anonymous gate rejected: URL not in jentic-public-apis allowlist. Message includes allowlist index URL. |
 | 4 | Docker not installed or daemon unreachable. Message includes install hint. |
+| 5 | Spec fetch or parse failure (engine exit code 2, passed through). |
+| 6 | Engine invocation failure (any other non-zero engine exit, passed through). |
 
 ### Error UX examples
 
 ```
 $ npx @jentic/api-scorecard-cli score ./local.yaml         # no key
-error: scoring local files requires a Jentic API key.
-  Get one at https://jentic.com/signup, then:
-    export JENTIC_API_KEY=...
+error: scoring from stdin requires a Jentic API key.
+  Set the MVP preview key, then retry:
+    export JENTIC_API_KEY=mvp-preview
 exit 2
 
 $ npx @jentic/api-scorecard-cli score https://example.com/openapi.yaml   # no key
-error: anonymous scoring is restricted to specs hosted at:
+error: anonymous scoring is restricted to OpenAPI documents hosted at:
   https://raw.githubusercontent.com/jentic/jentic-public-apis/refs/heads/main/apis/openapi/
-  Browse available specs:
+  Browse available documents:
     https://github.com/jentic/jentic-public-apis/tree/main/apis/openapi
-  Or sign up: https://jentic.com/signup
+  Or set the MVP preview key:
+    export JENTIC_API_KEY=mvp-preview
 exit 3
 
 $ npx @jentic/api-scorecard-cli score ./openapi.yaml      # docker not in PATH
@@ -521,7 +524,7 @@ The runner always invokes the engine with `--format json --include-diagnostics -
 | 5 | Spec fetch / parse failure. |
 | 6 | Engine invocation failure. |
 
-CLI translates these to its own exit codes plus user-friendly messages.
+The CLI passes these through verbatim and adds its own codes for host-side concerns (4 = Docker missing). The user-facing exit-code contract is §5.
 
 ## 7. Result JSON schema
 
@@ -685,7 +688,7 @@ When the implementation lands, these acceptance checks validate the architecture
 **Anonymous / gate path:**
 - `npx @jentic/api-scorecard-cli score <jentic-public-apis-url>` (no key) → success, scorecard printed.
 - `npx @jentic/api-scorecard-cli score https://example.com/openapi.yaml` (no key) → exit 3 with allowlist-index hint.
-- `npx @jentic/api-scorecard-cli score ./local.yaml` (no key) → exit 2 with signup hint.
+- `npx @jentic/api-scorecard-cli score ./local.yaml` (no key) → exit 2 with `mvp-preview` hint.
 
 **MVP key scheme:**
 - `JENTIC_API_KEY=garbage npx @jentic/api-scorecard-cli score ./local.yaml` → exit 2 with placeholder-key error message.


### PR DESCRIPTION
## Summary

- Adds a per-command **CLI reference** section to the README (synopsis, commands index, `score` section with Arguments / Options / Environment / Exit codes). Structure mirrors `gh`, `kubectl`, `docker`, `npm`; scales when new commands land.
- Aligns `docs/architecture.md` §5 exit-code contract with the runner: adds codes 5 and 6 (passed through verbatim from the container), corrects code 2's wording, fixes the §5 error-UX examples that had drifted from the messages in `docker/src/jentic_scorecard_runner/gate.py`, drops the inaccurate "CLI translates these" line in §6, and updates one stale "signup hint" callout in §11.

## Test plan

- [ ] `README.md` renders with anchors resolving (`#score`, `#control-output-depth`, `#machine-readable-output`, `#llm-analysis`, `#anonymous-vs-keyed-access`).
- [ ] Exit-code table values match `packages/cli/src/exit-codes.ts` and the gate behavior in `docker/src/jentic_scorecard_runner/gate.py`.
- [ ] Architecture §5 example messages match what `gate.py` actually prints.

Docs-only, no runtime impact.