### PR TITLE
ci(rebuild-alpha-29): rebuild GHCR alpha.29 from the original git tag

### DIFF
--- a/.github/workflows/rebuild-alpha-29.yml
+++ b/.github/workflows/rebuild-alpha-29.yml
@@ -1,0 +1,165 @@
+name: Rebuild alpha.29 GHCR image
+
+# One-shot recovery workflow. Run #26941739990 raced with a dependabot
+# merge during workflow startup; lerna saw `EBEHIND` and exited 0
+# without graduating, but downstream `publish-docker` still ran and
+# overwrote `ghcr.io/jentic/jentic-api-scorecard:1.0.0-alpha.29` with
+# fresh post-graduation bytes that no longer accept the `mvp-preview`
+# placeholder key.
+#
+# The original 2026-06-02 alpha.29 digest was then pruned by the
+# `unstable` rebuild's orphan-prune step, so we cannot repoint the
+# tag — we have to rebuild from the v1.0.0-alpha.29 git tag.
+#
+# This produces a new digest with new SBOM/provenance attestations,
+# but restores the consumer-facing behavior (mvp-preview accepted)
+# that anyone pinned to alpha.29 expects.
+#
+# Delete this workflow file once it's served its purpose.
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+  id-token: write
+  attestations: write
+
+jobs:
+  rebuild:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      IMAGE_NAME: ghcr.io/jentic/jentic-api-scorecard
+      RESTORE_TAG: 1.0.0-alpha.29
+      SOURCE_REF: v1.0.0-alpha.29
+    steps:
+      - name: Checkout v1.0.0-alpha.29 sources
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ env.SOURCE_REF }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Confirm sources still contain mvp-preview
+        run: |
+          set -euo pipefail
+          if ! grep -q '_MVP_KEY = "mvp-preview"' docker/src/jentic_scorecard_runner/gate.py; then
+            echo "::error::v1.0.0-alpha.29 sources do not contain mvp-preview — wrong tag?"
+            exit 1
+          fi
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Build and push
+        id: build
+        uses: docker/build-push-action@v7
+        with:
+          context: ./docker
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ env.IMAGE_NAME }}:${{ env.RESTORE_TAG }}
+          annotations: |
+            index:org.opencontainers.image.authors=vladimir@jentic.com
+            index:org.opencontainers.image.url=https://github.com/jentic/jentic-api-scorecard
+            index:org.opencontainers.image.source=https://github.com/jentic/jentic-api-scorecard
+            index:org.opencontainers.image.description=Jentic API Scorecard Docker image (rebuilt alpha.29)
+            index:org.opencontainers.image.licenses=Apache-2.0
+          sbom: true
+          provenance: mode=max
+
+      - name: Smoke test --help
+        run: docker run --rm ${{ env.IMAGE_NAME }}:${{ env.RESTORE_TAG }} score --help
+
+      - name: Smoke test mvp-preview is accepted
+        run: |
+          set -euo pipefail
+          OUT=$(printf '{"openapi":"3.0.0","info":{"title":"t","version":"1"},"paths":{"/x":{"get":{"responses":{"200":{"description":"ok"}}}}}}' \
+            | docker run --rm -i \
+                -e JENTIC_API_KEY=mvp-preview \
+                "${IMAGE_NAME}:${RESTORE_TAG}" score 2>&1) || true
+          if echo "$OUT" | grep -qE 'requires a Jentic API key|not recognized|GATE_REJECTED'; then
+            echo "::error::rebuilt alpha.29 image still rejects mvp-preview"
+            echo "$OUT" | head -40
+            exit 1
+          fi
+
+      - name: Resolve per-platform digests
+        id: platforms
+        run: |
+          set -euo pipefail
+          index_ref="${IMAGE_NAME}@${INDEX_DIGEST}"
+          index_json=$(docker buildx imagetools inspect "$index_ref" --raw)
+          amd64_digest=$(echo "$index_json" | jq -r '.manifests[] | select(.platform.os == "linux" and .platform.architecture == "amd64") | .digest' | head -n1)
+          arm64_digest=$(echo "$index_json" | jq -r '.manifests[] | select(.platform.os == "linux" and .platform.architecture == "arm64") | .digest' | head -n1)
+          if [ -z "$amd64_digest" ] || [ -z "$arm64_digest" ]; then
+            echo "::error::Failed to resolve per-platform digests from index manifest"
+            echo "$index_json"
+            exit 1
+          fi
+          echo "amd64=$amd64_digest" >> "$GITHUB_OUTPUT"
+          echo "arm64=$arm64_digest" >> "$GITHUB_OUTPUT"
+        env:
+          INDEX_DIGEST: ${{ steps.build.outputs.digest }}
+
+      - name: Generate SPDX SBOM (amd64)
+        uses: anchore/sbom-action@v0
+        with:
+          image: ${{ env.IMAGE_NAME }}@${{ steps.platforms.outputs.amd64 }}
+          format: spdx-json
+          output-file: ./image.sbom.amd64.spdx.json
+          upload-artifact: false
+          upload-release-assets: false
+
+      - name: Generate SPDX SBOM (arm64)
+        uses: anchore/sbom-action@v0
+        with:
+          image: ${{ env.IMAGE_NAME }}@${{ steps.platforms.outputs.arm64 }}
+          format: spdx-json
+          output-file: ./image.sbom.arm64.spdx.json
+          upload-artifact: false
+          upload-release-assets: false
+
+      - name: Attest build provenance (index)
+        uses: actions/attest-build-provenance@v4
+        with:
+          subject-name: ${{ env.IMAGE_NAME }}
+          subject-digest: ${{ steps.build.outputs.digest }}
+          push-to-registry: true
+
+      - name: Attest SBOM (amd64)
+        uses: actions/attest@v4
+        with:
+          subject-name: ${{ env.IMAGE_NAME }}
+          subject-digest: ${{ steps.platforms.outputs.amd64 }}
+          sbom-path: ./image.sbom.amd64.spdx.json
+          push-to-registry: true
+
+      - name: Attest SBOM (arm64)
+        uses: actions/attest@v4
+        with:
+          subject-name: ${{ env.IMAGE_NAME }}
+          subject-digest: ${{ steps.platforms.outputs.arm64 }}
+          sbom-path: ./image.sbom.arm64.spdx.json
+          push-to-registry: true
+
+      - name: Report
+        run: |
+          echo "Rebuilt and pushed: ${IMAGE_NAME}:${RESTORE_TAG}"
+          echo "Index digest: ${INDEX_DIGEST}"
+          echo "amd64 digest: ${{ steps.platforms.outputs.amd64 }}"
+          echo "arm64 digest: ${{ steps.platforms.outputs.arm64 }}"
+        env:
+          INDEX_DIGEST: ${{ steps.build.outputs.digest }}


