### PR TITLE
ci(release): drop --conventional-graduate after the 1.0.0 cut

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,7 +64,7 @@ jobs:
         run: |
           git config user.name "${{ steps.app-token.outputs.app-slug }}[bot]"
           git config user.email "${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com"
-          npx lerna version --conventional-commits --conventional-graduate --no-private --yes --force-publish
+          npx lerna version --conventional-commits --no-private --yes --force-publish
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
       - name: Mark release as latest


### PR DESCRIPTION
## Summary

- Drop `--conventional-graduate` from `release.yml` now that the `1.0.0` graduation cut has shipped (`v1.0.0` tag exists, `@jentic/api-scorecard-cli@1.0.0` is on the `latest` dist-tag).
- On stable bases the flag is a no-op for version computation, but lerna logs `option --force-publish superseded by --conventional-graduate` on every release run — this removes that warning from CI output.

## Test plan

- [x] Next `release.yml` run completes without the "superseded" warning.

Closes #115