### PR TITLE
test(e2e): cover real-key success path for local-file + --bundle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,4 +173,6 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Run e2e mocha
+        env:
+          JENTIC_API_KEY: ${{ secrets.JENTIC_API_KEY }}
         run: npx lerna run test:e2e

--- a/packages/cli/test/e2e/score.e2e.test.ts
+++ b/packages/cli/test/e2e/score.e2e.test.ts
@@ -9,6 +9,7 @@ import { expect } from 'chai';
 import { startMockSpecServer } from './mock-spec-server.ts';
 
 const CLI_BIN = fileURLToPath(new URL('../../bin/jentic-api-scorecard.mjs', import.meta.url));
+const SAMPLE_SPEC = fileURLToPath(new URL('../fixtures/sample.yaml', import.meta.url));
 const OAK_PETSTORE_URL =
   'https://raw.githubusercontent.com/jentic/jentic-public-apis/refs/heads/main/apis/openapi/swagger-api/petstore/1.0.27/openapi.json';
 
@@ -510,5 +511,29 @@ describe('score command — e2e against docker', function () {
     } finally {
       started.server.close();
     }
+  });
+
+  describe('real JENTIC_API_KEY against the live validator (regression: #114)', function () {
+    const realKey = process.env['JENTIC_API_KEY'];
+    const itOrSkip = realKey === undefined || realKey === '' ? it.skip : it;
+
+    itOrSkip('local-file input exits 0', async function () {
+      const result = await runCliAsync(['score', SAMPLE_SPEC], {
+        ...envWithoutKey(),
+        JENTIC_API_KEY: realKey,
+      });
+      expect(result.exitCode, `stderr: ${result.stderr}`).to.equal(0);
+      expect(strip(result.stdout)).to.include('API Readiness Scorecard');
+    });
+
+    itOrSkip('petstore URL + --bundle exits 0', async function () {
+      const result = await runCliAsync(['score', OAK_PETSTORE_URL, '--bundle'], {
+        ...envWithoutKey(),
+        JENTIC_API_KEY: realKey,
+      });
+      expect(result.exitCode, `stderr: ${result.stderr}`).to.equal(0);
+      expect(strip(result.stdout)).to.include('API Readiness Scorecard');
+      expect(result.stderr).to.include('Bundling');
+    });
   });
 });

--- a/packages/cli/test/e2e/score.e2e.test.ts
+++ b/packages/cli/test/e2e/score.e2e.test.ts
@@ -88,7 +88,7 @@ describe('score command — e2e against docker', function () {
     });
   });
 
