### PR TITLE
ci(release): fail fast if main moves during workflow startup

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,6 +61,24 @@ jobs:
           node-version: 24.10.0
       - name: Install monorepo dependencies
         run: npm ci --engine-strict=false --ignore-scripts
+      # Guard against a race between `workflow_dispatch` queue time
+      # and the lerna step: if another commit lands on main while the
+      # runner is starting up or installing deps, `lerna version` sees
+      # the local checkout behind upstream and bails with a non-fatal
+      # `EBEHIND` warning (exit 0). Downstream `publish-docker` then
+      # rebuilds GHCR at the existing tag with post-graduation bytes,
+      # violating tag-immutability. We `git fetch` so we see the same
+      # upstream state lerna will, then fail fast — placed immediately
+      # before lerna so the gap is milliseconds. See issue #119.
+      - name: Fail if main moved during workflow startup
+        run: |
+          set -euo pipefail
+          git fetch origin main --quiet
+          BEHIND=$(git rev-list --count HEAD..origin/main)
+          if [ "$BEHIND" -gt 0 ]; then
+            echo "::error::main moved $BEHIND commit(s) during workflow startup. Re-run release.yml."
+            exit 1
+          fi
       - name: Version bump & GitHub release
         run: |
           git config user.name "${{ steps.app-token.outputs.app-slug }}[bot]"


### PR DESCRIPTION
## Summary

- Adds a guard step to `release.yml` that fetches `origin/main` and fails the job if the local checkout is behind upstream.
- Closes the race where a commit landing on `main` between `workflow_dispatch` queue time and the lerna step causes `lerna version` to swallow `EBEHIND` and exit 0, after which downstream `publish-docker` rebuilds GHCR at the existing tag with post-graduation bytes (incident in run #26941739990 / PR #118).
- Placed **after** `npm ci`, immediately before `Version bump & GitHub release`, so the window between the guard's view of upstream and lerna's own internal fetch is milliseconds rather than the ~30–60s `setup-node` + `npm ci` block. The explicit `git fetch origin main` keeps the guard honest even though `actions/checkout@v6` already fetched once at job start.

## Test plan

- [ ] Re-trigger `release.yml` and confirm the new step is a no-op when `main` is up to date.
- [ ] (Manual / hard to reproduce) If feasible, simulate the race by pushing to `main` after the runner starts but before the guard step — the job should fail with the `::error::main moved …` annotation, and `publish-docker` / `release-publish` should not run (both gated on `needs: [release-prepare]`).

Closes #119