### PR TITLE
ci(workflows): block dependency lifecycle scripts in npm ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
           cache: 'npm'
           cache-dependency-path: 'package-lock.json'
       - name: Install dependencies
-        run: npm ci --engine-strict=false
+        run: npm ci --engine-strict=false --ignore-scripts
       - name: Lint commit message
         run: |
           npx commitlint --from ${{ github.event.pull_request.base.sha }} --to ${{ github.event.pull_request.head.sha }} --verbose
@@ -69,7 +69,7 @@ jobs:
           cache-dependency-path: 'package-lock.json'
 
       - name: Install dependencies
-        run: npm ci --engine-strict=false
+        run: npm ci --engine-strict=false --ignore-scripts
 
       - name: Run lint
         run: npm run lint
@@ -91,7 +91,7 @@ jobs:
           cache-dependency-path: 'package-lock.json'
 
       - name: Install dependencies
-        run: npm ci --engine-strict=false
+        run: npm ci --engine-strict=false --ignore-scripts
 
       - name: Build TypeScript
         run: npx lerna run build:typescript
@@ -110,7 +110,7 @@ jobs:
           cache-dependency-path: 'package-lock.json'
 
       - name: Install dependencies
-        run: npm ci --engine-strict=false
+        run: npm ci --engine-strict=false --ignore-scripts
 
       - name: Run tests
         run: npm test
@@ -149,7 +149,7 @@ jobs:
           cache-dependency-path: 'package-lock.json'
 
       - name: Install dependencies
-        run: npm ci --engine-strict=false
+        run: npm ci --engine-strict=false --ignore-scripts
 
       - name: Build CLI
         run: npx lerna run build:typescript

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,7 @@ jobs:
         with:
           node-version: 24.10.0
       - name: Install monorepo dependencies
-        run: npm ci --engine-strict=false
+        run: npm ci --engine-strict=false --ignore-scripts
       - name: Version bump & GitHub release
         run: |
           git config user.name "${{ steps.app-token.outputs.app-slug }}[bot]"
@@ -123,7 +123,7 @@ jobs:
           node-version: 24.10.0
           registry-url: https://registry.npmjs.org
       - name: Install monorepo dependencies
-        run: npm ci --engine-strict=false
+        run: npm ci --engine-strict=false --ignore-scripts
       - name: Build monorepo
         run: npm run build
       - name: Publish monorepo npm packages


### PR DESCRIPTION
## Summary

- Pass `--ignore-scripts` to every `npm ci` in `.github/workflows/ci.yml` (5 jobs) and `.github/workflows/release.yml` (2 jobs).
- Blocks transitive dependency `preinstall` / `install` / `postinstall` hooks from executing during CI installs — the standard supply-chain hardening for `npm ci`.
- The root `prepare: husky` script becomes a harmless no-op in CI (release.yml already sets `HUSKY=0`; CI jobs don't need git hooks installed).
- The SBOM-staging `npm install` already passed `--ignore-scripts`; this aligns the rest of the pipeline with that posture.

No package.json changes — local `npm install` continues to run scripts so `husky` keeps installing git hooks for contributors.

## Test plan

- [ ] CI run on this PR exercises every modified job (`lint-commit-messages`, `typescript-lint`, `typescript-build`, `typescript-test`, `test-e2e`) with the new flag.
- [ ] No CI job depends on a transitive package's lifecycle hook firing during install.