### PR TITLE
docs(README): clarify spec never leaves local env

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,8 +275,9 @@ shipped, and run without a runtime dependency on Jentic.
 ### Your OpenAPI document never leaves your environment
 
 Scoring runs entirely in a container **on your own machine**. Local files are
-piped in over stdin; URLs are fetched by the container's engine, not by Jentic.
-Either way, your spec is never uploaded.
+piped in over stdin; URLs are fetched on your side — by the container's engine,
+or host-side by the CLI when you pass `--bundle` — never by Jentic. Either way,
+your spec is never uploaded.
 
 The **only** call to Jentic is a key-check round-trip against `api.jentic.com` —
 it carries your key, never any part of your spec, and OAK URLs (jentic-public-apis)

--- a/README.md
+++ b/README.md
@@ -272,6 +272,25 @@ paste a URL or drop a file, no Docker or Node required.
 For teams that need to know exactly what's running, verify exactly what was
 shipped, and run without a runtime dependency on Jentic.
 
+### Your OpenAPI document never leaves your environment
+
+Scoring happens entirely inside a container running **on your own machine**.
+Your spec is never uploaded to Jentic.
+
+- **Local files** are bundled on your host and piped straight into the local
+  container over stdin — the bytes go from your disk to a process on the same
+  machine, nothing else.
+- **URLs** are fetched by the local container's engine, not by Jentic — the
+  document and any external `$ref`s it resolves come to your machine, and the
+  scorecard is computed there.
+
+The **only** outbound call to Jentic is a small key-check round-trip against
+`api.jentic.com` that authenticates your key and increments your usage counter.
+It carries your key, never any part of your spec, and OAK URLs
+(jentic-public-apis) skip even that. The one exception is `--with-llm`, which
+sends spec context to the LLM provider **you** choose — and pointing it at a
+local endpoint (Ollama) keeps that on-machine too.
+
 ### Auditable end to end
 
 Every component in the scoring stack — runner, CLI, release pipeline, and
@@ -298,15 +317,12 @@ verifies an artifact end-to-end before you install it:
 
 The image is a closed system at scoring time: every Python wheel, Node.js
 binary, and validator tarball it needs is baked in at build time. Scoring does
