### PR TITLE
docs(README): add skills.sh badge and directory link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Jentic API Scorecard
 
+[![skills.sh](https://skills.sh/b/jentic/jentic-api-scorecard)](https://skills.sh/jentic/jentic-api-scorecard)
+
 ![Jentic API Scorecard preview](https://github.com/jentic/jentic-api-scorecard/raw/main/assets/scorecard-preview.jpg)
 
 An OpenAPI document that passes validation isn't necessarily one an AI agent can use. Grammar is
@@ -278,6 +280,8 @@ Install it straight from this repository with the
 ```bash
 npx skills add jentic/jentic-api-scorecard --skill jentic-api-scorecard
 ```
+
+It's also listed in the [skills.sh directory](https://skills.sh/jentic/jentic-api-scorecard).
 
 ### TanStack Intent
 


### PR DESCRIPTION
## What

Adds the [skills.sh](https://www.skills.sh/) directory presence to the README:

- A **skills.sh badge** at the top of the README:
  ```
  [![skills.sh](https://skills.sh/b/jentic/jentic-api-scorecard)](https://skills.sh/jentic/jentic-api-scorecard)
  ```
- A **directory link** in the "Vercel `skills` CLI" section pointing at <https://skills.sh/jentic/jentic-api-scorecard>.

## Why

skills.sh is Vercel's Agent Skills Directory, built on the `vercel-labs/skills` CLI we already support. There's no submission step — listings are telemetry-driven and **ranked by install count**. Our skill page already exists but sits at ~1 install. Surfacing the badge/link drives installs via the CLI, which is the only lever on visibility/ranking.

Badge image and page URLs verified to resolve (`200 image/svg+xml` after the `skills.sh` → `www.skills.sh` redirect; GitHub's image proxy follows it). Kept the docs' canonical `skills.sh/...` form.