### PR TITLE
fix(score): correct schema depth via jentic-apitools 1.0.0a18

### DIFF
--- a/docker/pyproject.toml
+++ b/docker/pyproject.toml
@@ -4,8 +4,8 @@ version = "0.1.0"
 description = "Container-internal runner for jentic-api-scorecard"
 requires-python = ">=3.12"
 dependencies = [
-    "jentic-apitools-pipelines==1.0.0a17",
-    "jentic-apitools-common==1.0.0a17",
+    "jentic-apitools-pipelines==1.0.0a18",
+    "jentic-apitools-common==1.0.0a18",
     "requests>=2.34.2,<3",
 ]
 

--- a/docker/uv.lock
+++ b/docker/uv.lock
@@ -307,7 +307,9 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c4/37/4549f149c9797c21b32c2683c33522af22522099de128b2406672526d005/greenlet-3.5.1-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:fa4f98af3a528f0c3fd592a26df7f376f93329c8f4d987f6bb979057af8bf5e2", size = 286220, upload-time = "2026-05-20T13:07:28.463Z" },
     { url = "https://files.pythonhosted.org/packages/38/ff/a4f436709716965eaab9f36ea7b906c8a927fbe32fb1372a2071d964f6b1/greenlet-3.5.1-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ffea73584b216150eab159b6d12348fb253e68757974de1e2c40d8a318ac89ed", size = 601585, upload-time = "2026-05-20T14:00:06.141Z" },
     { url = "https://files.pythonhosted.org/packages/65/ad/54bc3fcee3ad368a61b19b67d88117f7a8c29727bf71fffdeda81fbd946e/greenlet-3.5.1-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1072b4f9edcc1e192d9283a66a3e68d6b84c561de33a83d7858beb9ba1effe10", size = 614215, upload-time = "2026-05-20T14:05:42.675Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/6c/de5b1b388cd2d9fbdfeab324863daba37d54e6e233ddbefd70b385a8c591/greenlet-3.5.1-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:89101bfd5011e069be974903cb3a4e4523845e4ece2d62dcd8d358933c0ef249", size = 620094, upload-time = "2026-05-20T14:09:09.18Z" },
     { url = "https://files.pythonhosted.org/packages/40/69/b91cda0647df839483201545913514c2827ebea5e5ccdf931842763bc127/greenlet-3.5.1-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:add5217d68b31130f0beca584d7fef4878327d2e31642b66618a14eef312b63b", size = 611358, upload-time = "2026-05-20T13:14:26.37Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/43/1204baffab8a6476464795a7ccf394a3248d4f22c9f87173a15b36b6d971/greenlet-3.5.1-cp312-cp312-manylinux_2_39_riscv64.whl", hash = "sha256:e6cd99ea59dd5d89f0c956606571d79bfe6f68c9eb7f4a4083a41a7f1587edee", size = 422782, upload-time = "2026-05-20T14:01:39.597Z" },
     { url = "https://files.pythonhosted.org/packages/59/90/3cf77e080350cd02fa307bb2abf05df48f4482c240275bbd2c203ba8bb1c/greenlet-3.5.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a5ea42a752d47a145eae922b605cd1634665ac3d5ec1e72402d5048e8d60d207", size = 1570475, upload-time = "2026-05-20T14:02:25.29Z" },
     { url = "https://files.pythonhosted.org/packages/65/2c/18cece62045e74598c3c393f70dce4a63f56222015ba29a5d4eeb04f764c/greenlet-3.5.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:c5551170cf4f5ff5623e9af81323751979fee2c731e2287b61f73cd27257b823", size = 1635625, upload-time = "2026-05-20T13:14:34.027Z" },
     { url = "https://files.pythonhosted.org/packages/30/f5/310d104ddf41eb5a70f4c268d22508dfb0c3c8e86fec152be34d0d2ed819/greenlet-3.5.1-cp312-cp312-win_amd64.whl", hash = "sha256:3c8bb982ad117d29478ef8f5533e97df21f1e2befd17a299257b0c96d1371c0b", size = 238791, upload-time = "2026-05-20T13:10:39.018Z" },
@@ -315,7 +317,9 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/27/69/7f7e5372d998b81001899b1c0823c957aa413ba0f2662e65821611cc31e4/greenlet-3.5.1-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:51518ff74664078fc51bffcc6fc529b0df5ae58da192691cee765d45ce944a2b", size = 285060, upload-time = "2026-05-20T13:08:51.899Z" },
     { url = "https://files.pythonhosted.org/packages/b1/bf/387f9b6b865fd2ae0d0be09e0004827295a01b71be76ed350dd1e28a91a4/greenlet-3.5.1-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1ffdb3c0bb002c99cd8f298957e046c3dbf6006b5b7cdf11a4e19194624a0a0a", size = 604370, upload-time = "2026-05-20T14:00:07.492Z" },
     { url = "https://files.pythonhosted.org/packages/32/f5/169ce3d4e4c67291bd18f8cbe0299c9f3e45102c7f1fb3c14780c93e4532/greenlet-3.5.1-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7715a5a2c3378ba602c3a440558261e13a820bb53a82693aacd7b7f6d964e283", size = 616987, upload-time = "2026-05-20T14:05:44.237Z" },