-not call PyPI or npmjs and pulls no runtime packages. The **only** outbound
-call to Jentic is a small key-check round-trip against `api.jentic.com` that
-authenticates your key and increments the per-key usage counter; OAK URLs
-(jentic-public-apis) skip even that. URL inputs additionally reach the network to fetch the OpenAPI
-document and resolve any external `$ref`s it points at. `--with-llm`
-optionally sends spec context to an LLM provider of your choice; a local
-endpoint (Ollama) keeps everything on-machine. Multi-arch images
-(linux/amd64 + linux/arm64) ship from the same release, so the same guarantees
-hold on Apple Silicon dev machines, ARM CI runners, and x86 servers alike.
+not call PyPI or npmjs and pulls no runtime packages. The only network traffic
+is the document fetch for URL inputs and the key-check round-trip described
+above — see [Your OpenAPI document never leaves your environment](#your-openapi-document-never-leaves-your-environment).
+Multi-arch images (linux/amd64 + linux/arm64) ship from the same release, so the
+same guarantees hold on Apple Silicon dev machines, ARM CI runners, and x86
+servers alike.
 
 ### Pinned for reproducibility
 

--- a/README.md
+++ b/README.md
@@ -305,16 +305,13 @@ verifies an artifact end-to-end before you install it:
   per-platform SBOMs, dual-store attestations (BuildKit OCI referrers + Sigstore), and
   verification via either `docker buildx imagetools inspect` or `gh attestation verify`.
 
-### Runs anywhere, minimal phone-home
+### Runs anywhere
 
 The image is a closed system at scoring time: every Python wheel, Node.js
-binary, and validator tarball it needs is baked in at build time. Scoring does
-not call PyPI or npmjs and pulls no runtime packages. Its network traffic is
-limited to the document fetch for URL inputs and the key-check round-trip — see
-[Your OpenAPI document never leaves your environment](#your-openapi-document-never-leaves-your-environment).
-Multi-arch images (linux/amd64 + linux/arm64) ship from the same release, so the
-same guarantees hold on Apple Silicon dev machines, ARM CI runners, and x86
-servers alike.
+binary, and validator tarball it needs is baked in at build time, so scoring
+pulls no runtime packages from PyPI or npmjs. Multi-arch images (linux/amd64 +
+linux/arm64) ship from the same release, so the same guarantees hold on Apple
+Silicon dev machines, ARM CI runners, and x86 servers alike.
 
 ### Pinned for reproducibility
 

--- a/README.md
+++ b/README.md
@@ -274,22 +274,14 @@ shipped, and run without a runtime dependency on Jentic.
 
 ### Your OpenAPI document never leaves your environment
 
-Scoring happens entirely inside a container running **on your own machine**.
-Your spec is never uploaded to Jentic.
+Scoring runs entirely in a container **on your own machine**. Local files are
+piped in over stdin; URLs are fetched by the container's engine, not by Jentic.
+Either way, your spec is never uploaded.
 
-- **Local files** are bundled on your host and piped straight into the local
-  container over stdin — the bytes go from your disk to a process on the same
-  machine, nothing else.
-- **URLs** are fetched by the local container's engine, not by Jentic — the
-  document and any external `$ref`s it resolves come to your machine, and the
-  scorecard is computed there.
-
-The **only** outbound call to Jentic is a small key-check round-trip against
-`api.jentic.com` that authenticates your key and increments your usage counter.
-It carries your key, never any part of your spec, and OAK URLs
-(jentic-public-apis) skip even that. The one exception is `--with-llm`, which
-sends spec context to the LLM provider **you** choose — and pointing it at a
-local endpoint (Ollama) keeps that on-machine too.
+The **only** call to Jentic is a key-check round-trip against `api.jentic.com` —
+it carries your key, never any part of your spec, and OAK URLs (jentic-public-apis)
+skip even that. The one exception is `--with-llm`, which sends spec context to the
+LLM provider **you** choose (point it at a local Ollama to keep that on-machine too).
 
 ### Auditable end to end
 
@@ -317,9 +309,9 @@ verifies an artifact end-to-end before you install it:
 
 The image is a closed system at scoring time: every Python wheel, Node.js
 binary, and validator tarball it needs is baked in at build time. Scoring does
-not call PyPI or npmjs and pulls no runtime packages. The only network traffic
-is the document fetch for URL inputs and the key-check round-trip described
-above — see [Your OpenAPI document never leaves your environment](#your-openapi-document-never-leaves-your-environment).
+not call PyPI or npmjs and pulls no runtime packages. Its network traffic is
+limited to the document fetch for URL inputs and the key-check round-trip — see
+[Your OpenAPI document never leaves your environment](#your-openapi-document-never-leaves-your-environment).
 Multi-arch images (linux/amd64 + linux/arm64) ship from the same release, so the
 same guarantees hold on Apple Silicon dev machines, ARM CI runners, and x86
 servers alike.


### PR DESCRIPTION
## What

Leads the README's **Enterprise-ready by default** section with a new subsection — **Your OpenAPI document never leaves your environment** — that answers the question people keep asking head-on: scoring runs in a container on the user's own machine, and the spec is never uploaded to Jentic.

- **Local files** → bundled host-side, piped to the local container over stdin.
- **URLs** → fetched by the local container's engine, not by Jentic.
- The **only** Jentic-bound traffic is the key-check round-trip — it carries the key, never spec content; OAK URLs skip even that.
- Documents the one exception: `--with-llm` sends spec context to the provider *you* choose (local Ollama keeps it on-machine).

Also trims the now-overlapping outbound-call / `--with-llm` claims out of **Runs anywhere, minimal phone-home** and cross-references the new subsection instead, so the facts live in one place.

## Why

The data-locality story was previously buried mid-paragraph in "Runs anywhere, minimal phone-home." Users (and prospective enterprise adopters) have been asking whether their specs get uploaded; the answer deserves a clearly-titled, lead-position subsection.

All claims are grounded in `docs/architecture.md` (§2 input dispatch, §5 auth, §6 container entry) — the source of truth. Docs-only change; no code touched, no test suites apply.

Closes #150