### PR DESCRIPTION
## Summary

One-shot \`workflow_dispatch\` workflow that rebuilds \`ghcr.io/jentic/jentic-api-scorecard:1.0.0-alpha.29\` from the \`v1.0.0-alpha.29\` git tag, restoring the consumer-facing behavior of \`@jentic/api-scorecard-cli@1.0.0-alpha.29\` on npm.

## Why

Run #26941739990 raced with a dependabot merge during workflow startup. \`lerna version\` saw \`EBEHIND\`, exited 0 without graduating, but downstream \`publish-docker\` still ran and overwrote the \`1.0.0-alpha.29\` GHCR tag with fresh post-graduation bytes that no longer accept \`JENTIC_API_KEY=mvp-preview\`. The original 2026-06-02 digest \`sha256:8b52319…faf37\` was then pruned by the next \`unstable\` build's orphan-prune step, so we can't repoint the tag — we have to rebuild from the git tag's sources.

The rebuild produces a new digest with new SBOM + provenance attestations (the originals were tied to the deleted bytes), but restores the behavior anyone pinned to alpha.29 expects.

## What it does

1. Checks out \`v1.0.0-alpha.29\` (read-only — never mutates the working tree on main).
2. Sanity-checks the sources still contain \`_MVP_KEY = "mvp-preview"\` so we can't accidentally rebuild from a wrong tag.
3. Builds + pushes multi-arch (\`linux/amd64\`, \`linux/arm64\`) at the \`1.0.0-alpha.29\` tag with \`sbom: true\` + \`provenance: mode=max\`.
4. Smoke-tests \`--help\` and that \`mvp-preview\` is accepted.
5. Generates per-platform SPDX SBOMs and attaches Sigstore-signed build-provenance + SBOM attestations to GitHub's attestation store, mirroring the pattern in \`docker-publish.yml\`.

## How to use

1. Merge this PR.
2. Run **Actions → Rebuild alpha.29 GHCR image → workflow_dispatch**.
3. After it lands green, open a follow-up PR to delete \`.github/workflows/rebuild-alpha-29.yml\` (one-shot — no point keeping it around).

## Out of scope

- The \`EBEHIND\` race in \`release.yml\` itself — needs a separate fix (pre-lerna guard that fails if local main is behind upstream).
- Restoring the *original* digest — those bytes were pruned from GHCR. New build = new digest. Anyone who pinned to the original digest still loses; anyone who pinned to the *tag* gets working behavior back.

## Test plan

- [ ] Workflow runs on \`workflow_dispatch\` and exits green.
- [ ] After run: \`npx @jentic/api-scorecard-cli@1.0.0-alpha.29 score …\` with \`JENTIC_API_KEY=mvp-preview\` exits 0.
- [ ] After run: \`gh attestation verify --type slsa-provenance oci://ghcr.io/jentic/jentic-api-scorecard:1.0.0-alpha.29 -R jentic/jentic-api-scorecard\` passes.