### PR TITLE
ci(restore-alpha-29): one-shot workflow to repoint GHCR alpha.29 tag

### DIFF
--- a/.github/workflows/restore-alpha-29.yml
+++ b/.github/workflows/restore-alpha-29.yml
@@ -1,0 +1,80 @@
+name: Restore alpha.29 GHCR tag
+
+# One-shot recovery workflow. Run #26941739990 raced with a dependabot
+# merge during workflow startup; lerna saw `EBEHIND` and exited 0
+# without graduating, but downstream `publish-docker` still ran and
+# overwrote `ghcr.io/jentic/jentic-api-scorecard:1.0.0-alpha.29` with
+# fresh bytes that no longer accept the `mvp-preview` placeholder key.
+# This workflow points the `1.0.0-alpha.29` tag back at the original
+# multi-arch index pushed on 2026-06-02 (digest below), restoring the
+# behavior consumers got when they pinned alpha.29 on npm.
+#
+# Delete this workflow file once it's served its purpose.
+
+on:
+  workflow_dispatch:
+
+permissions:
+  packages: write
+
+jobs:
+  restore:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    env:
+      IMAGE_NAME: ghcr.io/jentic/jentic-api-scorecard
+      RESTORE_TAG: 1.0.0-alpha.29
+      ORIGINAL_DIGEST: sha256:8b52319418beee86e949df067958a71bf52db597065d761af8caba3d185faf37
+    steps:
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Confirm original digest is reachable
+        run: |
+          set -euo pipefail
+          docker buildx imagetools inspect "${IMAGE_NAME}@${ORIGINAL_DIGEST}" \
+            --format '{{json .Manifest}}' \
+            | jq -e '.mediaType == "application/vnd.oci.image.index.v1+json"' >/dev/null
+          docker buildx imagetools inspect "${IMAGE_NAME}@${ORIGINAL_DIGEST}" \
+            --format '{{json .Manifest}}' \
+            | jq -e '[.manifests[] | select(.platform.os == "linux") | .platform.architecture] | sort == ["amd64","arm64"]' >/dev/null
+
+      - name: Repoint tag at the original index
+        run: |
+          set -euo pipefail
+          docker buildx imagetools create \
+            --tag "${IMAGE_NAME}:${RESTORE_TAG}" \
+            "${IMAGE_NAME}@${ORIGINAL_DIGEST}"
+
+      - name: Verify the tag now resolves to the original digest
+        run: |
+          set -euo pipefail
+          CURRENT=$(docker buildx imagetools inspect "${IMAGE_NAME}:${RESTORE_TAG}" \
+            --format '{{json .Manifest}}' | jq -r '.digest')
+          if [ "$CURRENT" != "$ORIGINAL_DIGEST" ]; then
+            echo "::error::tag still points at $CURRENT, expected $ORIGINAL_DIGEST"
+            exit 1
+          fi
+          echo "OK: ${IMAGE_NAME}:${RESTORE_TAG} -> ${ORIGINAL_DIGEST}"
+
+      - name: Smoke test that mvp-preview is accepted again
+        run: |
+          set -euo pipefail
+          docker pull "${IMAGE_NAME}:${RESTORE_TAG}"
+          OUT=$(printf '{"openapi":"3.0.0","info":{"title":"t","version":"1"},"paths":{}}' \
+            | docker run --rm -i \
+                -e JENTIC_API_KEY=mvp-preview \
+                "${IMAGE_NAME}:${RESTORE_TAG}" score 2>&1) || true
+          if echo "$OUT" | grep -qE 'requires a Jentic API key|not recognized|GATE_REJECTED'; then
+            echo "::error::restored image rejected mvp-preview — wrong digest restored"
+            echo "$OUT" | head -40
+            exit 1
+          fi
+          echo "OK: restored image accepts mvp-preview as expected"


### PR DESCRIPTION
## Summary

One-shot \`workflow_dispatch\` workflow that repoints \`ghcr.io/jentic/jentic-api-scorecard:1.0.0-alpha.29\` at its original 2026-06-02 multi-arch index digest, restoring the consumer-facing behavior of \`@jentic/api-scorecard-cli@1.0.0-alpha.29\` on npm.

## Why

Run #26941739990 raced with a dependabot merge during workflow startup. \`lerna version\` saw \`EBEHIND\`, exited 0 without graduating, but downstream \`publish-docker\` still ran and overwrote the \`1.0.0-alpha.29\` GHCR tag with fresh post-graduation bytes that no longer accept \`JENTIC_API_KEY=mvp-preview\`. The npm package is unchanged, but its hard-coded image ref now resolves to a different artifact than consumers got when they pinned alpha.29.

Original index digest \`sha256:8b52319418beee86e949df067958a71bf52db597065d761af8caba3d185faf37\` is still on GHCR (orphaned after the rebuild). \`docker buildx imagetools create\` repoints the tag without rebuilding — the original SBOM/provenance attestations remain reachable through the index.

## What it does

1. Confirms the original digest is reachable and is the multi-arch index (\`linux/amd64\` + \`linux/arm64\`).
2. Repoints the \`1.0.0-alpha.29\` tag at it via \`imagetools create\`.
3. Verifies the tag resolves to the original digest.
4. Smoke-tests that \`mvp-preview\` is accepted again.

## How to use

1. Merge this PR.
2. Run **Actions → Restore alpha.29 GHCR tag → workflow_dispatch**.
3. After it lands green, open a follow-up PR to delete \`.github/workflows/restore-alpha-29.yml\` (one-shot — no point keeping it around).

## Out of scope

- The \`EBEHIND\` race in \`release.yml\` itself — needs a separate fix (pre-lerna guard that fails if local main is behind upstream).
- Pruning today's orphan rebuild digest — auto-pruned on the next push to main via the existing \`docker-publish.yml\` prune step.

## Test plan

- [ ] Workflow runs on \`workflow_dispatch\` and exits green.
- [ ] After run: \`docker buildx imagetools inspect ghcr.io/jentic/jentic-api-scorecard:1.0.0-alpha.29\` shows index digest \`sha256:8b52319…faf37\`.
- [ ] After run: a stdin score with \`JENTIC_API_KEY=mvp-preview\` against the restored image exits 0 (i.e., behavior restored).

Replaces #116 (which was cut from a non-main branch).