### PR TITLE
docs: tighten Delivery-1 framing, §9 fail-open prose, and quota visibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ JENTIC_API_KEY=<your-key> npx @jentic/api-scorecard-cli@alpha score \
 JENTIC_API_KEY=<your-key> npx @jentic/api-scorecard-cli@alpha score ./openapi.yaml
 ```
 
+> Free keys come with **100 scorings**. See [Anonymous vs keyed access](#anonymous-vs-keyed-access) for signup, quota, and the deprecated `mvp-preview` placeholder.
+
 That's it. The CLI pulls the scoring engine automatically on first run.
 
 ![CLI score output](https://github.com/jentic/jentic-api-scorecard/raw/main/assets/cli-screenshot.png)

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ JENTIC_API_KEY=<your-key> npx @jentic/api-scorecard-cli@alpha score \
 JENTIC_API_KEY=<your-key> npx @jentic/api-scorecard-cli@alpha score ./openapi.yaml
 ```
 
+> [!IMPORTANT]
 > Free keys come with **100 scorings**. See [Anonymous vs keyed access](#anonymous-vs-keyed-access) for signup and quota details.
 
 That's it. The CLI pulls the scoring engine automatically on first run.

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ troubleshooting.
 
 OpenAPI documents from [Jentic Public APIs (OAK)](https://github.com/jentic/jentic-public-apis)
 score without any key and stay on the free tier — those URLs bypass key validation entirely.
-For everything else (local files, URLs outside OAK), get a key at [jentic.com/signup](https://jentic.com/signup):
+For everything else (local files, URLs outside OAK), get a key at [jentic.com/signup](https://jentic.com/signup) — once signed in, click **Score → CLI & Keys** to issue your key:
 
 ```bash
 export JENTIC_API_KEY=<your-key>

--- a/README.md
+++ b/README.md
@@ -161,8 +161,8 @@ export JENTIC_API_KEY=<your-key>
 ```
 
 Real keys are validated live by the container against `api.jentic.com`. The same call doubles
-as the per-key usage / rate-limit accounting hit. If you exceed your quota the CLI exits with
-code `7` and prints the `Retry-After` value.
+as the per-key usage / rate-limit accounting hit. **Each free key gets 100 scorings**; once
+that quota is exhausted the CLI exits with code `7` and prints the `Retry-After` value.
 
 `JENTIC_API_KEY=mvp-preview` is honored as a deprecated free-pass during the alpha and prints
 a `DEPRECATED:`-prefixed stderr warning; it is removed in a follow-up minor release.

--- a/README.md
+++ b/README.md
@@ -267,9 +267,9 @@ verifies an artifact end-to-end before you install it:
 The image is a closed system at scoring time: every Python wheel, Node.js
 binary, and validator tarball it needs is baked in at build time. Scoring does
 not call PyPI or npmjs and pulls no runtime packages. The **only** outbound
-call to Jentic is a small validator round-trip that authenticates your key
-and increments the per-key usage counter; OAK URLs (jentic-public-apis) skip
-even that. URL inputs additionally reach the network to fetch the OpenAPI
+call to Jentic is a small key-check round-trip against `api.jentic.com` that
+authenticates your key and increments the per-key usage counter; OAK URLs
+(jentic-public-apis) skip even that. URL inputs additionally reach the network to fetch the OpenAPI
 document and resolve any external `$ref`s it points at. `--with-llm`
 optionally sends spec context to an LLM provider of your choice; a local
 endpoint (Ollama) keeps everything on-machine. Multi-arch images

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ as the per-key usage / rate-limit accounting hit. **Each free key gets 100 scori
 that quota is exhausted the CLI exits with code `7` and prints the `Retry-After` value along
 with a link to upgrade your plan.
 
-`JENTIC_API_KEY=mvp-preview` is honored as a deprecated free-pass during the alpha and prints
+`JENTIC_API_KEY=mvp-preview` is honored as a **deprecated** free-pass during the alpha and prints
 a `DEPRECATED:`-prefixed stderr warning; it is removed in a follow-up minor release.
 
 ## CLI reference

--- a/README.md
+++ b/README.md
@@ -262,15 +262,17 @@ verifies an artifact end-to-end before you install it:
   per-platform SBOMs, dual-store attestations (BuildKit OCI referrers + Sigstore), and
   verification via either `docker buildx imagetools inspect` or `gh attestation verify`.
 
-### Runs anywhere, calls home nowhere
+### Runs anywhere, minimal phone-home
 
 The image is a closed system at scoring time: every Python wheel, Node.js
 binary, and validator tarball it needs is baked in at build time. Scoring does
-not call PyPI, npmjs, a Jentic backend, or any external service. Local-file
-inputs and bundled-URL inputs run fully offline; URL inputs reach the network
-only to fetch the OpenAPI document and resolve any external `$ref`s it points
-at. `--with-llm` optionally sends spec context to an LLM provider of the
-user's choice; a local endpoint (Ollama) keeps everything on-machine. Multi-arch images
+not call PyPI or npmjs and pulls no runtime packages. The **only** outbound
+call to Jentic is a small validator round-trip that authenticates your key
+and increments the per-key usage counter; OAK URLs (jentic-public-apis) skip
+even that. URL inputs additionally reach the network to fetch the OpenAPI
+document and resolve any external `$ref`s it points at. `--with-llm`
+optionally sends spec context to an LLM provider of your choice; a local
+endpoint (Ollama) keeps everything on-machine. Multi-arch images
 (linux/amd64 + linux/arm64) ship from the same release, so the same guarantees
 hold on Apple Silicon dev machines, ARM CI runners, and x86 servers alike.
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ JENTIC_API_KEY=<your-key> npx @jentic/api-scorecard-cli@alpha score \
 JENTIC_API_KEY=<your-key> npx @jentic/api-scorecard-cli@alpha score ./openapi.yaml
 ```
 
-> Free keys come with **100 scorings**. See [Anonymous vs keyed access](#anonymous-vs-keyed-access) for signup, quota, and the deprecated `mvp-preview` placeholder.
+> Free keys come with **100 scorings**. See [Anonymous vs keyed access](#anonymous-vs-keyed-access) for signup and quota details.
 
 That's it. The CLI pulls the scoring engine automatically on first run.
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,9 @@ npm install -g @jentic/api-scorecard-cli@alpha
 This installs the latest alpha of the CLI globally. The scoring engine (Docker image) is downloaded automatically
 the first time you run `score` — allow a minute or two on a typical connection.
 
+For local files or non-OAK URLs you'll also need a `JENTIC_API_KEY` — see
+[Anonymous vs keyed access](#anonymous-vs-keyed-access).
+
 Verify the install:
 
 ```bash
@@ -63,7 +66,7 @@ jentic-api-scorecard --version
 ## Try it now
 
 OpenAPI documents from [Jentic Public APIs (OAK)](https://github.com/jentic/jentic-public-apis)
-score without any key or limit — no signup, no config:
+score without any key, uncapped — no signup, no config:
 
 ```bash
 npx @jentic/api-scorecard-cli@alpha score \
@@ -157,7 +160,7 @@ troubleshooting.
 
 OpenAPI documents from [Jentic Public APIs (OAK)](https://github.com/jentic/jentic-public-apis)
 score without any key and stay on the free tier — those URLs bypass key validation entirely.
-For everything else (local files, URLs outside OAK), get a key at [jentic.com/signup](https://jentic.com/signup) — once signed in, click **Score → CLI & Keys** to issue your key:
+For everything else (local files, URLs outside OAK), get a key at [jentic.com/signup](https://jentic.com/signup) — once signed in, click **Score → CLI & Keys** to issue your key. Then set it:
 
 ```bash
 export JENTIC_API_KEY=<your-key>
@@ -214,7 +217,7 @@ jentic-api-scorecard score <input> [options]
 
 | Variable | When | Purpose |
 |---|---|---|
-| `JENTIC_API_KEY` | URLs outside OAK and local files | Real key issued at [jentic.com/signup](https://jentic.com/signup); validated live against `api.jentic.com` (see [Anonymous vs keyed access](#anonymous-vs-keyed-access)). |
+| `JENTIC_API_KEY` | URLs outside OAK and local files | Real key issued at [jentic.com/signup](https://jentic.com/signup); validated live against `api.jentic.com` (see [Anonymous vs keyed access](#anonymous-vs-keyed-access)). **Free quota: 100 scorings per calendar month.** |
 | LLM provider + routing vars | With `--with-llm` | The CLI auto-detects credentials (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GEMINI_API_KEY`, AWS keys) and routing (`LLM_PROVIDER`, `LIGHT_LLM_PROVIDER`, `LLM_MODEL`, `LLM_LIGHT_MODEL`, `*_API_URL`, `LLM_MAX_TOKENS`) and forwards them to the container; loopback URLs are rewritten so a host-side Ollama is reachable. Full reference: [LLM Signals guide](https://github.com/jentic/jentic-api-scorecard/blob/main/docs/llm-signals.md). |
 
 #### Exit codes

--- a/README.md
+++ b/README.md
@@ -165,7 +165,8 @@ export JENTIC_API_KEY=<your-key>
 
 Real keys are validated live by the container against `api.jentic.com`. The same call doubles
 as the per-key usage / rate-limit accounting hit. **Each free key gets 100 scorings**; once
-that quota is exhausted the CLI exits with code `7` and prints the `Retry-After` value.
+that quota is exhausted the CLI exits with code `7` and prints the `Retry-After` value along
+with a link to upgrade your plan.
 
 `JENTIC_API_KEY=mvp-preview` is honored as a deprecated free-pass during the alpha and prints
 a `DEPRECATED:`-prefixed stderr warning; it is removed in a follow-up minor release.

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ JENTIC_API_KEY=<your-key> npx @jentic/api-scorecard-cli@alpha score ./openapi.ya
 ```
 
 > [!IMPORTANT]
-> Free keys come with **100 scorings**. See [Anonymous vs keyed access](#anonymous-vs-keyed-access) for signup and quota details.
+> Free keys come with **100 scorings per month** (resets at the start of each calendar month). See [Anonymous vs keyed access](#anonymous-vs-keyed-access) for signup and quota details.
 
 That's it. The CLI pulls the scoring engine automatically on first run.
 
@@ -164,9 +164,9 @@ export JENTIC_API_KEY=<your-key>
 ```
 
 Real keys are validated live by the container against `api.jentic.com`. The same call doubles
-as the per-key usage / rate-limit accounting hit. **Each free key gets 100 scorings**; once
-that quota is exhausted the CLI exits with code `7` and prints the `Retry-After` value along
-with a link to upgrade your plan.
+as the per-key usage / rate-limit accounting hit. **Each free key gets 100 scorings per month**,
+resetting at the start of each calendar month. Once that quota is exhausted the CLI exits with
+code `7` and prints the `Retry-After` value along with a link to upgrade your plan.
 
 `JENTIC_API_KEY=mvp-preview` is honored as a **deprecated** free-pass during the alpha and prints
 a `DEPRECATED:`-prefixed stderr warning; it is removed in a follow-up minor release.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -208,6 +208,8 @@ The container validates real keys live against `POST https://api.jentic.com/api/
 
 URLs matching the jentic-public-apis allowlist (see "Anonymous gate" above) are always free and **skip the validation call entirely**, regardless of whether a key is set. This keeps OAK contributions zero-friction even after rate limits ship.
 
+**Free quota**: 100 scorings per calendar month per key, resetting at the start of each month. Keys exceeding the quota receive a 429 with the upgrade link in the ProblemDetails `detail` field. Subscribed keys carry their own quota terms surfaced by the same endpoint.
+
 `JENTIC_API_KEY=mvp-preview` is honored as a **deprecated** free-pass for the alpha migration window: the container prints a one-line `DEPRECATED:`-prefixed stderr warning ("`DEPRECATED: JENTIC_API_KEY=mvp-preview will stop working in a future release; sign up at https://jentic.com/signup for a real key.`") and proceeds without contacting the validator. The placeholder is removed in a follow-up minor release.
 
 ### LLM provider keys (only when `--with-llm` is set)
@@ -673,7 +675,7 @@ The auth pipeline is wired end-to-end against the Jentic backend:
 - **Real keys**: issued at `jentic.com/signup`. Validated live by the container against `POST https://api.jentic.com/api/v1/usage/api-scoring` (header `X-Jentic-API-Key`). The same call doubles as the per-key usage / rate-limit accounting hit, so a single round-trip both authenticates and increments.
 - **Free tier**: URLs under [`jentic/jentic-public-apis`](https://github.com/jentic/jentic-public-apis) score without contacting the validator at all, regardless of whether a key is set.
 - **`mvp-preview` (deprecated)**: honored as a free-pass for one minor version with a `DEPRECATED:`-prefixed stderr warning, then removed.
-- **Fail-open**: when the validator is unreachable (3xx, unexpected 4xx, 5xx, network error, timeout, malformed body) the container prints a one-line warning and lets scoring proceed. PO-confirmed policy — an outage on Jentic's side must not block scoring.
+- **Fail-open**: when `api.jentic.com` is unreachable (3xx, unexpected 4xx, 5xx, network error, timeout, malformed body) the container prints a one-line warning and lets scoring proceed. PO-confirmed policy — an outage on Jentic's side must not block scoring.
 
 The 429 response body is a Jentic ProblemDetails JSON per the [api-problem-details domain schema](https://raw.githubusercontent.com/jentic/api-problem-details/refs/heads/main/openapi-domain.yaml); the container surfaces the `detail` field and the `Retry-After` header (when present) on stderr and exits with `RATE_LIMITED` (7).
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,4 +1,4 @@
-# Jentic API Scorecard — Architecture (MVP / Delivery 1)
+# Jentic API Scorecard — Architecture (Delivery 1)
 
 > Status: Draft. Architecture for the initial public release.
 > Framework: Jentic API AI Readiness Framework (JAIRF) v0.2.0 — see https://github.com/jentic/api-ai-readiness-framework
@@ -53,7 +53,7 @@ Source: https://petstore3.swagger.io/api/v3/openapi.json
 | LLM analysis | Off by default. Opt-in via `--with-llm`; CLI forwards present provider credentials and routing variables (OpenAI / Anthropic / Gemini / AWS cloud, or OpenAI-compatible local endpoints via `OPENAI_API_URL`) to the container, which passes `--enable-llm-analysis` to the engine. See §5 "Bring your own LLM". |
 | Usage tracking | The same `POST /api/v1/usage/api-scoring` call that authenticates a real key also increments the user's per-key scoring counter. Allowlisted (jentic-public-apis) URLs do not increment. |
 | Default output | Headline + dimensions on stdout; spinner phases on stderr. `--detail` controls payload depth (summary → dimensions → signals → diagnostics). `--format json` for machine-readable output. |
-| Out of scope (MVP) | HTML formatter wired in (formatter package scaffolded only); user-facing image flags (image management is fully abstracted by the CLI); subcommands beyond `score` (no `login` / `whoami` / etc.); creds file persistence. |
+| Out of scope (Delivery 1) | HTML formatter wired in (formatter package scaffolded only); user-facing image flags (image management is fully abstracted by the CLI); subcommands beyond `score` (no `login` / `whoami` / etc.); creds file persistence. |
 
 ## 3. Component diagram
 
@@ -195,7 +195,7 @@ export JENTIC_API_KEY=<your-key>
 npx @jentic/api-scorecard-cli score ./openapi.yaml
 ```
 
-No `login` subcommand, no credentials file, no token persistence — those are post-MVP UX additions on top of an env-var foundation that already works.
+No `login` subcommand, no credentials file, no token persistence — those are post-Delivery-1 UX additions on top of an env-var foundation that already works (see §10).
 
 #### Key validation and rate limiting
 
@@ -672,14 +672,14 @@ The auth pipeline is wired end-to-end against the Jentic backend:
 
 - **Real keys**: issued at `jentic.com/signup`. Validated live by the container against `POST https://api.jentic.com/api/v1/usage/api-scoring` (header `X-Jentic-API-Key`). The same call doubles as the per-key usage / rate-limit accounting hit, so a single round-trip both authenticates and increments.
 - **Free tier**: URLs under [`jentic/jentic-public-apis`](https://github.com/jentic/jentic-public-apis) score without contacting the validator at all, regardless of whether a key is set.
-- **`mvp-preview` (deprecated)**: honored as a free-pass for one minor version with a stderr deprecation warning, then removed.
-- **Fail-open**: when the validator is unreachable (DNS error, timeout, 5xx, malformed body) the container prints a one-line warning and lets scoring proceed. This trades strict enforcement for availability while the Jentic backend stabilizes.
+- **`mvp-preview` (deprecated)**: honored as a free-pass for one minor version with a `DEPRECATED:`-prefixed stderr warning, then removed.
+- **Fail-open**: when the validator is unreachable (3xx, unexpected 4xx, 5xx, network error, timeout, malformed body) the container prints a one-line warning and lets scoring proceed. PO-confirmed policy — an outage on Jentic's side must not block scoring.
 
 The 429 response body is a Jentic ProblemDetails JSON per the [api-problem-details domain schema](https://raw.githubusercontent.com/jentic/api-problem-details/refs/heads/main/openapi-domain.yaml); the container surfaces the `detail` field and the `Retry-After` header (when present) on stderr and exits with `RATE_LIMITED` (7).
 
 ## 10. Out of scope (Delivery 1)
 
-- HTML formatter wired into the CLI. The `@jentic/api-scorecard-formatter-html` package is scaffolded with a typed `format(result): string` stub so the monorepo shape and contract are in place; the implementation lands post-MVP.
+- HTML formatter wired into the CLI. The `@jentic/api-scorecard-formatter-html` package is scaffolded with a typed `format(result): string` stub so the monorepo shape and contract are in place; the implementation lands in Phase 14.
 - User-facing image flags. The CLI fully abstracts image management: it always pulls the image tag matching its own version, with no user override.
 - Subcommands beyond `score` (e.g. `login`, `logout`, `whoami`, `config`, `lint`) and any persistent credentials file. Auth is env-var only.
 - Multi-spec / portfolio scoring.

--- a/specs/mission.md
+++ b/specs/mission.md
@@ -19,7 +19,7 @@ Jentic API Scorecard is a CLI tool that scores an OpenAPI document against JAIRF
 We:
 
 - **Score an OpenAPI spec by URL or piped JSON** — six JAIRF dimensions (FC, DXJ, ARAX, AU, SEC, AID) with overall score, level (`ai-aware`, etc.), and grade (A+ … F).
-- **Run scoring locally** in an isolated Docker container — no spec content leaves the user's machine. The only outbound call to Jentic is a small validator round-trip that authenticates the key and increments the per-key usage counter; allowlisted (jentic-public-apis) URLs skip even that.
+- **Run scoring locally** in an isolated Docker container — no spec content leaves the user's machine. The only outbound call to Jentic is a small key-check round-trip against `api.jentic.com` that authenticates the key and increments the per-key usage counter; allowlisted (jentic-public-apis) URLs skip even that.
 - **Gate anonymous use** to specs in [`jentic/jentic-public-apis`](https://github.com/jentic/jentic-public-apis) (which always score for free); other inputs require a real `JENTIC_API_KEY` issued at [jentic.com/signup](https://jentic.com/signup), validated live against `api.jentic.com` (see `docs/architecture.md` §9).
 - **Emit machine-readable JSON** verbatim from the engine, plus pretty / Markdown projections for human readers (deferred to the npm CLI; today the image emits JSON only).
 - **Optionally invoke LLM-backed analysis** via `--with-llm` when an LLM provider key (OpenAI / Anthropic / Gemini / AWS Bedrock) is forwarded by the host.

--- a/specs/roadmap.md
+++ b/specs/roadmap.md
@@ -245,6 +245,6 @@ This phase replaces the prior "Later Phases" entry "CLI connecting to remote doc
 - Plugins / custom rubrics on top of JAIRF
 - `--cpus` / `--memory` flags + matching engine worker-pool hints (deferred until a concrete user-pain signal)
 - Login subcommand / persistent credentials file
-- Server-side analytics or telemetry beyond the existing usage-counter validator round-trip
+- Server-side analytics or telemetry beyond the existing usage-counter key-check round-trip
 
 <!-- Items above are clearly out of current scope for the initial product trajectory. -->

--- a/specs/tech-stack.md
+++ b/specs/tech-stack.md
@@ -76,7 +76,7 @@ The current state, grounded in repository evidence. Planned-but-not-built items 
 - **Deployment target:** GHCR (`ghcr.io/jentic/jentic-api-scorecard`). Manual today; automated via `docker-image.yml` on the roadmap.
 - **Environment management:** env-vars only (`JENTIC_API_KEY`, optional LLM provider keys). No `.env` file, no secret manager.
 - **Observability:** stderr for engine warnings + (eventual) host-side spinner phases. No metrics, no tracing, no telemetry.
-- **Outbound calls from the container:** limited to the per-invocation validator round-trip (`POST api.jentic.com/api/v1/usage/api-scoring`), which authenticates the key and increments the per-key usage counter. Allowlisted (jentic-public-apis) URLs skip even that. See `docs/architecture.md` §9.
+- **Outbound calls from the container:** limited to the per-invocation key-check round-trip (`POST api.jentic.com/api/v1/usage/api-scoring`), which authenticates the key and increments the per-key usage counter. Allowlisted (jentic-public-apis) URLs skip even that. See `docs/architecture.md` §9.
 - **Error handling / resilience:** structured exit codes (`docker/src/jentic_scorecard_runner/exit_codes.py`: `SUCCESS=0`, `GENERIC_ERROR=1`, `AUTH_INVALID_KEY=2`, `GATE_REJECTED=3`, `SPEC_FAILURE=5`, `ENGINE_FAILURE=6`, `RATE_LIMITED=7`). Pipeline exceptions and `result.success == False` both map to `ENGINE_FAILURE`. `SPEC_FAILURE` (5) is reserved in the public contract and currently unreachable since the in-process pipeline does not expose a separate spec-policy exit code. `RATE_LIMITED` (7) is returned when the validator at `api.jentic.com` answers 429. The engine's own timeout knobs (`OASProcessConfiguration.conn_timeout` / `read_timeout`, default 300s each) bound network reads.
 
 ## Constraints and Conventions
@@ -96,10 +96,10 @@ The current state, grounded in repository evidence. Planned-but-not-built items 
 
 ## What We Are Not Using
 
-- **No FastAPI / web server.** This is a CLI, not a service. The architecture deliberately has no backend in the loop (`docs/architecture.md` §1).
+- **No FastAPI / web server.** This is a CLI, not a service. We do not operate any backend in the scoring orchestration loop (`docs/architecture.md` §1). The one outbound call to Jentic is the per-invocation key-check round-trip described in `Outbound calls from the container` above.
 - **No database.** No persistent state; one spec per `docker run` invocation.
 - **No type checker (mypy / pyright).** Ruff handles Python linting; Python type checks are not enforced. TypeScript runs strict-mode `tsc --noEmit` for `packages/`.
-- **No telemetry beyond the validator round-trip.** The container's only outbound call to Jentic is the `/api/v1/usage/api-scoring` validator hit, which doubles as the per-key usage counter. Allowlisted (jentic-public-apis) URLs do not increment. No Sentry, no analytics, no logs shipped off-host.
+- **No telemetry beyond the key-check round-trip.** The container's only outbound call to Jentic is the `/api/v1/usage/api-scoring` hit, which doubles as the per-key usage counter. Allowlisted (jentic-public-apis) URLs do not increment. No Sentry, no analytics, no logs shipped off-host.
 - **No `dockerode` (Docker SDK).** When the npm CLI lands, it shells out to `docker` via `child_process.spawn`. Decision recorded in `docs/architecture.md` §2.
 
 ## Roadmap, not yet built

--- a/specs/tech-stack.md
+++ b/specs/tech-stack.md
@@ -75,7 +75,8 @@ The current state, grounded in repository evidence. Planned-but-not-built items 
 
 - **Deployment target:** GHCR (`ghcr.io/jentic/jentic-api-scorecard`). Manual today; automated via `docker-image.yml` on the roadmap.
 - **Environment management:** env-vars only (`JENTIC_API_KEY`, optional LLM provider keys). No `.env` file, no secret manager.
-- **Observability:** stderr for engine warnings + (eventual) host-side spinner phases. No metrics, no tracing, no telemetry beyond the per-invocation validator round-trip described in `docs/architecture.md` §9.
+- **Observability:** stderr for engine warnings + (eventual) host-side spinner phases. No metrics, no tracing, no telemetry.
+- **Outbound calls from the container:** limited to the per-invocation validator round-trip (`POST api.jentic.com/api/v1/usage/api-scoring`), which authenticates the key and increments the per-key usage counter. Allowlisted (jentic-public-apis) URLs skip even that. See `docs/architecture.md` §9.
 - **Error handling / resilience:** structured exit codes (`docker/src/jentic_scorecard_runner/exit_codes.py`: `SUCCESS=0`, `GENERIC_ERROR=1`, `AUTH_INVALID_KEY=2`, `GATE_REJECTED=3`, `SPEC_FAILURE=5`, `ENGINE_FAILURE=6`, `RATE_LIMITED=7`). Pipeline exceptions and `result.success == False` both map to `ENGINE_FAILURE`. `SPEC_FAILURE` (5) is reserved in the public contract and currently unreachable since the in-process pipeline does not expose a separate spec-policy exit code. `RATE_LIMITED` (7) is returned when the validator at `api.jentic.com` answers 429. The engine's own timeout knobs (`OASProcessConfiguration.conn_timeout` / `read_timeout`, default 300s each) bound network reads.
 
 ## Constraints and Conventions

--- a/specs/tech-stack.md
+++ b/specs/tech-stack.md
@@ -76,7 +76,7 @@ The current state, grounded in repository evidence. Planned-but-not-built items 
 - **Deployment target:** GHCR (`ghcr.io/jentic/jentic-api-scorecard`). Manual today; automated via `docker-image.yml` on the roadmap.
 - **Environment management:** env-vars only (`JENTIC_API_KEY`, optional LLM provider keys). No `.env` file, no secret manager.
 - **Observability:** stderr for engine warnings + (eventual) host-side spinner phases. No metrics, no tracing, no telemetry.
-- **Outbound calls from the container:** limited to the per-invocation key-check round-trip (`POST api.jentic.com/api/v1/usage/api-scoring`), which authenticates the key and increments the per-key usage counter. Allowlisted (jentic-public-apis) URLs skip even that. See `docs/architecture.md` §9.
+- **Outbound calls to Jentic:** limited to the per-invocation key-check round-trip (`POST https://api.jentic.com/api/v1/usage/api-scoring`), which authenticates the key and increments the per-key usage counter. Allowlisted (jentic-public-apis) URLs skip even that. URL-mode scoring additionally fetches the target OpenAPI document and any external `$ref`s; `--with-llm` forwards spec context to the user-selected LLM provider. See `docs/architecture.md` §9.
 - **Error handling / resilience:** structured exit codes (`docker/src/jentic_scorecard_runner/exit_codes.py`: `SUCCESS=0`, `GENERIC_ERROR=1`, `AUTH_INVALID_KEY=2`, `GATE_REJECTED=3`, `SPEC_FAILURE=5`, `ENGINE_FAILURE=6`, `RATE_LIMITED=7`). Pipeline exceptions and `result.success == False` both map to `ENGINE_FAILURE`. `SPEC_FAILURE` (5) is reserved in the public contract and currently unreachable since the in-process pipeline does not expose a separate spec-policy exit code. `RATE_LIMITED` (7) is returned when the validator at `api.jentic.com` answers 429. The engine's own timeout knobs (`OASProcessConfiguration.conn_timeout` / `read_timeout`, default 300s each) bound network reads.
 
 ## Constraints and Conventions
@@ -96,7 +96,7 @@ The current state, grounded in repository evidence. Planned-but-not-built items 
 
 ## What We Are Not Using
 
-- **No FastAPI / web server.** This is a CLI, not a service. We do not operate any backend in the scoring orchestration loop (`docs/architecture.md` §1). The one outbound call to Jentic is the per-invocation key-check round-trip described in `Outbound calls from the container` above.
+- **No FastAPI / web server.** This is a CLI, not a service. We do not operate any backend in the scoring orchestration loop (`docs/architecture.md` §1). The one outbound call to Jentic is the per-invocation key-check round-trip described in `Outbound calls to Jentic` above.
 - **No database.** No persistent state; one spec per `docker run` invocation.
 - **No type checker (mypy / pyright).** Ruff handles Python linting; Python type checks are not enforced. TypeScript runs strict-mode `tsc --noEmit` for `packages/`.
 - **No telemetry beyond the key-check round-trip.** The container's only outbound call to Jentic is the `/api/v1/usage/api-scoring` hit, which doubles as the per-key usage counter. Allowlisted (jentic-public-apis) URLs do not increment. No Sentry, no analytics, no logs shipped off-host.


### PR DESCRIPTION
## Summary

Bundled doc cleanup. **No scope retirement** — Delivery 1 (Foundation + CLI + Docker self-contained) remains the framing; this PR tightens the words around it and surfaces a missing user-facing detail.

- **`docs/architecture.md`**
  - Title: `(MVP / Delivery 1)` → `(Delivery 1)`. The "MVP" alias was redundant with "Delivery 1" and lagged the rest of the doc.
  - `§2` Decisions table: `Out of scope (MVP)` → `Out of scope (Delivery 1)` for symmetry with `§10`.
  - `§9.1` mvp-preview bullet: now mentions the `DEPRECATED:`-prefixed warning (matches `§9` after #101).
  - `§9.1` fail-open bullet: trigger list broadened from "DNS error, timeout, 5xx, malformed body" to "3xx, unexpected 4xx, 5xx, network error, timeout, malformed body" — matches what `usage.py` actually returns (`UsageUnverifiable`) post-#101. Trailing "trades off … while the Jentic backend stabilizes" replaced with PO-confirmed policy framing.
  - `§9` line 198 "post-MVP UX additions" → "post-Delivery-1 UX additions (see §10)" — points at the canonical deferred-features list instead of coining a new label.
  - `§10` HTML-formatter line: "lands post-MVP" → "lands in Phase 14" (concrete pointer beats vague tense).

- **`specs/tech-stack.md`**
  - Split the **Observability** bullet (what operators see — stderr, no metrics/tracing) from a new **Outbound calls** bullet (what the container sends — the validator round-trip). The previous form conflated the two and read as if the validator hit was telemetry.

- **`README.md`**
  - *Anonymous vs keyed access* now states the default quota explicitly ("Each free key gets 100 scorings") so users know the cost of free-tier scoring before they hit `exit 7`. Previously the README only described the *consequence* (rate-limit-reached + `Retry-After`) but not the *threshold*.

## Test plan

Docs only — no tests, no behavior change.

Refs #99 #101