+    { url = "https://files.pythonhosted.org/packages/19/ba/c24110c55dffa55aa6e1d98b45310da33801aeba7686ff0190fe5d46fd32/greenlet-3.5.1-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:d40a890035c0058cadbdc4af7569800fd28a0e527a0fdbb7b5f9418f176846ce", size = 622911, upload-time = "2026-05-20T14:09:10.598Z" },
     { url = "https://files.pythonhosted.org/packages/ee/e5/7f2e41d5273be07e77560d61ea4e56485b4d6c316d2a84518c62d1364061/greenlet-3.5.1-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:dc71ff466927a201b08305acac451ebe1aedfcea002f62f1f2f2ac2ac1e6a135", size = 613911, upload-time = "2026-05-20T13:14:27.539Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/7b/d20db2e8a5ad6c038702f3179b136f93f0a3d1a21a0c0777f3e470cdf4b2/greenlet-3.5.1-cp313-cp313-manylinux_2_39_riscv64.whl", hash = "sha256:67821bb03e4e98664490edb787ff6af501194c29bbee0f5c1dfdcf1dc3d9d436", size = 425228, upload-time = "2026-05-20T14:01:40.837Z" },
     { url = "https://files.pythonhosted.org/packages/c5/a4/fbdc67579b73615a1f91615e814303cc71e06128f7baaba87be79b8fb90c/greenlet-3.5.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:cd443683db272ebaaca03af98c0b063ab30db70ea8a31a1559f35e3f7b744ccd", size = 1570689, upload-time = "2026-05-20T14:02:27.225Z" },
     { url = "https://files.pythonhosted.org/packages/e6/b4/77abbe35078be39718a46cd49caf16bceb35662f97a34101dca28aa98e47/greenlet-3.5.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:089fff7a6ce8d9316d1f65ebc00273a56be258c1725b32b94de90a3a979557e1", size = 1635602, upload-time = "2026-05-20T13:14:36.344Z" },
     { url = "https://files.pythonhosted.org/packages/37/f7/129f27ca700845b8ee8ca88ce7f43435a1239c2eddb7677fc938822762cf/greenlet-3.5.1-cp313-cp313-win_amd64.whl", hash = "sha256:110a1ca7b49b014b097f6078272c3f4ed31af45b254de5228b79adba879f6af9", size = 238683, upload-time = "2026-05-20T13:11:50.57Z" },
@@ -323,7 +327,9 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/8a/cb/c62454606daf5640369c94d8a9dd540599b1bfc090e2d2180cb77f4038d2/greenlet-3.5.1-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:d8ab31c9de8651a2facdd5c5bb0011f2380dd1a7af78ce2adf4b56095294fc07", size = 285579, upload-time = "2026-05-20T13:08:56.396Z" },
     { url = "https://files.pythonhosted.org/packages/ec/71/c4270398c2eba968a6071af1dfbdcaeee6ec1c24bc8b435b8cc452700da6/greenlet-3.5.1-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5e300185139abc337ade480c327183adf42a875ac7181bfe66d7d4efea31fbea", size = 651106, upload-time = "2026-05-20T14:00:09.448Z" },
     { url = "https://files.pythonhosted.org/packages/1a/ab/71e34b78a44ec271fb5f550c17bc46d301ddc5953890d935f270b0dcdb5a/greenlet-3.5.1-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7ffdb990dcaa0234cf9845aead5df2e3c3a8b6507d409274dd87e0d5ab05ffc2", size = 663478, upload-time = "2026-05-20T14:05:45.88Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/2d/2d80842910da44f78c286532d084b8a5c3717c844ae80ceb3858738ae89a/greenlet-3.5.1-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:6c09df69dc1712d131332054a858a3e5cca400967fa3a672e2324fbb0971448c", size = 667767, upload-time = "2026-05-20T14:09:12.15Z" },
     { url = "https://files.pythonhosted.org/packages/77/96/4efd6fa5c62c85426a0c19077a586258ebc3a2a146ff2493e4312a697a22/greenlet-3.5.1-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2f82b3597e9d83b63408affed0b48fd0f54935edac4302237b9a837be0dae33c", size = 660800, upload-time = "2026-05-20T13:14:29.129Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/d3/dad2eecedfbb1ed7050a20dcfae40c1442b74bc7423608be2c7e03ee7133/greenlet-3.5.1-cp314-cp314-manylinux_2_39_riscv64.whl", hash = "sha256:a4764e0bfc6a4d114c865b32520805c16a990ef5f286a514413b05d5ecd6a23d", size = 470786, upload-time = "2026-05-20T14:01:42.064Z" },
     { url = "https://files.pythonhosted.org/packages/7a/e0/6c71401a25cac7000261304e866a2f2cc04dc74810d40e2f118aa4799495/greenlet-3.5.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:c0141e37414c10164e702b8fb1473304221ad98f71600850c6ef7ff4880feba0", size = 1617518, upload-time = "2026-05-20T14:02:28.662Z" },
     { url = "https://files.pythonhosted.org/packages/41/26/c5c06643e8c0af9e7bf18e16cb51d0ab7625155f0392e1c9015d66d556cd/greenlet-3.5.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:50ae25a67bea74ea41fb14b960bc532df73eb713417b2d61892dced82fe8d3bc", size = 1681593, upload-time = "2026-05-20T13:14:39.417Z" },
     { url = "https://files.pythonhosted.org/packages/8a/bd/e11a108317485075e68af9d23039619b86b28130c3b50d227d42edece64b/greenlet-3.5.1-cp314-cp314-win_amd64.whl", hash = "sha256:8a17c42330e261299766b75ac1ea32caa437a9453c8f65d16a13140db378ecd3", size = 239800, upload-time = "2026-05-20T13:09:30.128Z" },
