### PR TITLE
ci(docker-security): filter Trivy SARIF to high/critical

### DIFF
--- a/.github/workflows/docker-security.yml
+++ b/.github/workflows/docker-security.yml
@@ -39,15 +39,14 @@ jobs:
 
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@v0.36.0
-        env:
-          # SARIF output ignores the `severity:` input; gate via env so the
-          # security tab stays aligned with the CRITICAL/HIGH policy below.
-          TRIVY_SEVERITY: 'CRITICAL,HIGH'
         with:
           image-ref: 'jentic-api-scorecard:security-scan'
           format: 'sarif'
           output: 'trivy-results.sarif'
           severity: 'CRITICAL,HIGH'
+          # SARIF output emits every severity unless this is set; without it the
+          # security tab fills with LOW/MEDIUM despite the severity filter above.
+          limit-severities-for-sarif: true
           ignore-unfixed: true
           vuln-type: 'os,library'
 


### PR DESCRIPTION
## What

Add `limit-severities-for-sarif: true` to the Trivy scan step and drop the `TRIVY_SEVERITY` env workaround.

## Why

The Security tab was filling with LOW/MEDIUM findings despite the workflow setting `severity: 'CRITICAL,HIGH'`. This is documented behaviour in `aquasecurity/trivy-action`: **SARIF output emits every severity regardless of the `severity` input** unless `limit-severities-for-sarif: true` is set.

The previous `TRIVY_SEVERITY` env block was based on the wrong assumption that the env var gates SARIF output — it doesn't; neither the input nor the env filters SARIF. The dedicated `limit-severities-for-sarif` input is the only setting that does.

## Effect

After this merges and the workflow re-runs on `main`, the Security tab will only surface CRITICAL/HIGH (and only fixable ones, via the existing `ignore-unfixed: true`). Existing LOW/MEDIUM alerts may need manual dismissal or will reconcile as the SARIF no longer reports them.