### PR TITLE
ci(release): drop redundant mark-as-latest step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,8 +19,9 @@ jobs:
 
   # Step 1: bump version, tag, create GitHub release, push to main.
   # No artifacts shipped yet — that happens in publish-docker and
-  # release-publish below. Keeping the version bump and "latest"
-  # flag here matches the previous workflow's behavior.
+  # release-publish below. lerna creates a non-prerelease GitHub
+  # release on a stable cut, so GitHub auto-promotes it to Latest
+  # without an explicit `gh release edit --latest`.
   release-prepare:
     name: Prepare release (version bump)
     needs: [ci]
@@ -65,12 +66,6 @@ jobs:
           git config user.name "${{ steps.app-token.outputs.app-slug }}[bot]"
           git config user.email "${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com"
           npx lerna version --conventional-commits --no-private --yes --force-publish
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-      - name: Mark release as latest
-        run: |
-          VERSION=$(node -p "require('./lerna.json').version")
-          gh release edit "v${VERSION}" --prerelease=false --latest
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
       - name: Extract released version and bump SHA


### PR DESCRIPTION
## Summary

- The `Mark release as latest` step in `release.yml` was added in 873171a (`fix(release): mark alpha releases as latest on GitHub`) as a workaround: `lerna version prerelease --preid alpha` produced prerelease GitHub releases, and we wanted alphas visible as **Latest** on the repo page until a stable cut shipped.
- Post-1.0.0 the workflow runs `lerna version --conventional-commits`, which produces a non-prerelease release for stable cuts. GitHub auto-promotes the most recent non-prerelease release to Latest, so the explicit `gh release edit --prerelease=false --latest` is a no-op.
- Verified against the current state: `gh api repos/jentic/jentic-api-scorecard/releases/latest` already resolves to `v1.0.0` without the step having any effect on a stable cut.

Builds on the alpha-channel cleanup in #106 / #121.

## Test plan

- [ ] Next stable release run still produces a release tagged Latest on the repo page (verified via `gh api .../releases/latest`).
- [ ] `release-prepare` job completes without the removed step (no missing-permission or missing-token errors downstream).