@@ -331,14 +337,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/90/12/41bf27fde4d3605d3773ae57751eda182b8be2f5398011c041173b1d9534/greenlet-3.5.1-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:ea8da1e900d758d078810d4255d8c6aa572181896a31ec79d779eb79c3adc9ad", size = 293637, upload-time = "2026-05-20T13:12:35.529Z" },
     { url = "https://files.pythonhosted.org/packages/44/44/ba14b23e9757707050c2f397d305bbcae62e5d7cad122f8b6baec5ae4a1f/greenlet-3.5.1-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a19570c52a21420dcbc94e661994bc325c0b5b11304540fed514586da5dc8f2e", size = 650840, upload-time = "2026-05-20T14:00:11.079Z" },
     { url = "https://files.pythonhosted.org/packages/a8/37/5ddc2b686a6844f91abecef43411842426da2e1573f60b49ecf2547f4ae1/greenlet-3.5.1-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:3d955c89b75eeca4723d7cc14135f393cd47c32e2a6cb4a8e4c6e760a26b0986", size = 656416, upload-time = "2026-05-20T14:05:47.118Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/46/5987dcd1a2570ba84f3b187536b2ca3ae97613387e57f5cfa99df068fe5e/greenlet-3.5.1-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ea37d5a157eb9493820d3792ac4ece28619a394391d2b9f2f78057d396ff0f0f", size = 656607, upload-time = "2026-05-20T14:09:13.949Z" },
     { url = "https://files.pythonhosted.org/packages/e1/f0/d17510297c35a2992712f0bf84de3779749999f7d3d63aa1f09db7c62dbe/greenlet-3.5.1-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:de2daaaebd1a5aa88c49045b6baf9310b3263796bd88db713edf37cf53e7bb4e", size = 654397, upload-time = "2026-05-20T13:14:30.696Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/c1/6da0a9ddcc29d7e51ef14883fa3dc1e53b3f4ffba00582106c7bf55da1d8/greenlet-3.5.1-cp314-cp314t-manylinux_2_39_riscv64.whl", hash = "sha256:8d8a23250ea3ec7b36de8fa4b541e9e2db3ee82915cc060ab0631609ad8b28de", size = 488287, upload-time = "2026-05-20T14:01:43.143Z" },
     { url = "https://files.pythonhosted.org/packages/37/eb/147387705bb89092645b012586e7273cb5ed3c90ef7eaf3a69173eaf0209/greenlet-3.5.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:3bfbd69cc349e43bf3a8ae1c85548ff0718efc887615c2db16c3833d7b0b072d", size = 1614469, upload-time = "2026-05-20T14:02:30.192Z" },
     { url = "https://files.pythonhosted.org/packages/a6/4e/37ee0da7732b7aa9896f17e15579a9df34b9fcb9dd494f0adfa749af6623/greenlet-3.5.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:4378720dd888136c27215a0214d32a4d37c3852765d45bc37aad0623423cfd78", size = 1675115, upload-time = "2026-05-20T13:14:40.972Z" },
     { url = "https://files.pythonhosted.org/packages/57/f3/97dfcf4a6eb5077f8a672234216fb5923eb89f2cab7081cb10b2cf75b605/greenlet-3.5.1-cp314-cp314t-win_amd64.whl", hash = "sha256:45718441607f9325d948db98cbc691276059316d0358c188c246da4e1d4d23d2", size = 245246, upload-time = "2026-05-20T13:12:22.646Z" },
     { url = "https://files.pythonhosted.org/packages/5d/73/d7f72e34b582f694f4a9b248162db7b09cc458a259ba8f0c0bfa1a34ea7d/greenlet-3.5.1-cp315-cp315-macosx_11_0_universal2.whl", hash = "sha256:2baee5ca02031757ffe8cc3d69f0cc0aec7065ce362622da74f32d3bcab1c541", size = 285575, upload-time = "2026-05-20T13:12:07.043Z" },
     { url = "https://files.pythonhosted.org/packages/df/59/fa9c6e87dc8ad27a95dabe2f29f372b733d05a8a67470f6c901ed9975655/greenlet-3.5.1-cp315-cp315-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9b1ec3274918a81d3ea778b9e75b56b72b33f300edb6cf7f3a7fe1dae56683de", size = 656428, upload-time = "2026-05-20T14:00:12.556Z" },
     { url = "https://files.pythonhosted.org/packages/f6/f9/e753408871eaa61dfe35e619cfc67512b036fde99893685d50eea9e07146/greenlet-3.5.1-cp315-cp315-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:111e2390ffffc47d5840b01711dd7fac07d4c09283d0283e7f3264b14e284c64", size = 667064, upload-time = "2026-05-20T14:05:48.662Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/74/807a047255bf1e09303627c46dc043dca596b6958a354d904f32ab382005/greenlet-3.5.1-cp315-cp315-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:10a9a1c0bfbc93d41156ffcb90c75fbc05544054faf15dcc1fdf9765f8b607f0", size = 672962, upload-time = "2026-05-20T14:09:15.532Z" },
     { url = "https://files.pythonhosted.org/packages/96/27/5565b5b40389f1c7753003a07e21892fda8660926787036d5bc0308b8113/greenlet-3.5.1-cp315-cp315-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e630136e905fe5ff43e86945ae41220b6d1470956a39220e708110ac48d01ea5", size = 665697, upload-time = "2026-05-20T13:14:32.943Z" },
+    { url = "https://files.pythonhosted.org/packages/76/32/19d4e13225193c29b13e308015223f7d75fd3d8623d49dd19040d2ce8ec1/greenlet-3.5.1-cp315-cp315-manylinux_2_39_riscv64.whl", hash = "sha256:ef08c1567c78074b22d1a200183d52d04a14df447bf70bcbb6a3507a48e776fc", size = 476047, upload-time = "2026-05-20T14:01:44.39Z" },
     { url = "https://files.pythonhosted.org/packages/cf/82/e7de4178c0c2d1c9a5a3be3cc0b33e46a85b3ee4a77c071bf7ad8600e079/greenlet-3.5.1-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:975eac34b44a7077ca4d421348455b94f0f518246a7f14bc6d2fdcfe5b584368", size = 1621256, upload-time = "2026-05-20T14:02:31.91Z" },
     { url = "https://files.pythonhosted.org/packages/00/10/f2dddcf7dacac17dfc68691809589adad06135eb28930429cf58a6467a2f/greenlet-3.5.1-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:9ab3c3a0b2ae6198e67c898dad5215a49f9ae0d0081b3c3ec59f333e39eeca26", size = 1685956, upload-time = "2026-05-20T13:14:42.55Z" },
     { url = "https://files.pythonhosted.org/packages/22/17/4a232b32133230ada52f70e9d7f5b65b0caef8772f01849bd8d149e7e4ca/greenlet-3.5.1-cp315-cp315-win_amd64.whl", hash = "sha256:cbfc69be86e10dcfef5b1e6269d1d6926552aa89ee39e1de3353360c1b6989ab", size = 239802, upload-time = "2026-05-20T13:13:15.481Z" },