-  describe('stream interleaving (regression: #84)', function () {
+  describe('stream interleaving', function () {
     let exitCode: number | null;
     let merged: string;
 
@@ -448,7 +448,7 @@ describe('score command — e2e against docker', function () {
     }
   });
 
-  describe('GATE_REJECTED (3) for a non-allowlisted URL with no key (regression: #107)', function () {
+  describe('GATE_REJECTED (3) for a non-allowlisted URL with no key', function () {
     let exitCode: number | null;
     let merged: string;
 
@@ -513,7 +513,7 @@ describe('score command — e2e against docker', function () {
     }
   });
 
-  describe('real JENTIC_API_KEY against the live validator (regression: #114)', function () {
+  describe('real JENTIC_API_KEY against the live validator', function () {
     beforeEach(function () {
       const realKey = process.env['JENTIC_API_KEY'];
       if (realKey === undefined || realKey === '') this.skip();

--- a/packages/cli/test/e2e/score.e2e.test.ts
+++ b/packages/cli/test/e2e/score.e2e.test.ts
@@ -514,23 +514,19 @@ describe('score command — e2e against docker', function () {
   });
 
   describe('real JENTIC_API_KEY against the live validator (regression: #114)', function () {
-    const realKey = process.env['JENTIC_API_KEY'];
-    const itOrSkip = realKey === undefined || realKey === '' ? it.skip : it;
+    beforeEach(function () {
+      const realKey = process.env['JENTIC_API_KEY'];
+      if (realKey === undefined || realKey === '') this.skip();
+    });
 
-    itOrSkip('local-file input exits 0', async function () {
-      const result = await runCliAsync(['score', SAMPLE_SPEC], {
-        ...envWithoutKey(),
-        JENTIC_API_KEY: realKey,
-      });
+    it('local-file input exits 0', async function () {
+      const result = await runCliAsync(['score', SAMPLE_SPEC], process.env);
       expect(result.exitCode, `stderr: ${result.stderr}`).to.equal(0);
       expect(strip(result.stdout)).to.include('API Readiness Scorecard');
     });
 
-    itOrSkip('petstore URL + --bundle exits 0', async function () {
-      const result = await runCliAsync(['score', OAK_PETSTORE_URL, '--bundle'], {
-        ...envWithoutKey(),
-        JENTIC_API_KEY: realKey,
-      });
+    it('petstore URL + --bundle exits 0', async function () {
+      const result = await runCliAsync(['score', OAK_PETSTORE_URL, '--bundle'], process.env);
       expect(result.exitCode, `stderr: ${result.stderr}`).to.equal(0);
       expect(strip(result.stdout)).to.include('API Readiness Scorecard');
       expect(result.stderr).to.include('Bundling');

--- a/packages/cli/test/e2e/score.e2e.test.ts
+++ b/packages/cli/test/e2e/score.e2e.test.ts
@@ -520,13 +520,19 @@ describe('score command — e2e against docker', function () {
     });
 
     it('local-file input exits 0', async function () {
-      const result = await runCliAsync(['score', SAMPLE_SPEC], process.env);
+      const result = await runCliAsync(['score', SAMPLE_SPEC], {
+        ...envWithoutKey(),
+        JENTIC_API_KEY: process.env['JENTIC_API_KEY'],
+      });
       expect(result.exitCode, `stderr: ${result.stderr}`).to.equal(0);
       expect(strip(result.stdout)).to.include('API Readiness Scorecard');
     });
 
     it('petstore URL + --bundle exits 0', async function () {
-      const result = await runCliAsync(['score', OAK_PETSTORE_URL, '--bundle'], process.env);
+      const result = await runCliAsync(['score', OAK_PETSTORE_URL, '--bundle'], {
+        ...envWithoutKey(),
+        JENTIC_API_KEY: process.env['JENTIC_API_KEY'],
+      });
       expect(result.exitCode, `stderr: ${result.stderr}`).to.equal(0);
       expect(strip(result.stdout)).to.include('API Readiness Scorecard');
       expect(result.stderr).to.include('Bundling');


### PR DESCRIPTION
## Summary

- Adds a CI-secret-gated `describe` block to `packages/cli/test/e2e/score.e2e.test.ts` that exercises the success path against the **real validator** for two inputs the existing e2e suite did not cover:
  - **Local file** — verifies `JENTIC_API_KEY` plumbing through to the container (`-e JENTIC_API_KEY` + stdin spec body).
  - **OAK petstore URL + `--bundle`** — verifies the host-side bundle → stdin path (which, unlike a bare URL hit, requires a key because the anonymous allowlist no longer applies once the bundled JSON is piped in).
- Skips both cases when `JENTIC_API_KEY` is unset/empty so `npm run test:e2e` stays local-runnable per `.claude/rules/testing.md`.
- Wires `JENTIC_API_KEY` from repo secrets into the `test-e2e` job's mocha step in `.github/workflows/ci.yml`. Scope is the single step — checkout, npm ci, TS build, and image build don't see the secret.

## Why this matters

Closes the gap from #106: with the `JENTIC_API_BASE_URL` host→container passthrough removed, no e2e case was asserting CLI → container → real validator → exit 0. A regression in `forwardJenticKey` wiring or `-e JENTIC_API_KEY` plumbing would have manifested as exit 2 in production with no CI signal.

## Safety notes (re: secrets in CI)

- The workflow triggers on `pull_request` (not `pull_request_target`), so fork PRs receive no repo secrets and the gated cases skip there. Branch PRs from `jentic/*` get the secret and exercise the real validator.
- Secret is scoped to the mocha step's `env:` block, never passed via argv (no `ps` exposure on the runner).
- GitHub auto-masks the secret in logs; the new assertions check `result.exitCode` and a headline string — no path where the key would naturally land in stdout/stderr.

## Test plan

- [x] `npm run lint -w @jentic/api-scorecard-cli` — clean
- [x] `npm run build:typescript -w @jentic/api-scorecard-cli` — clean
- [x] `npm run test:e2e` **without** `JENTIC_API_KEY` — both new cases skip (`pending`), all 36 other cases pass
- [x] `JENTIC_API_KEY=… npm run test:e2e` — both new cases pass (`local-file` ~5.9s, `--bundle` ~7.3s), all 38 cases pass

Refs #114