### PR TITLE
docs(README): note the 100-scoring default quota per free key

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,8 +161,8 @@ export JENTIC_API_KEY=<your-key>
 ```
 
 Real keys are validated live by the container against `api.jentic.com`. The same call doubles
-as the per-key usage / rate-limit accounting hit. If you exceed your quota the CLI exits with
-code `7` and prints the `Retry-After` value.
+as the per-key usage / rate-limit accounting hit. **Each free key gets 100 scorings**; once
+that quota is exhausted the CLI exits with code `7` and prints the `Retry-After` value.
 
 `JENTIC_API_KEY=mvp-preview` is honored as a deprecated free-pass during the alpha and prints
 a `DEPRECATED:`-prefixed stderr warning; it is removed in a follow-up minor release.


### PR DESCRIPTION
## Summary

Surface the default per-key quota in the *Anonymous vs keyed access* section so users know the cost of free-tier scoring before they hit \`exit 7\`. Today the README only describes the *consequence* (rate-limit-reached message + \`Retry-After\`) but not the *threshold*.

## Test plan

Docs only — no behavior change.

Refs #99