@@ -346,7 +356,9 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/7a/57/816d9cff29119da3505b3d6a5e14a8af89006ac36f47f891ff293ee05af1/greenlet-3.5.1-cp315-cp315t-macosx_11_0_universal2.whl", hash = "sha256:a6fdf2433a5441ef9a95464f7c3e674775da1c8c1177fff311cee1acad4626ed", size = 293877, upload-time = "2026-05-20T13:10:19.078Z" },
     { url = "https://files.pythonhosted.org/packages/23/a1/59b0a7c7d140ff1a75626680b9a9899b79a9176cab298b394968fb023295/greenlet-3.5.1-cp315-cp315t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7546556f0d649f99f6a361098a55f761181bb2ea12ff150bb16d26092ad88244", size = 655333, upload-time = "2026-05-20T14:00:14.758Z" },
     { url = "https://files.pythonhosted.org/packages/72/1b/5efe127597625042218939d01855109f352779050768b670b52edcc16a6c/greenlet-3.5.1-cp315-cp315t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:d5ee3ea898009fa898f85f9982255d35278c477bebe185beca249cab42d4526c", size = 659443, upload-time = "2026-05-20T14:05:50.159Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/9d/1dcdf7b95ab3cf8c7b6d7277c18a5e167312f2b362ddfcc5d5e6d8d84b43/greenlet-3.5.1-cp315-cp315t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a57b0d05a0448eed231d59c0ceb287dde984551e54cbc51ac2d4865712838e9c", size = 659998, upload-time = "2026-05-20T14:09:16.912Z" },
     { url = "https://files.pythonhosted.org/packages/6c/6d/c404246ea4d22d097a7426d0efb5b781bd7eb67715f09e79001bd552ab18/greenlet-3.5.1-cp315-cp315t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a5c81f74d204d3edd136ebfd50dce53acbb776995d721a0fe801626cfc93b8cd", size = 658356, upload-time = "2026-05-20T13:14:35.091Z" },
+    { url = "https://files.pythonhosted.org/packages/05/7e/c4959664fc231d587d66d8e81f2095e98056ba1954beafdcbe635e251052/greenlet-3.5.1-cp315-cp315t-manylinux_2_39_riscv64.whl", hash = "sha256:b0703c2cef53e01baec47f7a3868009913ad71ec678bbecb42a6f40895e4ce62", size = 494470, upload-time = "2026-05-20T14:01:45.611Z" },
     { url = "https://files.pythonhosted.org/packages/51/02/f8ee37fb6d2219329f350af241c27fcf12df57e723d11f6fc6d3bacdadaa/greenlet-3.5.1-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:2c18ef16bf6d4dd410e4dd52996888ea1497be26892fe5bbc73580aba4287b8e", size = 1619216, upload-time = "2026-05-20T14:02:33.403Z" },
     { url = "https://files.pythonhosted.org/packages/93/c5/3dc9475ace2c7a3680da12372cddd7f1ac874eb410a1ac48d3e9dab83782/greenlet-3.5.1-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:17d86354f0ae6b61bf9be5148d0dd34e06c3cb7c602c671f79f29ac3b150e659", size = 1678427, upload-time = "2026-05-20T13:14:43.71Z" },
     { url = "https://files.pythonhosted.org/packages/df/4e/750c15c317a41ffb36f0bf40b933e3d744a7dede61889f74443ea69690cf/greenlet-3.5.1-cp315-cp315t-win_amd64.whl", hash = "sha256:e7516cf6ae6b8a582c2770a0caed47b8a48373ed732c33d69a72913ae6ac923e", size = 245225, upload-time = "2026-05-20T13:13:59.366Z" },
