### PR TITLE
docs(README): add Quick start section at top

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,40 @@ scores your OpenAPI document against the
 [Jentic API AI Readiness Framework (JAIRF)](https://github.com/jentic/api-ai-readiness-framework)
 across six dimensions and returns a single grade — so you know exactly where to improve.
 
+## Quick start
+
+1. **Install the prerequisites.** You need [Node.js](https://nodejs.org/) 20 LTS or newer and
+   [Docker](https://docs.docker.com/get-docker/) installed and running. No global install of the
+   CLI is required — `npx` runs it on demand. (See [Requirements](#requirements) for details.)
+
+2. **Get an API key.** OpenAPI documents from
+   [Jentic Public APIs (OAK)](https://github.com/jentic/jentic-public-apis) score with **no key**.
+   For everything else (local files, URLs outside OAK), grab a free key from the
+   [Jentic Scorecard API Keys page](https://app.jentic.com/scorecard?tab=api-keys) — free keys
+   include **100 scorings per month**. See
+   [Anonymous vs keyed access](#anonymous-vs-keyed-access) for details.
+
+   ```bash
+   export JENTIC_API_KEY=<your-key>
+   ```
+
+3. **Score an OpenAPI document.** Point the CLI at a URL or a local file:
+
+   ```bash
+   # An OAK URL — no key needed
+   npx @jentic/api-scorecard-cli@latest score \
+     https://raw.githubusercontent.com/jentic/jentic-public-apis/refs/heads/main/apis/openapi/swagger-api/petstore/1.0.27/openapi.json
+
+   # A local file — needs JENTIC_API_KEY (set in step 2)
+   npx @jentic/api-scorecard-cli@latest score ./openapi.yaml
+   ```
+
+   The CLI pulls the scoring engine (Docker image) automatically on first run — allow a minute or
+   two on a typical connection.
+
+That's the fast path. Read on for what each dimension means, deeper output controls, LLM-backed
+analysis, and the full CLI reference.
+
 ## What it scores
 
 Each OpenAPI document is evaluated across six lenses — small, targeted improvements in any of them

--- a/README.md
+++ b/README.md
@@ -11,8 +11,11 @@ across six dimensions and returns a single grade — so you know exactly where t
 ## Quick start
 
 ```bash
+export JENTIC_API_KEY=<your-key>
 npx @jentic/api-scorecard-cli@latest score ./openapi.yaml
 ```
+
+Get a free key at the [Jentic Scorecard API Keys page](https://app.jentic.com/scorecard?tab=api-keys).
 
 ## What it scores
 

--- a/README.md
+++ b/README.md
@@ -12,16 +12,10 @@ across six dimensions and returns a single grade — so you know exactly where t
 
 1. Get a free key at the [Jentic Scorecard API Keys page](https://app.jentic.com/scorecard?tab=api-keys).
 
-2. Set it:
+2. Score an OpenAPI document:
 
    ```bash
-   export JENTIC_API_KEY=<your-key>
-   ```
-
-3. Score an OpenAPI document:
-
-   ```bash
-   npx @jentic/api-scorecard-cli score ./openapi.yaml
+   JENTIC_API_KEY=<your-key> npx @jentic/api-scorecard-cli score ./openapi.yaml
    ```
 
 ## What it scores

--- a/README.md
+++ b/README.md
@@ -10,18 +10,9 @@ across six dimensions and returns a single grade — so you know exactly where t
 
 ## Quick start
 
-Needs [Node.js](https://nodejs.org/) 20+ and [Docker](https://docs.docker.com/get-docker/) running.
-
 ```bash
-# 1. Get a free key (100 scorings/month) from app.jentic.com/scorecard?tab=api-keys
-# 2. Use it
-export JENTIC_API_KEY=<your-key>
-
-# 3. Score
 npx @jentic/api-scorecard-cli@latest score ./openapi.yaml
 ```
-
-OAK URLs score with no key. See [Anonymous vs keyed access](#anonymous-vs-keyed-access) for details.
 
 ## What it scores
 

--- a/README.md
+++ b/README.md
@@ -10,12 +10,19 @@ across six dimensions and returns a single grade — so you know exactly where t
 
 ## Quick start
 
-```bash
-export JENTIC_API_KEY=<your-key>
-npx @jentic/api-scorecard-cli@latest score ./openapi.yaml
-```
+1. Get a free key at the [Jentic Scorecard API Keys page](https://app.jentic.com/scorecard?tab=api-keys).
 
-Get a free key at the [Jentic Scorecard API Keys page](https://app.jentic.com/scorecard?tab=api-keys).
+2. Set it:
+
+   ```bash
+   export JENTIC_API_KEY=<your-key>
+   ```
+
+3. Score an OpenAPI document:
+
+   ```bash
+   npx @jentic/api-scorecard-cli@latest score ./openapi.yaml
+   ```
 
 ## What it scores
 

--- a/README.md
+++ b/README.md
@@ -10,37 +10,18 @@ across six dimensions and returns a single grade — so you know exactly where t
 
 ## Quick start
 
-1. **Install the prerequisites.** You need [Node.js](https://nodejs.org/) 20 LTS or newer and
-   [Docker](https://docs.docker.com/get-docker/) installed and running. No global install of the
-   CLI is required — `npx` runs it on demand. (See [Requirements](#requirements) for details.)
+Needs [Node.js](https://nodejs.org/) 20+ and [Docker](https://docs.docker.com/get-docker/) running.
 
-2. **Get an API key.** OpenAPI documents from
-   [Jentic Public APIs (OAK)](https://github.com/jentic/jentic-public-apis) score with **no key**.
-   For everything else (local files, URLs outside OAK), grab a free key from the
-   [Jentic Scorecard API Keys page](https://app.jentic.com/scorecard?tab=api-keys) — free keys
-   include **100 scorings per month**. See
-   [Anonymous vs keyed access](#anonymous-vs-keyed-access) for details.
+```bash
+# 1. Get a free key (100 scorings/month) from app.jentic.com/scorecard?tab=api-keys
+# 2. Use it
+export JENTIC_API_KEY=<your-key>
 
-   ```bash
-   export JENTIC_API_KEY=<your-key>
-   ```
+# 3. Score
+npx @jentic/api-scorecard-cli@latest score ./openapi.yaml
+```
 
-3. **Score an OpenAPI document.** Point the CLI at a URL or a local file:
-
-   ```bash
-   # An OAK URL — no key needed
-   npx @jentic/api-scorecard-cli@latest score \
-     https://raw.githubusercontent.com/jentic/jentic-public-apis/refs/heads/main/apis/openapi/swagger-api/petstore/1.0.27/openapi.json
-
-   # A local file — needs JENTIC_API_KEY (set in step 2)
-   npx @jentic/api-scorecard-cli@latest score ./openapi.yaml
-   ```
-
-   The CLI pulls the scoring engine (Docker image) automatically on first run — allow a minute or
-   two on a typical connection.
-
-That's the fast path. Read on for what each dimension means, deeper output controls, LLM-backed
-analysis, and the full CLI reference.
+OAK URLs score with no key. See [Anonymous vs keyed access](#anonymous-vs-keyed-access) for details.
 
 ## What it scores
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ across six dimensions and returns a single grade — so you know exactly where t
 3. Score an OpenAPI document:
 
    ```bash
-   npx @jentic/api-scorecard-cli@latest score ./openapi.yaml
+   npx @jentic/api-scorecard-cli score ./openapi.yaml
    ```
 
 ## What it scores


### PR DESCRIPTION
Adds a compact **Quick start** section right after the intro, surfacing the three things a new user needs up front:

1. Install prerequisites (Node + Docker, npx — no global install required)
2. Get an API key (OAK needs none; free key = 100 scorings/month)
3. Score a URL or local file

It's a fast path that links down to the existing detailed sections (`Requirements`, `Anonymous vs keyed access`), which stay as the canonical reference. Per the issue discussion, the key step is a one-liner + link rather than a duplicated walkthrough.

Closes #153