### PR TITLE
fix(gate): point key links at stable app.jentic.com URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ troubleshooting.
 
 OpenAPI documents from [Jentic Public APIs (OAK)](https://github.com/jentic/jentic-public-apis)
 score without any key and stay on the free tier — those URLs bypass key validation entirely.
-For everything else (local files, URLs outside OAK), get a key at [jentic.com/signup](https://jentic.com/signup) — once signed in, click **Score → CLI & Keys** to issue your key. Then set it:
+For everything else (local files, URLs outside OAK), get a key from the [Jentic Scorecard API Keys page](https://app.jentic.com/scorecard?tab=api-keys). Then set it:
 
 ```bash
 export JENTIC_API_KEY=<your-key>
@@ -245,7 +245,7 @@ jentic-api-scorecard score <input> [options]
 
 | Variable | When | Purpose |
 |---|---|---|
-| `JENTIC_API_KEY` | URLs outside OAK and local files | Real key issued at [jentic.com/signup](https://jentic.com/signup); validated live against `api.jentic.com` (see [Anonymous vs keyed access](#anonymous-vs-keyed-access)). **Free quota: 100 scorings per calendar month.** |
+| `JENTIC_API_KEY` | URLs outside OAK and local files | Real key issued at the [Jentic Scorecard API Keys page](https://app.jentic.com/scorecard?tab=api-keys); validated live against `api.jentic.com` (see [Anonymous vs keyed access](#anonymous-vs-keyed-access)). **Free quota: 100 scorings per calendar month.** |
 | LLM provider + routing vars | With `--with-llm` | The CLI auto-detects credentials (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GEMINI_API_KEY`, AWS keys) and routing (`LLM_PROVIDER`, `LIGHT_LLM_PROVIDER`, `LLM_MODEL`, `LLM_LIGHT_MODEL`, `*_API_URL`, `LLM_MAX_TOKENS`) and forwards them to the container; loopback URLs are rewritten so a host-side Ollama is reachable. Full reference: [LLM Signals guide](https://github.com/jentic/jentic-api-scorecard/blob/main/docs/llm-signals.md). |
 
 #### Exit codes

--- a/docker/src/jentic_scorecard_runner/gate.py
+++ b/docker/src/jentic_scorecard_runner/gate.py
@@ -41,7 +41,7 @@ def check_gate(url: str | None) -> ExitCode:
         if url is None:
             print(
                 "error: scoring from stdin requires a Jentic API key.\n"
-                "  Sign up for a key at https://jentic.com/signup and retry:\n"
+                "  Get a key at https://app.jentic.com/scorecard?tab=api-keys and retry:\n"
                 "    export JENTIC_API_KEY=<your-key>",
                 file=sys.stderr,
             )
@@ -51,8 +51,8 @@ def check_gate(url: str | None) -> ExitCode:
             "  https://raw.githubusercontent.com/jentic/jentic-public-apis/refs/heads/main/apis/openapi/\n"
             "  Browse available documents:\n"
             "    https://github.com/jentic/jentic-public-apis/tree/main/apis/openapi\n"
-            "  Or sign up for a key:\n"
-            "    https://jentic.com/signup",
+            "  Or get a key:\n"
+            "    https://app.jentic.com/scorecard?tab=api-keys",
             file=sys.stderr,
         )
         return ExitCode.GATE_REJECTED
@@ -66,14 +66,14 @@ def check_gate(url: str | None) -> ExitCode:
             message = f"error: rate limit reached for your Jentic API key.\n  {detail}"
             if retry_after is not None:
                 message += f"\n  Retry-After: {retry_after}"
-            message += "\n  Manage your usage at https://jentic.com/account"
+            message += "\n  Manage your key at https://app.jentic.com/scorecard?tab=api-keys"
             print(message, file=sys.stderr)
             return ExitCode.RATE_LIMITED
         case UsageInvalidKey(detail=detail):
             print(
                 "error: this key is not recognized.\n"
                 f"  {detail}\n"
-                "  Check or regenerate your key at https://jentic.com/account",
+                "  Check or regenerate your key at https://app.jentic.com/scorecard?tab=api-keys",
                 file=sys.stderr,
             )
             return ExitCode.AUTH_INVALID_KEY

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -365,7 +365,7 @@ stdout stays clean so `--format json | jq` works without filtering.
 ```
 $ npx @jentic/api-scorecard-cli score ./local.yaml         # no key
 error: scoring from stdin requires a Jentic API key.
-  Sign up for a key at https://jentic.com/signup and retry:
+  Get a key at https://app.jentic.com/scorecard?tab=api-keys and retry:
     export JENTIC_API_KEY=<your-key>
 exit 2
 
@@ -374,8 +374,8 @@ error: anonymous scoring is restricted to OpenAPI documents hosted at:
   https://raw.githubusercontent.com/jentic/jentic-public-apis/refs/heads/main/apis/openapi/
   Browse available documents:
     https://github.com/jentic/jentic-public-apis/tree/main/apis/openapi
-  Or sign up for a key:
-    https://jentic.com/signup
+  Or get a key:
+    https://app.jentic.com/scorecard?tab=api-keys
 exit 3
 
 $ npx @jentic/api-scorecard-cli score ./openapi.yaml      # docker not in PATH
@@ -387,7 +387,7 @@ $ JENTIC_API_KEY=<your-key> npx @jentic/api-scorecard-cli score ./local.yaml   #
 error: rate limit reached for your Jentic API key.
   monthly scoring quota exhausted
   Retry-After: 3600
-  Manage your usage at https://jentic.com/account
+  Manage your key at https://app.jentic.com/scorecard?tab=api-keys
 exit 7
 ```
 
@@ -672,7 +672,7 @@ When the engine releases an update we want to ship, we:
 
 The auth pipeline is wired end-to-end against the Jentic backend:
 
-- **Real keys**: issued at `jentic.com/signup`. Validated live by the container against `POST https://api.jentic.com/api/v1/usage/api-scoring` (header `X-Jentic-API-Key`). The same call doubles as the per-key usage / rate-limit accounting hit, so a single round-trip both authenticates and increments.
+- **Real keys**: issued at `https://app.jentic.com/scorecard?tab=api-keys`. Validated live by the container against `POST https://api.jentic.com/api/v1/usage/api-scoring` (header `X-Jentic-API-Key`). The same call doubles as the per-key usage / rate-limit accounting hit, so a single round-trip both authenticates and increments.
 - **Free tier**: URLs under [`jentic/jentic-public-apis`](https://github.com/jentic/jentic-public-apis) score without contacting the validator at all, regardless of whether a key is set.
 - **Fail-open**: when `api.jentic.com` is unreachable (3xx, unexpected 4xx, 5xx, network error, timeout, malformed body) the container prints a one-line warning and lets scoring proceed. PO-confirmed policy — an outage on Jentic's side must not block scoring.
 


### PR DESCRIPTION
## What

Replaces the hard-coded `jentic.com/signup` and `jentic.com/account` links in the gate's user-facing messages with the canonical, stable key-management page:

```
https://app.jentic.com/scorecard?tab=api-keys
```

This URL deep-links straight to the API Keys tab, so the previous "once signed in, click **Score → CLI & Keys**" navigation hint in the README is no longer needed and was dropped.

## Where

- `docker/src/jentic_scorecard_runner/gate.py` — all four runtime messages (stdin-no-key, anonymous-gate-rejected, rate-limited, invalid-key).
- `docs/architecture.md` — the error-UX examples and the §9 auth "Real keys" line that mirror the gate verbatim.
- `README.md` — the keyed-access section and the `JENTIC_API_KEY` env-var table row.

Historical CHANGELOG entries and the `specs/` roadmap/tech-stack references to the old `jentic.com/signup` flow are intentionally left untouched — they describe past/deprecated behavior, not the live gate.

## Verification

- `cd docker && uv run poe lint` — clean.
- `cd docker && uv run poe test tests/test_gate.py` — 24 passed (no test asserted on the URL strings).

Closes #126