### PR TITLE
refactor(gate): tighten validator client and dispatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ as the per-key usage / rate-limit accounting hit. If you exceed your quota the C
 code `7` and prints the `Retry-After` value.
 
 `JENTIC_API_KEY=mvp-preview` is honored as a deprecated free-pass during the alpha and prints
-a stderr warning; it is removed in a follow-up minor release.
+a `DEPRECATED:`-prefixed stderr warning; it is removed in a follow-up minor release.
 
 ## CLI reference
 

--- a/docker/src/jentic_scorecard_runner/gate.py
+++ b/docker/src/jentic_scorecard_runner/gate.py
@@ -16,6 +16,7 @@ Order of decisions in `check_gate`:
 import os
 import re
 import sys
+from typing import assert_never
 
 from jentic_scorecard_runner.exit_codes import ExitCode
 from jentic_scorecard_runner.usage import (
@@ -34,73 +35,67 @@ _ALLOWLIST_PATTERN = re.compile(
 )
 
 
-def _fail(code: ExitCode, message: str) -> ExitCode:
-    print(message, file=sys.stderr)
-    return code
-
-
-def _warn(message: str) -> None:
-    print(message, file=sys.stderr)
-
-
 def check_gate(url: str | None) -> ExitCode:
     """Returns SUCCESS if the request is allowed, or a non-zero exit code."""
     if url is not None and _ALLOWLIST_PATTERN.match(url):
         return ExitCode.SUCCESS
 
-    key = os.environ.get("JENTIC_API_KEY", "")
+    key = os.environ.get("JENTIC_API_KEY", "").strip()
 
     if not key:
         if url is None:
-            return _fail(
-                ExitCode.AUTH_INVALID_KEY,
+            print(
                 "error: scoring from stdin requires a Jentic API key.\n"
                 "  Sign up for a key at https://jentic.com/signup and retry:\n"
                 "    export JENTIC_API_KEY=<your-key>",
+                file=sys.stderr,
             )
-        return _fail(
-            ExitCode.GATE_REJECTED,
+            return ExitCode.AUTH_INVALID_KEY
+        print(
             "error: anonymous scoring is restricted to OpenAPI documents hosted at:\n"
             "  https://raw.githubusercontent.com/jentic/jentic-public-apis/refs/heads/main/apis/openapi/\n"
             "  Browse available documents:\n"
             "    https://github.com/jentic/jentic-public-apis/tree/main/apis/openapi\n"
             "  Or sign up for a key:\n"
             "    https://jentic.com/signup",
+            file=sys.stderr,
         )
+        return ExitCode.GATE_REJECTED
 
     if key == _MVP_KEY:
-        _warn(
-            "warning: JENTIC_API_KEY=mvp-preview is deprecated; "
-            "sign up at https://jentic.com/signup for a real key."
+        print(
+            "DEPRECATED: JENTIC_API_KEY=mvp-preview will stop working in a future release; "
+            "sign up at https://jentic.com/signup for a real key.",
+            file=sys.stderr,
         )
         return ExitCode.SUCCESS
 
     result = check_usage(key)
 
-    if isinstance(result, UsageAllowed):
-        return ExitCode.SUCCESS
-
-    if isinstance(result, UsageRateLimited):
-        message = f"error: rate limit reached for your Jentic API key.\n  {result.detail}"
-        if result.retry_after is not None:
-            message += f"\n  Retry-After: {result.retry_after}"
-        message += "\n  Manage your usage at https://jentic.com/account"
-        return _fail(ExitCode.RATE_LIMITED, message)
-
-    if isinstance(result, UsageInvalidKey):
-        return _fail(
-            ExitCode.AUTH_INVALID_KEY,
-            "error: this key is not recognized.\n"
-            f"  {result.detail}\n"
-            "  Check or regenerate your key at https://jentic.com/account",
-        )
-
-    if isinstance(result, UsageUnverifiable):
-        _warn(
-            f"warning: could not reach api.jentic.com to validate key ({result.reason}); "
-            "proceeding."
-        )
-        return ExitCode.SUCCESS
-
-    _warn(f"warning: unexpected validator result type {type(result).__name__}; proceeding.")
-    return ExitCode.SUCCESS
+    match result:
+        case UsageAllowed():
+            return ExitCode.SUCCESS
+        case UsageRateLimited(detail=detail, retry_after=retry_after):
+            message = f"error: rate limit reached for your Jentic API key.\n  {detail}"
+            if retry_after is not None:
+                message += f"\n  Retry-After: {retry_after}"
+            message += "\n  Manage your usage at https://jentic.com/account"
+            print(message, file=sys.stderr)
+            return ExitCode.RATE_LIMITED
+        case UsageInvalidKey(detail=detail):
+            print(
+                "error: this key is not recognized.\n"
+                f"  {detail}\n"
+                "  Check or regenerate your key at https://jentic.com/account",
+                file=sys.stderr,
+            )
+            return ExitCode.AUTH_INVALID_KEY
+        case UsageUnverifiable(reason=reason):
+            print(
+                f"warning: could not reach api.jentic.com to validate key ({reason}); "
+                "proceeding with scoring.",
+                file=sys.stderr,
+            )
+            return ExitCode.SUCCESS
+        case _:
+            assert_never(result)

--- a/docker/src/jentic_scorecard_runner/usage.py
+++ b/docker/src/jentic_scorecard_runner/usage.py
@@ -6,7 +6,8 @@ and maps the response to a `UsageResult` variant:
 - 2xx → UsageAllowed (valid, within quota)
 - 429 → UsageRateLimited (valid, over quota)
 - 401 / 403 → UsageInvalidKey (unknown key)
-- network error / 5xx / malformed → UsageUnverifiable (caller fails open)
+- anything else (3xx, unexpected 4xx, 5xx, network error, timeout,
+  malformed body) → UsageUnverifiable (caller fails open)
 
 The function never raises.
 """

--- a/docker/src/jentic_scorecard_runner/usage.py
+++ b/docker/src/jentic_scorecard_runner/usage.py
@@ -1,16 +1,16 @@
 """Live key validation against the Jentic usage endpoint.
 
-`check_usage` POSTs to `/api/v1/usage/api-scoring` with the user's API key. A
-2xx response means the key is valid and within quota; 429 means the key is
-valid but the user is over quota; 401/403 means the key is unknown.
-Anything else (network error, 5xx, malformed body) is reported as
-unverifiable so the caller can fail open.
+`check_usage` POSTs to `/api/v1/usage/api-scoring` with the user's API key
+and maps the response to a `UsageResult` variant:
 
-The function never raises — it always returns one of the four
-`UsageResult` variants below.
+- 2xx → UsageAllowed (valid, within quota)
+- 429 → UsageRateLimited (valid, over quota)
+- 401 / 403 → UsageInvalidKey (unknown key)
+- network error / 5xx / malformed → UsageUnverifiable (caller fails open)
+
+The function never raises.
 """
 
-import json
 import os
 from dataclasses import dataclass
 
@@ -21,6 +21,7 @@ _DEFAULT_BASE_URL = "https://api.jentic.com"
 _USAGE_PATH = "/api/v1/usage/api-scoring"
 _CONNECT_TIMEOUT_SECONDS = 5
 _READ_TIMEOUT_SECONDS = 10
+_USER_AGENT = "jentic-api-scorecard-runner"
 
 
 @dataclass(frozen=True)
@@ -50,13 +51,18 @@ UsageResult = UsageAllowed | UsageRateLimited | UsageInvalidKey | UsageUnverifia
 def check_usage(key: str) -> UsageResult:
     base_url = os.environ.get("JENTIC_API_BASE_URL", _DEFAULT_BASE_URL).rstrip("/")
     url = f"{base_url}{_USAGE_PATH}"
-    headers = {"Accept": "application/json", "X-Jentic-API-Key": key}
+    headers = {
+        "Accept": "application/json",
+        "User-Agent": _USER_AGENT,
+        "X-Jentic-API-Key": key,
+    }
 
     try:
         response = requests.post(
             url,
             headers=headers,
             timeout=(_CONNECT_TIMEOUT_SECONDS, _READ_TIMEOUT_SECONDS),
+            allow_redirects=False,
         )
     except requests.RequestException as exc:
         return UsageUnverifiable(reason=str(exc) or exc.__class__.__name__)
@@ -66,23 +72,25 @@ def check_usage(key: str) -> UsageResult:
         return UsageAllowed()
 
     if status == 429:
-        detail = _problem_detail(response) or "rate limit reached"
+        detail = _problem_detail(response) or "Server provided no detail."
         retry_after = response.headers.get("Retry-After")
         return UsageRateLimited(detail=detail, retry_after=retry_after)
 
     if status in (401, 403):
-        detail = _problem_detail(response) or "key not recognized"
+        detail = _problem_detail(response) or "Server provided no detail."
         return UsageInvalidKey(detail=detail)
 
-    return UsageUnverifiable(reason=f"validation endpoint returned HTTP {status}")
+    return UsageUnverifiable(reason=f"HTTP {status}")
 
 
 def _problem_detail(response: requests.Response) -> str | None:
     try:
-        body = json.loads(response.content)
-    except (ValueError, TypeError):
+        body = response.json()
+    except ValueError:
         return None
     if not isinstance(body, dict):
         return None
     detail = body.get("detail")
-    return detail if isinstance(detail, str) and detail else None
+    if isinstance(detail, str) and detail:
+        return detail
+    return None

--- a/docker/tests/test_gate.py
+++ b/docker/tests/test_gate.py
@@ -79,13 +79,13 @@ class TestMvpDeprecation:
         monkeypatch.setenv("JENTIC_API_KEY", "mvp-preview")
         assert check_gate(url="https://example.com/openapi.yaml") == ExitCode.SUCCESS
         err = capsys.readouterr().err
-        assert "deprecated" in err
+        assert "DEPRECATED:" in err
         assert "jentic.com/signup" in err
 
     def test_mvp_key_allows_stdin_with_warning(self, monkeypatch, capsys):
         monkeypatch.setenv("JENTIC_API_KEY", "mvp-preview")
         assert check_gate(url=None) == ExitCode.SUCCESS
-        assert "deprecated" in capsys.readouterr().err
+        assert "DEPRECATED:" in capsys.readouterr().err
 
     def test_mvp_key_does_not_call_validator(self, monkeypatch, base_url):
         monkeypatch.setenv("JENTIC_API_KEY", "mvp-preview")
@@ -104,6 +104,26 @@ class TestRealKeyValidation:
         monkeypatch.setenv("JENTIC_API_KEY", "real-key")
         assert check_gate(url=None) == ExitCode.SUCCESS
 
+    def test_allowed_when_200_body_is_empty(self, base_url, monkeypatch):
+        base_url.expect_request(_USAGE_PATH, method="POST").respond_with_data("", status=200)
+        monkeypatch.setenv("JENTIC_API_KEY", "real-key")
+        assert check_gate(url=None) == ExitCode.SUCCESS
+
+    def test_allowed_when_200_body_is_non_dict(self, base_url, monkeypatch):
+        base_url.expect_request(_USAGE_PATH, method="POST").respond_with_data(
+            "[1, 2, 3]", status=200, content_type="application/json"
+        )
+        monkeypatch.setenv("JENTIC_API_KEY", "real-key")
+        assert check_gate(url=None) == ExitCode.SUCCESS
+
+    def test_post_has_no_request_body(self, base_url, monkeypatch):
+        base_url.expect_request(_USAGE_PATH, method="POST").respond_with_data("", status=204)
+        monkeypatch.setenv("JENTIC_API_KEY", "real-key")
+        assert check_gate(url=None) == ExitCode.SUCCESS
+        assert len(base_url.log) == 1
+        request, _ = base_url.log[0]
+        assert request.data == b""
+
     def test_forwards_api_key_header(self, base_url, monkeypatch):
         base_url.expect_request(
             _USAGE_PATH,
@@ -111,6 +131,24 @@ class TestRealKeyValidation:
             headers={"X-Jentic-API-Key": "real-key"},
         ).respond_with_data("", status=204)
         monkeypatch.setenv("JENTIC_API_KEY", "real-key")
+        assert check_gate(url=None) == ExitCode.SUCCESS
+
+    def test_forwards_user_agent_header(self, base_url, monkeypatch):
+        base_url.expect_request(
+            _USAGE_PATH,
+            method="POST",
+            headers={"User-Agent": "jentic-api-scorecard-runner"},
+        ).respond_with_data("", status=204)
+        monkeypatch.setenv("JENTIC_API_KEY", "real-key")
+        assert check_gate(url=None) == ExitCode.SUCCESS
+
+    def test_strips_whitespace_from_key(self, base_url, monkeypatch):
+        base_url.expect_request(
+            _USAGE_PATH,
+            method="POST",
+            headers={"X-Jentic-API-Key": "real-key"},
+        ).respond_with_data("", status=204)
+        monkeypatch.setenv("JENTIC_API_KEY", "  real-key\n")
         assert check_gate(url=None) == ExitCode.SUCCESS
 
     def test_rate_limited_returns_exit_7(self, base_url, monkeypatch, capsys):
@@ -182,6 +220,26 @@ class TestFailOpen:
         err = capsys.readouterr().err
         assert "could not reach api.jentic.com" in err
         assert "HTTP 503" in err
+
+    def test_unexpected_4xx_fails_open(self, base_url, monkeypatch, capsys):
+        base_url.expect_request(_USAGE_PATH, method="POST").respond_with_data(
+            "bad request", status=400
+        )
+        monkeypatch.setenv("JENTIC_API_KEY", "real-key")
+        assert check_gate(url=None) == ExitCode.SUCCESS
+        err = capsys.readouterr().err
+        assert "could not reach api.jentic.com" in err
+        assert "HTTP 400" in err
+
+    def test_3xx_redirect_not_followed_fails_open(self, base_url, monkeypatch, capsys):
+        base_url.expect_request(_USAGE_PATH, method="POST").respond_with_data(
+            "", status=302, headers={"Location": "https://evil.example.com/"}
+        )
+        monkeypatch.setenv("JENTIC_API_KEY", "real-key")
+        assert check_gate(url=None) == ExitCode.SUCCESS
+        err = capsys.readouterr().err
+        assert "could not reach api.jentic.com" in err
+        assert "HTTP 302" in err
 
     def test_unreachable_host_fails_open(self, monkeypatch, capsys):
         # Port 1 on localhost reliably refuses connections in CI.

--- a/docker/tests/test_integration.py
+++ b/docker/tests/test_integration.py
@@ -73,7 +73,7 @@ class TestMVPKeyScheme:
     def test_mvp_key_url_mode(self):
         r = docker_run("score", "--url", PETSTORE_URL, env={"JENTIC_API_KEY": "mvp-preview"})
         assert r.returncode == ExitCode.SUCCESS
-        assert "deprecated" in r.stderr
+        assert "DEPRECATED:" in r.stderr
         data = json.loads(r.stdout)
         assert "summary" in data
         assert data["summary"]["score"] > 0

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -204,7 +204,7 @@ The container validates real keys live against `POST https://api.jentic.com/api/
 - **2xx** — key valid and within quota; scoring proceeds.
 - **429** — key valid but the user is over quota. The body is a Jentic ProblemDetails JSON (per the [Jentic API problem-details domain](https://raw.githubusercontent.com/jentic/api-problem-details/refs/heads/main/openapi-domain.yaml)); the container surfaces the `detail` string and the `Retry-After` header (when present) on stderr and exits with `RATE_LIMITED` (7).
 - **401 / 403** — server-side key rejection. Container exits with `AUTH_INVALID_KEY` (2) and prints the server's `detail`.
-- **Anything else (3xx, unexpected 4xx, 5xx, network error, timeout, malformed body)** — the container fails open: it prints a one-line warning to stderr and lets scoring proceed. This trades off strict enforcement for availability — an outage on Jentic's side does not block scoring.
+- **Anything else (3xx, unexpected 4xx, 5xx, network error, timeout, malformed body)** — the container fails open: it prints a one-line warning to stderr and lets scoring proceed. **Policy**: validator unreachability fails open. This is intentional and PO-confirmed — an outage on Jentic's side must not block scoring.
 
 URLs matching the jentic-public-apis allowlist (see "Anonymous gate" above) are always free and **skip the validation call entirely**, regardless of whether a key is set. This keeps OAK contributions zero-friction even after rate limits ship.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -199,16 +199,16 @@ No `login` subcommand, no credentials file, no token persistence — those are p
 
 #### Key validation and rate limiting
 
-The container validates real keys live against `POST https://api.jentic.com/api/v1/usage/api-scoring`, sending the key in the `X-Jentic-API-Key` header. The endpoint is the same call that increments the user's scoring counter, so a single round-trip both authenticates the request and enforces the per-key rate limit. Responses are interpreted as:
+The container validates real keys live against `POST https://api.jentic.com/api/v1/usage/api-scoring`, sending the key in the `X-Jentic-API-Key` header. The HTTP client sets `allow_redirects=False` so a 3xx response cannot bounce the request — and the `X-Jentic-API-Key` header — to a different host than the one the runner intended to reach (`requests` does not strip custom headers on cross-host redirects). The endpoint is the same call that increments the user's scoring counter, so a single round-trip both authenticates the request and enforces the per-key rate limit. Responses are interpreted as:
 
 - **2xx** — key valid and within quota; scoring proceeds.
 - **429** — key valid but the user is over quota. The body is a Jentic ProblemDetails JSON (per the [Jentic API problem-details domain](https://raw.githubusercontent.com/jentic/api-problem-details/refs/heads/main/openapi-domain.yaml)); the container surfaces the `detail` string and the `Retry-After` header (when present) on stderr and exits with `RATE_LIMITED` (7).
 - **401 / 403** — server-side key rejection. Container exits with `AUTH_INVALID_KEY` (2) and prints the server's `detail`.
-- **Network error, timeout, 5xx, malformed body** — the container fails open: it prints a one-line warning to stderr and lets scoring proceed. This trades off strict enforcement for availability — an outage on Jentic's side does not block scoring.
+- **Anything else (3xx, unexpected 4xx, 5xx, network error, timeout, malformed body)** — the container fails open: it prints a one-line warning to stderr and lets scoring proceed. This trades off strict enforcement for availability — an outage on Jentic's side does not block scoring.
 
 URLs matching the jentic-public-apis allowlist (see "Anonymous gate" above) are always free and **skip the validation call entirely**, regardless of whether a key is set. This keeps OAK contributions zero-friction even after rate limits ship.
 
-`JENTIC_API_KEY=mvp-preview` is honored as a **deprecated** free-pass for the alpha migration window: the container prints a one-line stderr warning ("`mvp-preview` is deprecated; sign up at https://jentic.com/signup for a real key") and proceeds without contacting the validator. The placeholder is removed in a follow-up minor release.
+`JENTIC_API_KEY=mvp-preview` is honored as a **deprecated** free-pass for the alpha migration window: the container prints a one-line `DEPRECATED:`-prefixed stderr warning ("`DEPRECATED: JENTIC_API_KEY=mvp-preview will stop working in a future release; sign up at https://jentic.com/signup for a real key.`") and proceeds without contacting the validator. The placeholder is removed in a follow-up minor release.
 
 ### LLM provider keys (only when `--with-llm` is set)
 


### PR DESCRIPTION
## Summary

Follow-up enhancements on top of #99 (`feat(gate): validate real keys live and enforce rate limits`):

- **`usage.py`**
  - Send a `User-Agent: jentic-api-scorecard-runner` header so backend operators can distinguish scorecard traffic from generic POSTs.
  - Disable redirect-following on the validator POST (`allow_redirects=False`). `requests` does not strip custom headers on cross-host redirects, so a 3xx → different host could otherwise leak `X-Jentic-API-Key`. A 3xx is now treated as fail-open.
  - Restructured docstring to a sum-type variant table.
  - Dropped a redundant nested `try/except TypeError` in `_problem_detail`; switched to `response.json()`.

- **`gate.py`**
  - Strip whitespace from `JENTIC_API_KEY` so a paste-with-newline / leading-space doesn't fall through to `UsageInvalidKey`.
  - Replace the chained `isinstance(result, ...)` dispatch + unreachable fallback with `match`/`case` + `typing.assert_never`. Sum-type exhaustivity is now compiler-checked: adding a new `UsageResult` variant without updating the dispatch will fail type checking instead of silently hitting the warn-and-proceed branch.
  - Inline the one-line `_warn` / `_fail` helpers — they were empty abstractions over `print(..., file=sys.stderr)`.
  - Switch the mvp-preview warning to a `DEPRECATED:`-prefixed line so the stderr signal is grep-able by integrators.

- **Tests** (`docker/tests/test_gate.py`)
  - Add coverage for: 200 with non-dict body, 200 with empty body, unexpected 4xx (e.g. 400) → fail open, 3xx redirect → fail open (paired with the `allow_redirects=False` change above), `User-Agent` forwarding, env-var whitespace stripping, and a wire-contract assertion that the validator POST sends no request body.

- **Docs**
  - `docs/architecture.md` §9: document the `allow_redirects=False` rationale; generalize the fail-open clause to "3xx, unexpected 4xx, 5xx, network error, timeout, malformed body"; update the `mvp-preview` warning quote to the new `DEPRECATED:`-prefixed text.
  - `README.md`: mention the `DEPRECATED:` prefix in the `mvp-preview` blurb.

Refs #99

## Test plan

- [x] `cd docker && uv run poe test` — 44 passed
- [x] `cd docker && uv run poe lint` — clean
- [x] `docker build -t jentic-api-scorecard:dev ./docker` (image rebuild required because `test_integration.py::TestMVPKeyScheme::test_mvp_key_url_mode` asserts the new `DEPRECATED:` prefix)

## Out of scope / deferred

- Fail-open vs fail-closed policy on validator unreachability — confirmed as documented intent during review; PO sign-off pending. No code change in this PR.