### PR TITLE
docs(README): make agent skill link absolute

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ code `7` and prints the `Retry-After` value along with a link to upgrade your pl
 
 ## Agent Skills
 
-This repository ships a versioned [agent skill](skills/jentic-api-scorecard/SKILL.md)
+This repository ships a versioned [agent skill](https://github.com/jentic/jentic-api-scorecard/blob/main/skills/jentic-api-scorecard/SKILL.md)
 that teaches AI coding agents how to use the CLI correctly — installing it, scoring
 files and URLs, producing JSON/HTML, wiring it into CI, enabling LLM analysis, and
 interpreting exit codes. Install it through whichever path fits your agent.


### PR DESCRIPTION
The Agent Skills section linked to the skill with a repo-relative path (`skills/jentic-api-scorecard/SKILL.md`). That resolves on GitHub but breaks when the README is rendered on the npm package page, where the tarball relocates files. Switched it to the absolute `https://github.com/jentic/jentic-api-scorecard/blob/main/...` form already used by every other doc link in the README.

Verified it was the only non-absolute link: a sweep for relative markdown links, reference-style definitions, and HTML `src`/`href` attributes turned up no others.