### PR TITLE
fix(cli): show '✔ Scoring done' above the report

### DIFF
--- a/packages/cli/src/commands/score.ts
+++ b/packages/cli/src/commands/score.ts
@@ -220,6 +220,8 @@ export async function runScore(input: string, options: ScoreOptions): Promise<nu
   const output =
     format === Format.JSON ? formatJson(filtered) : formatPretty(filtered, input, { detail });
 
+  const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
+
   if (options.output !== undefined) {
     try {
       writeReport(output, options.output, format);
@@ -229,10 +231,8 @@ export async function runScore(input: string, options: ScoreOptions): Promise<nu
       process.stderr.write(`error: ${message}\n`);
       return ExitCode.GENERIC_ERROR;
     }
-    const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
     done(`Scoring done in ${elapsed}s`);
   } else {
-    const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
     done(`Scoring done in ${elapsed}s`);
     process.stdout.write(output);
   }

--- a/packages/cli/src/commands/score.ts
+++ b/packages/cli/src/commands/score.ts
@@ -220,18 +220,20 @@ export async function runScore(input: string, options: ScoreOptions): Promise<nu
   const output =
     format === Format.JSON ? formatJson(filtered) : formatPretty(filtered, input, { detail });
 
-  const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
-  done(`Scoring done in ${elapsed}s`);
-
   if (options.output !== undefined) {
     try {
       writeReport(output, options.output, format);
     } catch (err) {
+      clearSpinner();
       const message = err instanceof Error ? err.message : String(err);
       process.stderr.write(`error: ${message}\n`);
       return ExitCode.GENERIC_ERROR;
     }
+    const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
+    done(`Scoring done in ${elapsed}s`);
   } else {
+    const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
+    done(`Scoring done in ${elapsed}s`);
     process.stdout.write(output);
   }
 

--- a/packages/cli/src/commands/score.ts
+++ b/packages/cli/src/commands/score.ts
@@ -220,11 +220,13 @@ export async function runScore(input: string, options: ScoreOptions): Promise<nu
   const output =
     format === Format.JSON ? formatJson(filtered) : formatPretty(filtered, input, { detail });
 
+  const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
+  done(`Scoring done in ${elapsed}s`);
+
   if (options.output !== undefined) {
     try {
       writeReport(output, options.output, format);
     } catch (err) {
-      clearSpinner();
       const message = err instanceof Error ? err.message : String(err);
       process.stderr.write(`error: ${message}\n`);
       return ExitCode.GENERIC_ERROR;
@@ -232,9 +234,6 @@ export async function runScore(input: string, options: ScoreOptions): Promise<nu
   } else {
     process.stdout.write(output);
   }
-
-  const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
-  done(`Scoring done in ${elapsed}s`);
 
   return ExitCode.SUCCESS;
 }

--- a/packages/cli/test/e2e/score.e2e.test.ts
+++ b/packages/cli/test/e2e/score.e2e.test.ts
@@ -59,6 +59,35 @@ describe('score command — e2e against docker', function () {
     });
   });
 
+  describe('stream interleaving (regression: #84)', function () {
+    let exitCode: number | null;
+    let merged: string;
+
+    before(function () {
+      // Merge stderr into stdout so we can observe the actual emission
+      // order users see on a TTY.
+      const result = spawnSync('bash', ['-c', `node "${CLI_BIN}" score "${SAMPLE_SPEC}" 2>&1`], {
+        env: { ...process.env, JENTIC_API_KEY: 'mvp-preview' },
+        encoding: 'utf8',
+        timeout: E2E_TIMEOUT_MS,
+      });
+      exitCode = result.status;
+      merged = strip(result.stdout ?? '');
+    });
+
+    it('exits 0', function () {
+      expect(exitCode).to.equal(0);
+    });
+
+    it("emits 'Scoring done in …' before the report headline", function () {
+      const doneIdx = merged.indexOf('Scoring done in');
+      const reportIdx = merged.indexOf('API Readiness Scorecard');
+      expect(doneIdx, 'spinner success line missing').to.be.greaterThan(-1);
+      expect(reportIdx, 'report headline missing').to.be.greaterThan(-1);
+      expect(doneIdx).to.be.lessThan(reportIdx);
+    });
+  });
+
   describe('--detail summary', function () {
     let exitCode: number | null;
     let stdout: string;

--- a/packages/cli/test/e2e/score.e2e.test.ts
+++ b/packages/cli/test/e2e/score.e2e.test.ts
@@ -65,9 +65,16 @@ describe('score command — e2e against docker', function () {
 
     before(function () {
       // Merge stderr into stdout so we can observe the actual emission
-      // order users see on a TTY.
-      const result = spawnSync('bash', ['-c', `node "${CLI_BIN}" score "${SAMPLE_SPEC}" 2>&1`], {
-        env: { ...process.env, JENTIC_API_KEY: 'mvp-preview' },
+      // order users see on a TTY. Paths are passed via env to avoid any
+      // shell-interpolation hazard if the repo lives under a path that
+      // contains shell metacharacters.
+      const result = spawnSync('bash', ['-c', 'node "$CLI" score "$SPEC" 2>&1'], {
+        env: {
+          ...process.env,
+          JENTIC_API_KEY: 'mvp-preview',
+          CLI: CLI_BIN,
+          SPEC: SAMPLE_SPEC,
+        },
         encoding: 'utf8',
         timeout: E2E_TIMEOUT_MS,
       });
@@ -346,6 +353,9 @@ describe('score command — e2e against docker', function () {
       );
       expect(result.status).to.not.equal(0);
       expect(result.stderr).to.include('failed to write');
+      // Suppress success chrome on the failure path so the user does not
+      // see ✔ followed by an error.
+      expect(result.stderr).to.not.include('Scoring done in');
     } finally {
       rmSync(workDir, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary
- Move the `done()` call ahead of the report write so the spinner success line lands above the pretty report on a TTY (the pre-#52 ordering).
- Drop a redundant `clearSpinner()` in the `-o` write-failure branch — `done()` already finalized the spinner moments earlier.

## Why
When stdout (the report) and stderr (the spinner) share a TTY, they interleave in emission order. Writing the report first pushed `✔ Scoring done in Xs` to the bottom of the screen, visually trailing the report. Restoring the pre-#52 sequence puts the success chrome at the top, which is what the user reads first; the report stays as the last thing on screen.

## Test plan
- [x] `npm test -w @jentic/api-scorecard-cli` (unit suite, 103 passing)
- [x] `npm run lint -w @jentic/api-scorecard-cli`
- [x] Existing e2e (`packages/cli/test/e2e/score.e2e.test.ts`) covers `-o` already (asserts `Scoring done in` lands on stderr); CI will re-run it.
- [x] Manual TTY smoke: `JENTIC_API_KEY=mvp-preview node packages/cli/bin/jentic-api-scorecard.mjs score docker/.build/sample.yaml` — confirm `✔ Scoring done in Xs` renders above the scorecard.

Closes #84