### PR TITLE
fix(release): retry CLI SBOM install past registry propagation lag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -180,16 +180,28 @@ jobs:
               "https://registry.npmjs.org/@jentic/api-scorecard-cli/-/api-scorecard-cli-${VERSION}.tgz"
         env:
           VERSION: ${{ needs.release-prepare.outputs.version }}
+      # The CLI now depends on its workspace sibling
+      # @jentic/api-scorecard-formatter-html, published moments earlier in this
+      # same job. The SBOM's `npm install` resolves that sibling from the
+      # registry, whose metadata can lag the publish ACK (same propagation window
+      # as the tarball download above) and surface as `ETARGET notarget`. Retry
+      # until the just-published version has propagated.
       - name: Generate SPDX SBOM for CLI
-        run: |
-          mkdir -p ./artifacts/sbom-staging
-          jq 'del(.devDependencies)' packages/cli/package.json \
-            > ./artifacts/sbom-staging/package.json
-          (cd ./artifacts/sbom-staging \
-            && npm install --omit=dev --no-audit --no-fund --ignore-scripts \
-            && npm sbom --sbom-format=spdx --sbom-type=application --omit=dev \
-              > ../cli.sbom.spdx.json)
-          jq empty ./artifacts/cli.sbom.spdx.json
+        uses: nick-fields/retry@v4
+        with:
+          max_attempts: 60
+          retry_wait_seconds: 30
+          timeout_minutes: 35
+          retry_on: error
+          command: |
+            mkdir -p ./artifacts/sbom-staging
+            jq 'del(.devDependencies)' packages/cli/package.json \
+              > ./artifacts/sbom-staging/package.json
+            (cd ./artifacts/sbom-staging \
+              && npm install --omit=dev --no-audit --no-fund --ignore-scripts \
+              && npm sbom --sbom-format=spdx --sbom-type=application --omit=dev \
+                > ../cli.sbom.spdx.json)
+            jq empty ./artifacts/cli.sbom.spdx.json
       - name: Attest SBOM
         uses: actions/attest@v4
         with:


### PR DESCRIPTION
## Problem

The v1.2.0 release run failed at the **Generate SPDX SBOM for CLI** step:

```
npm error code ETARGET
npm error notarget No matching version found for @jentic/api-scorecard-formatter-html@1.2.0
```

**The publish itself succeeded** — `lerna success published 2 packages`, and both `@jentic/api-scorecard-cli@1.2.0` and `@jentic/api-scorecard-formatter-html@1.2.0` are on npm. The failure is purely in the post-publish SBOM step.

## Root cause

This is a regression introduced when the CLI gained a runtime dependency on its workspace sibling `@jentic/api-scorecard-formatter-html` (Phase 14, #134). The SBOM step copies the CLI's `package.json` to a staging dir and runs `npm install --omit=dev` to materialize the production dependency tree. That install now has to resolve the sibling **from the registry**, seconds after it was published in the same job — and npm's metadata propagation can lag the publish ACK (the workflow already documents this exact window for the tarball download: *"tarball blob 404'd for >10 min after a successful lerna publish"*). Before Phase 14 the CLI had no `@jentic/*` runtime dep, so the SBOM install only pulled long-indexed public packages and never hit this race.

## Fix

Wrap the SBOM generation in `nick-fields/retry@v4` with the same budget as the existing **Download published CLI tarball from registry** step (60 attempts × 30s, 35 min cap). It retries the `npm install` + `npm sbom` until the just-published dependency has propagated. No behavioural change on a healthy release; it just tolerates the propagation window instead of failing on it.

## Notes
- Scope is the single SBOM step; nothing else changes.
- `release.yml` validated as well-formed YAML.
- Follow-up (separate): `@jentic/api-scorecard-formatter-html` currently gets no SBOM/attestation of its own — tracked in a separate issue.