### PR TITLE
fix(cli): capture container stderr to keep spinner intact

### DIFF
--- a/packages/cli/src/commands/score.ts
+++ b/packages/cli/src/commands/score.ts
@@ -199,6 +199,9 @@ export async function runScore(input: string, options: ScoreOptions): Promise<nu
 
   if (result.exitCode !== 0) {
     clearSpinner();
+    if (result.stderr) {
+      process.stderr.write(result.stderr);
+    }
     if (result.stdout) {
       process.stdout.write(result.stdout);
     }
@@ -248,6 +251,10 @@ export async function runScore(input: string, options: ScoreOptions): Promise<nu
   } else {
     done(`Scoring done in ${elapsed}s`);
     process.stdout.write(output);
+  }
+
+  if (result.stderr) {
+    process.stderr.write(result.stderr);
   }
 
   return ExitCode.SUCCESS;

--- a/packages/cli/src/commands/score.ts
+++ b/packages/cli/src/commands/score.ts
@@ -243,6 +243,9 @@ export async function runScore(input: string, options: ScoreOptions): Promise<nu
       writeReport(output, options.output, format);
     } catch (err) {
       clearSpinner();
+      if (result.stderr) {
+        process.stderr.write(result.stderr);
+      }
       const message = err instanceof Error ? err.message : String(err);
       process.stderr.write(`error: ${message}\n`);
       return ExitCode.GENERIC_ERROR;

--- a/packages/cli/src/commands/score.ts
+++ b/packages/cli/src/commands/score.ts
@@ -213,6 +213,9 @@ export async function runScore(input: string, options: ScoreOptions): Promise<nu
   const parseResult = tryParseEngineOutput(result.stdout, format);
   if (!parseResult.ok) {
     clearSpinner();
+    if (result.stderr) {
+      process.stderr.write(result.stderr);
+    }
     process.stderr.write(parseResult.stderr);
     if (parseResult.stdout) {
       if (options.output !== undefined) {

--- a/packages/cli/src/docker.ts
+++ b/packages/cli/src/docker.ts
@@ -142,6 +142,9 @@ export function runDocker(opts: DockerRunOptions): Promise<DockerRunResult> {
       });
     }
 
+    // Buffer stderr instead of inheriting it: live writes during the run
+    // would interleave with the ora spinner caption (issue #107). The
+    // container emits stderr at end-of-run, so the buffer stays bounded.
     if (child.stderr) {
       child.stderr.on('data', (chunk: Buffer) => {
         stderrChunks.push(chunk);

--- a/packages/cli/src/docker.ts
+++ b/packages/cli/src/docker.ts
@@ -59,6 +59,7 @@ export interface DockerRunOptions {
 export interface DockerRunResult {
   exitCode: number;
   stdout: string;
+  stderr: string;
 }
 
 const FORWARDED_SIGNALS: NodeJS.Signals[] = ['SIGINT', 'SIGTERM', 'SIGHUP'];
@@ -105,12 +106,13 @@ export function runDocker(opts: DockerRunOptions): Promise<DockerRunResult> {
 
   return new Promise((resolve, reject) => {
     const child = spawn('docker', dockerArgs, {
-      stdio: [opts.stdinPayload !== undefined ? 'pipe' : 'inherit', 'pipe', 'inherit'],
+      stdio: [opts.stdinPayload !== undefined ? 'pipe' : 'inherit', 'pipe', 'pipe'],
     });
 
     let settled = false;
     const signalHandlers = new Map<NodeJS.Signals, () => void>();
     const stdoutChunks: Buffer[] = [];
+    const stderrChunks: Buffer[] = [];
 
     const cleanup = (): void => {
       for (const [sig, handler] of signalHandlers) {
@@ -140,13 +142,19 @@ export function runDocker(opts: DockerRunOptions): Promise<DockerRunResult> {
       });
     }
 
+    if (child.stderr) {
+      child.stderr.on('data', (chunk: Buffer) => {
+        stderrChunks.push(chunk);
+      });
+    }
+
     child.on('error', (err: NodeJS.ErrnoException) => {
       if (err.code === 'ENOENT') {
         process.stderr.write(
           "error: 'docker' command not found.\n" +
             '  Install Docker: https://docs.docker.com/get-docker/\n',
         );
-        settle(() => resolve({ exitCode: ExitCode.DOCKER_MISSING, stdout: '' }));
+        settle(() => resolve({ exitCode: ExitCode.DOCKER_MISSING, stdout: '', stderr: '' }));
         return;
       }
       settle(() => reject(err));
@@ -154,12 +162,13 @@ export function runDocker(opts: DockerRunOptions): Promise<DockerRunResult> {
 
     child.on('close', (code, signal) => {
       const stdout = Buffer.concat(stdoutChunks).toString('utf8');
+      const stderr = Buffer.concat(stderrChunks).toString('utf8');
       if (signal !== null) {
         const signo = osConstants.signals[signal] ?? 0;
-        settle(() => resolve({ exitCode: 128 + signo, stdout }));
+        settle(() => resolve({ exitCode: 128 + signo, stdout, stderr }));
         return;
       }
-      settle(() => resolve({ exitCode: code ?? ExitCode.GENERIC_ERROR, stdout }));
+      settle(() => resolve({ exitCode: code ?? ExitCode.GENERIC_ERROR, stdout, stderr }));
     });
 
     if (opts.stdinPayload !== undefined && child.stdin) {

--- a/packages/cli/src/docker.ts
+++ b/packages/cli/src/docker.ts
@@ -153,11 +153,15 @@ export function runDocker(opts: DockerRunOptions): Promise<DockerRunResult> {
 
     child.on('error', (err: NodeJS.ErrnoException) => {
       if (err.code === 'ENOENT') {
-        process.stderr.write(
-          "error: 'docker' command not found.\n" +
-            '  Install Docker: https://docs.docker.com/get-docker/\n',
+        settle(() =>
+          resolve({
+            exitCode: ExitCode.DOCKER_MISSING,
+            stdout: '',
+            stderr:
+              "error: 'docker' command not found.\n" +
+              '  Install Docker: https://docs.docker.com/get-docker/\n',
+          }),
         );
-        settle(() => resolve({ exitCode: ExitCode.DOCKER_MISSING, stdout: '', stderr: '' }));
         return;
       }
       settle(() => reject(err));

--- a/packages/cli/test/e2e/score.e2e.test.ts
+++ b/packages/cli/test/e2e/score.e2e.test.ts
@@ -447,15 +447,59 @@ describe('score command — e2e against docker', function () {
     }
   });
 
-  it('exits with GATE_REJECTED (3) for a non-allowlisted URL with no key', function () {
-    // RFC 6761 reserves .test as never-resolvable, so even if the gate were
-    // bypassed the engine could not fetch the URL.
-    const result = spawnSync('node', [CLI_BIN, 'score', 'https://invalid.test/openapi.yaml'], {
-      env: envWithoutKey(),
-      encoding: 'utf8',
-      timeout: E2E_TIMEOUT_MS,
+  describe('GATE_REJECTED (3) for a non-allowlisted URL with no key (regression: #107)', function () {
+    let exitCode: number | null;
+    let stderr: string;
+    let merged: string;
+
+    before(function () {
+      // RFC 6761 reserves .test as never-resolvable, so even if the gate were
+      // bypassed the engine could not fetch the URL.
+      const result = spawnSync('node', [CLI_BIN, 'score', 'https://invalid.test/openapi.yaml'], {
+        env: envWithoutKey(),
+        encoding: 'utf8',
+        timeout: E2E_TIMEOUT_MS,
+      });
+      exitCode = result.status;
+      stderr = strip(result.stderr ?? '');
+
+      // Merge stderr into stdout so we can observe the actual emission
+      // order users see on a TTY.
+      const mergedResult = spawnSync(
+        'bash',
+        ['-c', 'node "$CLI" score "https://invalid.test/openapi.yaml" 2>&1'],
+        {
+          env: { ...envWithoutKey(), CLI: CLI_BIN },
+          encoding: 'utf8',
+          timeout: E2E_TIMEOUT_MS,
+        },
+      );
+      merged = strip(mergedResult.stdout ?? '');
     });
-    expect(result.status).to.equal(3);
+
+    it('exits 3', function () {
+      expect(exitCode).to.equal(3);
+    });
+
+    it('writes the gate error to stderr intact', function () {
+      expect(stderr).to.include('anonymous scoring is restricted');
+      expect(stderr).to.include('jentic-public-apis');
+    });
+
+    it('does not collide the gate error with the Scoring spinner caption', function () {
+      // The bug: stderr was inherited live, so the container's error
+      // interleaved with the still-animating ora 'Scoring…' line. After
+      // the fix, every line of the gate error stands alone — no line
+      // contains both 'Scoring' and 'error:'.
+      for (const line of merged.split('\n')) {
+        const hasSpinnerText = line.includes('Scoring');
+        const hasErrorText = line.includes('error:');
+        expect(
+          hasSpinnerText && hasErrorText,
+          `spinner and gate error share a line: ${JSON.stringify(line)}`,
+        ).to.equal(false);
+      }
+    });
   });
 
   it('URL + --bundle without a key exits with AUTH_INVALID_KEY (2)', async function () {

--- a/packages/cli/test/e2e/score.e2e.test.ts
+++ b/packages/cli/test/e2e/score.e2e.test.ts
@@ -449,23 +449,13 @@ describe('score command — e2e against docker', function () {
 
   describe('GATE_REJECTED (3) for a non-allowlisted URL with no key (regression: #107)', function () {
     let exitCode: number | null;
-    let stderr: string;
     let merged: string;
 
     before(function () {
       // RFC 6761 reserves .test as never-resolvable, so even if the gate were
-      // bypassed the engine could not fetch the URL.
-      const result = spawnSync('node', [CLI_BIN, 'score', 'https://invalid.test/openapi.yaml'], {
-        env: envWithoutKey(),
-        encoding: 'utf8',
-        timeout: E2E_TIMEOUT_MS,
-      });
-      exitCode = result.status;
-      stderr = strip(result.stderr ?? '');
-
-      // Merge stderr into stdout so we can observe the actual emission
-      // order users see on a TTY.
-      const mergedResult = spawnSync(
+      // bypassed the engine could not fetch the URL. Merge stderr into stdout
+      // via 2>&1 so we can observe the emission order users see on a TTY.
+      const result = spawnSync(
         'bash',
         ['-c', 'node "$CLI" score "https://invalid.test/openapi.yaml" 2>&1'],
         {
@@ -474,31 +464,38 @@ describe('score command — e2e against docker', function () {
           timeout: E2E_TIMEOUT_MS,
         },
       );
-      merged = strip(mergedResult.stdout ?? '');
+      exitCode = result.status;
+      merged = strip(result.stdout ?? '');
     });
 
     it('exits 3', function () {
       expect(exitCode).to.equal(3);
     });
 
-    it('writes the gate error to stderr intact', function () {
-      expect(stderr).to.include('anonymous scoring is restricted');
-      expect(stderr).to.include('jentic-public-apis');
+    it('writes the gate error intact', function () {
+      expect(merged).to.include('anonymous scoring is restricted');
+      expect(merged).to.include('jentic-public-apis');
     });
 
-    it('does not collide the gate error with the Scoring spinner caption', function () {
-      // The bug: stderr was inherited live, so the container's error
-      // interleaved with the still-animating ora 'Scoring…' line. After
-      // the fix, every line of the gate error stands alone — no line
-      // contains both 'Scoring' and 'error:'.
+    it('emits the gate error on its own line, after every spinner frame', function () {
+      // Two regressions to defend against:
+      //   1. The original bug — stderr inherited live, so the error's
+      //      first line shared a row with the ora 'Scoring…' caption.
+      //      Caught by the per-line check: no line contains both.
+      //   2. A future regression that moves the spinner below the error.
+      //      Caught by the index check: 'error:' lands after the last
+      //      'Scoring' frame.
       for (const line of merged.split('\n')) {
-        const hasSpinnerText = line.includes('Scoring');
-        const hasErrorText = line.includes('error:');
         expect(
-          hasSpinnerText && hasErrorText,
+          line.includes('Scoring') && line.includes('error:'),
           `spinner and gate error share a line: ${JSON.stringify(line)}`,
         ).to.equal(false);
       }
+      const errorIdx = merged.indexOf('error:');
+      const lastSpinnerIdx = merged.lastIndexOf('Scoring');
+      expect(errorIdx, 'gate error missing').to.be.greaterThan(-1);
+      expect(lastSpinnerIdx, 'spinner caption missing').to.be.greaterThan(-1);
+      expect(errorIdx).to.be.greaterThan(lastSpinnerIdx);
     });
   });
 


### PR DESCRIPTION
## Summary

- The docker child was spawned with stderr inherited, so the container's stderr landed on the terminal while ora was still animating `Scoring…`. For multi-line errors (the gate's anonymous-scoring rejection is the most user-visible) the first line collided with the spinner caption, producing the jagged `- Scoring… error: anonymous scoring is restricted…` header in the screenshot on #107.
- Capture stderr like stdout in `runDocker`, then in `runScore` clear the spinner first on non-zero exits and flush stderr as a clean block. On the success path, success-mode stderr (e.g. validator-unverifiable warnings) is flushed *after* `done()` so the ✔ line still renders.
- Add an e2e regression test that runs the gate-rejected URL through `2>&1` and asserts no single line of merged output contains both `Scoring` and `error:`.

Closes #107

## Test plan

- [x] `npm run lint`
- [x] `npm test` — 113 passing
- [x] `npm run test:e2e` — 36 passing, including the new `regression: #107` block
- [x] Manual smoke: `node packages/cli/bin/jentic-api-scorecard.mjs score https://invalid.test/openapi.yaml` exits 3 and prints the gate error as a clean block under the spinner line