@@ -373,7 +385,7 @@ wheels = [
 
 [[package]]
 name = "jentic-apitools-analyze"
-version = "1.0.0a17"
+version = "1.0.0a18"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "deepdiff" },
@@ -385,14 +397,14 @@ dependencies = [
     { name = "jentic-openapi-validator-spectral" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fb/2d/b3ffa5b9af4bf15bac2b5460239600f890e8fc18eaea79499251dbdcaa4c/jentic_apitools_analyze-1.0.0a17.tar.gz", hash = "sha256:7b9532d729b2991051138359efed53ddd72abc9971cfc7dbdd03bf1033a4d365", size = 29883, upload-time = "2026-05-29T09:58:55.616Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/93/8e2550e86adfc31fec00629acd3e0496390e03a03dac915b9b337f9a7bd4/jentic_apitools_analyze-1.0.0a18.tar.gz", hash = "sha256:8c1ba2451361cbdd1483a0aec90202043ba5ec0f00dc4584ee3e89a9c6fcea6a", size = 30769, upload-time = "2026-06-11T08:57:01.952Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d3/ce/61a378f6cf29e9ca05b4e9d229c8c46a1a3224239911f92d305796b4cf78/jentic_apitools_analyze-1.0.0a17-py3-none-any.whl", hash = "sha256:d2813ebbf855ce88b1cd48a2a386f45fb0e723bac243d275560ed8e9b49696d4", size = 50130, upload-time = "2026-05-29T09:58:47.212Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/6a/eaa2d14e3404a0adb08acf53ec64567487e5b1c51b164a28b81a9c7be11b/jentic_apitools_analyze-1.0.0a18-py3-none-any.whl", hash = "sha256:c913ff3b8004f59994f6e61c1d4e4cb1798ef350ca9013420c9242ce543e5ee0", size = 51096, upload-time = "2026-06-11T08:56:53.12Z" },
 ]
 
 [[package]]
 name = "jentic-apitools-common"
-version = "1.0.0a17"
+version = "1.0.0a18"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jentic-openapi-validator" },
@@ -400,14 +412,14 @@ dependencies = [
     { name = "pydantic-settings" },
     { name = "python-dotenv" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/25/f0/5405e71673486777b79f014d7b222cef8353d0b6b8bb173a7b60fe616b7a/jentic_apitools_common-1.0.0a17.tar.gz", hash = "sha256:524e8086297e0cc5a0d66bd40cdf92a2a59f49bcac04c8c1d95c2fbf4af5e21a", size = 26063, upload-time = "2026-05-29T09:58:56.945Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/79/25/4540c479892c141b5fbdf17bea67ffc4cc26e8b21a8cbc4c505d9a31b5c6/jentic_apitools_common-1.0.0a18.tar.gz", hash = "sha256:3f7b507c84194526e03d7cf8a4d5e13389e0469ffa09f5f3b3033b5e9cf97bd6", size = 26063, upload-time = "2026-06-11T08:57:03.605Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7a/ea/9221a9080343a28bbc4b17762d2a2b1935fb6b0c0977ebe6d52a79a82f4c/jentic_apitools_common-1.0.0a17-py3-none-any.whl", hash = "sha256:4a68771c703660ece0dc57ed02ba718ef3809b07e387e93ad372a2088ce02728", size = 30624, upload-time = "2026-05-29T09:58:49.263Z" },
+    { url = "https://files.pythonhosted.org/packages/15/76/0e34cb2a907152e687fec94ff5627f8c0c4f89e934a0a2dcdf189fdbbd0f/jentic_apitools_common-1.0.0a18-py3-none-any.whl", hash = "sha256:95490071b3374eee0fc48b45c02ab301a09d2157ff40e898d8d8dfb6a5158910", size = 30623, upload-time = "2026-06-11T08:56:55.156Z" },
 ]
 
 [[package]]
 name = "jentic-apitools-llm"
-version = "1.0.0a17"
+version = "1.0.0a18"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "boto3" },
@@ -416,14 +428,14 @@ dependencies = [
     { name = "pydantic-settings" },
     { name = "requests" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c7/39/57b8452e680ba718152e856e328b9db044ad6b1c6b74f1596b192b107da1/jentic_apitools_llm-1.0.0a17.tar.gz", hash = "sha256:16256d470cb900ce52901ee0a7252849e33818bc46d81d316c8b933df8cc8124", size = 16548, upload-time = "2026-05-29T09:58:58.29Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/d0/7443dbb6944df3803a907a1e1c6e9c11497ea1c9cab30766524637363cd4/jentic_apitools_llm-1.0.0a18.tar.gz", hash = "sha256:16b6a5ca446b733af96b1c671fe8c52e3614087203d667bfc27a37e1c63e9c1f", size = 16551, upload-time = "2026-06-11T08:57:04.926Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/27/81/59f108e3bd2d3ed0277c27c88b0009471768353c98379e032daefa8c841a/jentic_apitools_llm-1.0.0a17-py3-none-any.whl", hash = "sha256:c2e8b9fb9fbdac1cabc7441d156b01f84e1050affbc8db9eed4d4a59c8c894d2", size = 23741, upload-time = "2026-05-29T09:58:51.01Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/7d/ac32c014804c6756a1e105f82d296d7b1c95f733a9e239f422c6ad09240a/jentic_apitools_llm-1.0.0a18-py3-none-any.whl", hash = "sha256:997749095efac09710dc3d8a16564381180709c412886e8f9fb25eaed69e7f30", size = 23743, upload-time = "2026-06-11T08:56:57.029Z" },
 ]
 
 [[package]]
 name = "jentic-apitools-pipelines"
-version = "1.0.0a17"
+version = "1.0.0a18"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "datadog" },
@@ -439,28 +451,28 @@ dependencies = [
     { name = "pydantic" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d6/ca/42159bce32a20655e6a78808152acf758df64de7832461ca07600b1b936a/jentic_apitools_pipelines-1.0.0a17.tar.gz", hash = "sha256:8e2657cdb04a0a1e4869224e8e081221e1ddd2e36606209812d4cc76a50f7584", size = 43815, upload-time = "2026-05-29T09:58:58.91Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9c/74/bc1ddfd742b4fead43c126a934d85530fa3a621f00be057f6d095c8ead86/jentic_apitools_pipelines-1.0.0a18.tar.gz", hash = "sha256:534af77483f47ee86ba745568019912e987f3f5cd29cf68fe73a528d54947257", size = 43812, upload-time = "2026-06-11T08:57:05.591Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a1/1b/7ed74f100369e6ea18844ed66bf64e756b34606e8c41bc41e77ee90452bd/jentic_apitools_pipelines-1.0.0a17-py3-none-any.whl", hash = "sha256:d8ac0b17d99994478c94d741a80e44a99fe124fe42ea3e92c202c377302640fa", size = 53212, upload-time = "2026-05-29T09:58:51.909Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/80/5e19dedc9477ce4fd507f5ed3f819ea342b835f38a070bedf354d3ca7519/jentic_apitools_pipelines-1.0.0a18-py3-none-any.whl", hash = "sha256:58dcfdf766df6c62f4f9fcdb25884d11ac627089323590b7c78bc5a6fb16657c", size = 53218, upload-time = "2026-06-11T08:56:58.12Z" },
 ]
 
 [[package]]
 name = "jentic-apitools-score"
-version = "1.0.0a17"
+version = "1.0.0a18"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jentic-apitools-analyze" },
     { name = "jentic-apitools-common" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/60/91/646e52ab4811027ecf7a625b2e98c67313fca0e451ed40d5b6520b33538a/jentic_apitools_score-1.0.0a17.tar.gz", hash = "sha256:611477034a99b284ffc74fb9e7f494bd83dc4aeb881b21bd27c065223bb3ac37", size = 55794, upload-time = "2026-05-29T09:59:00.463Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0d/50/76dae005d3a5e720c51c9ddfd3f95e8481f239e1932a7fcf27fa674faa0a/jentic_apitools_score-1.0.0a18.tar.gz", hash = "sha256:502b149d844d874fbb5773d843fcd806e9bacbd9451e3bbbaee973d3d7888e93", size = 55797, upload-time = "2026-06-11T08:57:06.953Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/08/c9/5ae3645e7b0b038769431e2d74483154f3dce0b582ebef59494d3ffb678f/jentic_apitools_score-1.0.0a17-py3-none-any.whl", hash = "sha256:e52b41ced749294828407a54aa42d01b279a8220049271ed734a0d3664acbed0", size = 95047, upload-time = "2026-05-29T09:58:53.657Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/08/7da0c9139a22efde986004e6a4f302dc51ff40a6d6ca653e120197949912/jentic_apitools_score-1.0.0a18-py3-none-any.whl", hash = "sha256:fc68935c0e5b8b7e2bc83aabe3d14c92389de8d3f5ebcfc3874b9fad9426ed3a", size = 95049, upload-time = "2026-06-11T08:57:00.034Z" },
 ]
 
 [[package]]
 name = "jentic-apitools-storage"
-version = "1.0.0a17"
+version = "1.0.0a18"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jentic-apitools-common" },
@@ -468,9 +480,9 @@ dependencies = [
     { name = "pygithub" },
     { name = "sqlalchemy" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/96/8f/05db0f9a8f0778b6cbab7382388d9df426e4805cf729086878497478dab2/jentic_apitools_storage-1.0.0a17.tar.gz", hash = "sha256:112282bdf13f3161a8626b29eef28e72a9c5c733c012214989801ba3bbd3e506", size = 17158, upload-time = "2026-05-29T09:59:01.215Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bc/d2/c26da27b8186348f198d0050a18d9592fbda3194d432087a5ad14ee18913/jentic_apitools_storage-1.0.0a18.tar.gz", hash = "sha256:5942f36a6e215edd863662ec3aa1befff80be45013338a4a8fe24190316975a2", size = 17157, upload-time = "2026-06-11T08:57:08.022Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/55/9c/e6d1bdb29f08f05d9816613ff1022880656d5d9f1d05ed175e2ddcf67d3b/jentic_apitools_storage-1.0.0a17-py3-none-any.whl", hash = "sha256:85a5795e5d8cfac6918c0565cec7d3661f9cd30d7e6daa6054cee27f90f3e706", size = 25032, upload-time = "2026-05-29T09:58:54.688Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/ac/9f7c01d8ecbc4e9a375f3d6851260b497b22a0af85ed1b4f40313c904e42/jentic_apitools_storage-1.0.0a18-py3-none-any.whl", hash = "sha256:c66248086daa8753f4db00bccce9d06a1a1b0bf36b640d77036afba4914e373c", size = 25031, upload-time = "2026-06-11T08:57:01.082Z" },
 ]
 
 [[package]]
@@ -513,61 +525,61 @@ wheels = [
 
 [[package]]
 name = "jentic-openapi-transformer"
-version = "1.0.0a56"
+version = "1.0.0a57"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jentic-openapi-common" },
     { name = "jentic-openapi-parser" },
     { name = "jentic-openapi-traverse" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/21/d6/c8a2ab38946ac80db616418b5abcd39c34467ab7b55df415fa6a870da2f7/jentic_openapi_transformer-1.0.0a56.tar.gz", hash = "sha256:8e7091618052e4acacb7c0012f002a7e7674f09217572519293a2da0ef617191", size = 12057, upload-time = "2026-05-19T11:26:40.002Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/95/96/d543f1589e4dae2865ff939ffc3763f672455a7c0061fc652c2eba14e54e/jentic_openapi_transformer-1.0.0a57.tar.gz", hash = "sha256:1daa8d20ee94986f7f570122c439e82967e32c8d1f3b6888314a690b374eb570", size = 12057, upload-time = "2026-06-10T15:09:57.852Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/82/da/3ad04775d16ba3b424b8d4fa030d69af7803d3ddf8d61b372ffb2828d5f9/jentic_openapi_transformer-1.0.0a56-py3-none-any.whl", hash = "sha256:7df24df42e4de3a2b56862aaf1d9b3310ba392013cfbfb3fe477576887b09294", size = 17513, upload-time = "2026-05-19T11:26:26.431Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/48/47c94decf092de9e5b88ced9f97d371217a8defaf468acc596a8b00705a4/jentic_openapi_transformer-1.0.0a57-py3-none-any.whl", hash = "sha256:42d3b2802d9dd33d7ab018ba5431dac05eb168c6c7a403faae328b9d47eff67b", size = 17514, upload-time = "2026-06-10T15:09:44.996Z" },
 ]
 
 [[package]]
 name = "jentic-openapi-transformer-redocly"
-version = "1.0.0a56"
+version = "1.0.0a57"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jentic-openapi-common" },
     { name = "jentic-openapi-transformer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7a/d5/5e616271be55d73c7434daf316d77c3ed2b1e24bebda9698a9b5d6531814/jentic_openapi_transformer_redocly-1.0.0a56.tar.gz", hash = "sha256:f9d3f65806f8c65a81365618c1dc9047441cad54b26ea336285cbd42cfaae013", size = 8592, upload-time = "2026-05-19T11:26:40.876Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0e/b6/7b2f7905311667f7dfbf99c3709256644ec9fb696502a794818920b7a8f7/jentic_openapi_transformer_redocly-1.0.0a57.tar.gz", hash = "sha256:42cc0c5606bd04707c3aa7e7f473a9dd4d08086839e3f350c8023507886b87a0", size = 8594, upload-time = "2026-06-10T15:09:58.678Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/73/ba/f19a9d0011cf86a37cc0f819dbe6716c284870ad2a257a436ac9bc29db96/jentic_openapi_transformer_redocly-1.0.0a56-py3-none-any.whl", hash = "sha256:040cc2297f8f4fbc79b78bde10957be258d5134d82e048c276f5d0989f1def9e", size = 11982, upload-time = "2026-05-19T11:26:27.922Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/59/38591fd5e0dc11ab7bcda6363912dc5eb8ef04375bdd06ea9a323412868d/jentic_openapi_transformer_redocly-1.0.0a57-py3-none-any.whl", hash = "sha256:36bdc7ce643bd66e110bcf21fff7bec7460f0e862c19ee172ca88a5dcf921aff", size = 11983, upload-time = "2026-06-10T15:09:46.38Z" },
 ]
 
 [[package]]
 name = "jentic-openapi-traverse"
-version = "1.0.0a56"
+version = "1.0.0a57"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jentic-openapi-datamodels" },
     { name = "jsonpointer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b6/5e/b19220151ce23821f0c324b8ce213e7aaf6191a1b2bba714cfcffb9158ce/jentic_openapi_traverse-1.0.0a56.tar.gz", hash = "sha256:36d6772438609bb4664b5c9f42b969df5059dde72a3f5326b351801c5c2ef29b", size = 16889, upload-time = "2026-05-19T11:26:42.018Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/24/74/8f4a89732bdae4e25d8c60ab640958a22d80a3ed916becf067fa4915063f/jentic_openapi_traverse-1.0.0a57.tar.gz", hash = "sha256:23bc4d6cdb2a1c34da0c2eebacdebd2ac596641e8b43758e6dcbcf94477bc7aa", size = 16877, upload-time = "2026-06-10T15:09:59.602Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/99/9b/52cc6a75a8cc3cef5451ba2d604c98fdba8969d2accb13ee8fcbadeedf8d/jentic_openapi_traverse-1.0.0a56-py3-none-any.whl", hash = "sha256:e0568fb0f1dedce389484abce2ccfe0af80eac7941df5e2fef78cb1d51ec4fe3", size = 22223, upload-time = "2026-05-19T11:26:29.25Z" },
+    { url = "https://files.pythonhosted.org/packages/89/d6/c31fd7384ad351a252fc119f415be75f8a6ae6398ae2404edaf5f7c19939/jentic_openapi_traverse-1.0.0a57-py3-none-any.whl", hash = "sha256:8d0d19b79e05e7d027acbb46d971ce23b04b57bf57d0da9c7f7313b2463387c3", size = 22218, upload-time = "2026-06-10T15:09:47.622Z" },
 ]
 
 [[package]]
 name = "jentic-openapi-validator"
-version = "1.0.0a56"
+version = "1.0.0a57"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jentic-openapi-parser" },
     { name = "lsprotocol" },
     { name = "openapi-spec-validator" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8a/00/e6020593ee6f801656163bb38cdee3ff2925d766dbcfee53a689843a19cc/jentic_openapi_validator-1.0.0a56.tar.gz", hash = "sha256:6978eafeadb7616c48aa64457bc613d93b7c0bd9936677e865214b5dd320ec63", size = 23255, upload-time = "2026-05-19T11:26:42.961Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/25/8a/935bfacfc6dd4648086226315257b205d8dc278641d42ebbb0964de75298/jentic_openapi_validator-1.0.0a57.tar.gz", hash = "sha256:97dbb240a844cbdd72e4fe9dea270514e17d608195825df3efcd27d0ef4fb08b", size = 23254, upload-time = "2026-06-10T15:10:00.719Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e0/a0/a983d19011a66b5f6adfaed79d1fa27820544243e2825ef63a03ceeb286b/jentic_openapi_validator-1.0.0a56-py3-none-any.whl", hash = "sha256:46d760909c3aa025fa6e17fb98d8ee4f7562d5a19b75514f070b9047d14af5fa", size = 31840, upload-time = "2026-05-19T11:26:30.756Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/02/a4e4c3b0657974fe7a886225a2203ece8d173ffbed888e0c5d3166f992c0/jentic_openapi_validator-1.0.0a57-py3-none-any.whl", hash = "sha256:7ade5bba5769c9f6391d18ae8e231fb9a3b7653e2db8de17f111c11326384cae", size = 31840, upload-time = "2026-06-10T15:09:48.993Z" },
 ]
 
 [[package]]
 name = "jentic-openapi-validator-redocly"
-version = "1.0.0a56"
+version = "1.0.0a57"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jentic-openapi-common" },
@@ -575,37 +587,37 @@ dependencies = [
     { name = "jsonpointer" },
     { name = "lsprotocol" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6b/4e/796b5152313e57ea72196d41378bf855c30899d1a13394d574773a4a0c43/jentic_openapi_validator_redocly-1.0.0a56.tar.gz", hash = "sha256:d47f674a5b951f419d0c148c9b5e7a2c37aaa399a4ca9297a43c173828ebb68b", size = 11597, upload-time = "2026-05-19T11:26:43.879Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1f/67/1dfa02b68b2000271031b62147298246a3468d2327c05580923a7556a60a/jentic_openapi_validator_redocly-1.0.0a57.tar.gz", hash = "sha256:a0e2f306c5a81becb18f1a58f00767ba56bd633f1bf5f88fb07a85ff12d5119a", size = 11593, upload-time = "2026-06-10T15:10:01.656Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/33/57/6e3c22a2283793d786c0eb2a9f3a52255b1cea510439968de87b85a99813/jentic_openapi_validator_redocly-1.0.0a56-py3-none-any.whl", hash = "sha256:8e6040b55b2172eb0952bb6767876033f502dd4278fadcea4bda3b4194e911d5", size = 15072, upload-time = "2026-05-19T11:26:32.201Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/ac/f64606a0c5ffc3d4e765ae2bb56946bb345c2ca0ba0fd845fd2106ff1997/jentic_openapi_validator_redocly-1.0.0a57-py3-none-any.whl", hash = "sha256:26762caedeb3ad530817398c0f941128c93906643db1ba978339b2eac345c84d", size = 15075, upload-time = "2026-06-10T15:09:50.211Z" },
 ]
 
 [[package]]
 name = "jentic-openapi-validator-speclynx"
-version = "1.0.0a56"
+version = "1.0.0a57"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jentic-openapi-common" },
     { name = "jentic-openapi-validator" },
     { name = "lsprotocol" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/02/cd/c8867bc3257f99ecdba6a79e8e7718c532a94b600b1b7376b61c5c7bc9c6/jentic_openapi_validator_speclynx-1.0.0a56.tar.gz", hash = "sha256:f2b59210218bc9e820d7fb06b3575d9330b54283f2f1205a13092ab412e6d8cb", size = 17676, upload-time = "2026-05-19T11:26:44.964Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0c/8b/edd4f4f18207143088a3bd741e5c4c810320e1921c22bf3f64f204b38d02/jentic_openapi_validator_speclynx-1.0.0a57.tar.gz", hash = "sha256:8d5175694318b358c20eef563a69aec4f351465265654974e80fc64187411984", size = 18026, upload-time = "2026-06-10T15:10:02.588Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/44/b1/4e96079607aba8ab5fa32013dbc15325d005a3f91ec1bcb38417e680725d/jentic_openapi_validator_speclynx-1.0.0a56-py3-none-any.whl", hash = "sha256:82d4c596c48bce0c290fe426720915d75d7d4d80adf96fed0014aa4acf993fa9", size = 20237, upload-time = "2026-05-19T11:26:33.755Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/ed/a4f5d349740ad09501d6af293a80ec237298d0198193b042bcd67a2de989/jentic_openapi_validator_speclynx-1.0.0a57-py3-none-any.whl", hash = "sha256:67a53faffbe6096ba6f98dd8651ca2953390975d36b7bff94224b0cf75e88473", size = 20587, upload-time = "2026-06-10T15:09:51.6Z" },
 ]
 
 [[package]]
 name = "jentic-openapi-validator-spectral"
-version = "1.0.0a56"
+version = "1.0.0a57"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jentic-openapi-common" },
     { name = "jentic-openapi-validator" },
     { name = "lsprotocol" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/91/83/cbe9c2c364886173c69f5455eee8d3ac3b66e8180f92cbbcce50ec99df1b/jentic_openapi_validator_spectral-1.0.0a56.tar.gz", hash = "sha256:659fe01e9a042602d3f18c32040cd69a893fbfbb32b2b4c4d9c1e8ce3b6e08ff", size = 12267, upload-time = "2026-05-19T11:26:46.2Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/30/54/e87fee941840787d43247089eaef2980a52a8b6171b773942804db3cea89/jentic_openapi_validator_spectral-1.0.0a57.tar.gz", hash = "sha256:46524b44065e344497bc9f339757b6142eb333ab8dfcd610742d6553f7be2704", size = 12266, upload-time = "2026-06-10T15:10:03.493Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0f/48/6dd464cb820dfceabe84334c69a7f7afc35fbb7653189ec23639c751635c/jentic_openapi_validator_spectral-1.0.0a56-py3-none-any.whl", hash = "sha256:ed4bc343110191531f9dd266c330befe1f056caf538f60bcece206255adf00c9", size = 15828, upload-time = "2026-05-19T11:26:34.896Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/8a/68eba1b3ef794b62011fe5678d288cd21e59d8f7090eba571e8df29ee9f7/jentic_openapi_validator_spectral-1.0.0a57-py3-none-any.whl", hash = "sha256:39f79b9d06c62b39c42dcd9a4c7edbfd99d265205f36020fec2151481880fdd4", size = 15827, upload-time = "2026-06-10T15:09:52.689Z" },
 ]
 
 [[package]]
@@ -628,8 +640,8 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "jentic-apitools-common", specifier = "==1.0.0a17" },
-    { name = "jentic-apitools-pipelines", specifier = "==1.0.0a17" },
+    { name = "jentic-apitools-common", specifier = "==1.0.0a18" },
+    { name = "jentic-apitools-pipelines", specifier = "==1.0.0a18" },
     { name = "requests", specifier = ">=2.34.2,<3" },
 ]
 
@@ -673,11 +685,11 @@ wheels = [
 
 [[package]]
 name = "jsonpointer"
-version = "3.0.0"
+version = "3.1.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6a/0a/eebeb1fa92507ea94016a2a790b93c2ae41a7e18778f85471dc54475ed25/jsonpointer-3.0.0.tar.gz", hash = "sha256:2b2d729f2091522d61c3b31f82e11870f60b68f43fbc705cb76bf4b832af59ef", size = 9114, upload-time = "2024-06-10T19:24:42.462Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/18/c7/af399a2e7a67fd18d63c40c5e62d3af4e67b836a2107468b6a5ea24c4304/jsonpointer-3.1.1.tar.gz", hash = "sha256:0b801c7db33a904024f6004d526dcc53bbb8a4a0f4e32bfd10beadf60adf1900", size = 9068, upload-time = "2026-03-23T22:32:32.458Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/71/92/5e77f98553e9e75130c78900d000368476aed74276eb8ae8796f65f00918/jsonpointer-3.0.0-py2.py3-none-any.whl", hash = "sha256:13e088adc14fca8b6aa8177c044e12701e6ad4b28ff10e65f2267a90109c9942", size = 7595, upload-time = "2024-06-10T19:24:40.698Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/6a/a83720e953b1682d2d109d3c2dbb0bc9bf28cc1cbc205be4ef4be5da709d/jsonpointer-3.1.1-py3-none-any.whl", hash = "sha256:8ff8b95779d071ba472cf5bc913028df06031797532f08a7d5b602d8b2a488ca", size = 7659, upload-time = "2026-03-23T22:32:31.568Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Bumps `jentic-apitools-pipelines` and `jentic-apitools-common` from `1.0.0a17` to `1.0.0a18`, which also pulls in updated `jentic-openapi-*` deps (a56 → a57) that the fix depends on.

## What this fixes

The scoring engine's schema-depth analysis under-counted nesting on dereferenced specs: shared inner subtrees were skipped on deeper traversal paths, so deeply-nested schemas reported a shallower depth than they actually have. a18 corrects this. The metric feeds the **Complexity Comfort** signal, so deep specs now score that signal against their true nesting.

## Verification

A/B'd the affected metrics across the old and new engine on the real Stripe spec (414 paths, 1422 schemas):

| Field | before (a17) | after (a18) |
|---|---|---|
| `max_schema_depth` | 37 | **71** |
| `normalised_schema_depth` | 8.5e-05 | **0.142** |
| `resolved_refs` | 3860 | 3860 |

Local checks, all green:
- `uv run poe test tests/test_main.py` / `tests/test_gate.py` — 10 + 24 passed
- Rebuilt image + `uv run poe test tests/test_integration.py` — 11 passed
- `uv run poe lint` — clean
- CLI smoke against the rebuilt image: petstore scores 69/100, Scoring Engine reports 0.4.2