### PR TITLE
ci(skill-security): add SkillSpector scan gate and badge

### DIFF
--- a/.github/workflows/skill-security.yml
+++ b/.github/workflows/skill-security.yml
@@ -1,0 +1,105 @@
+name: SkillSpector
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '0 4 * * 2' # weekly, Tuesdays 04:00 UTC (same cadence as CodeQL / docker-security)
+  workflow_dispatch:
+
+concurrency:
+  group: skill-security-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+permissions:
+  contents: read
+  security-events: write # upload SARIF to the GitHub Security tab
+
+jobs:
+  # Glob skills/* into a JSON matrix so new skills are scanned automatically —
+  # no workflow edit needed when a second skill lands.
+  discover:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      skills: ${{ steps.list.outputs.skills }}
+    steps:
+      - uses: actions/checkout@v6
+      - id: list
+        run: |
+          skills=$(ls -d skills/*/ | xargs -n1 basename | jq -R . | jq -cs .)
+          echo "skills=${skills}" >> "$GITHUB_OUTPUT"
+          echo "Discovered skills: ${skills}"
+
+  skill-security:
+    needs: discover
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false # one flagged skill must not cancel the others' scans
+      matrix:
+        skill: ${{ fromJSON(needs.discover.outputs.skills) }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      # SkillSpector is not published to PyPI and cuts no release tags, so we
+      # install from a pinned commit SHA — an unpinned main could flip the gate
+      # (or its ruleset) without a change on our side. Bump deliberately in its
+      # own PR. cff7ecc = v2.1.4.
+      - name: Install SkillSpector
+        run: python -m pip install "git+https://github.com/NVIDIA/SkillSpector.git@cff7ecc4f2881d9e23ea4bb801a6353e1dbe39e6"
+
+      # Static analysis only (--no-llm): the semantic LLM stage needs a provider
+      # credential we don't expose to CI, and it adds nothing for a markdown-only
+      # skill (verified locally). Two scans because the CLI emits one --format per
+      # run: JSON carries the aggregate verdict (risk_assessment) the gate
+      # enforces; SARIF carries only individual findings, which feed the Security
+      # tab but cannot drive the SAFE/CAUTION/DANGER gate on their own.
+      - name: Scan ${{ matrix.skill }}
+        run: |
+          skillspector scan "skills/${{ matrix.skill }}/" \
+            --no-llm --format json --output report.json
+          skillspector scan "skills/${{ matrix.skill }}/" \
+            --no-llm --format sarif --output results.sarif
+          cat report.json
+
+      # Best-effort audit trail, not the gate. A pull_request from a forked repo
+      # gets a read-only GITHUB_TOKEN without security-events:write, so we skip
+      # the upload there rather than let it fail noisily; the scan + JSON gate
+      # below still run for forks. continue-on-error covers any other transient
+      # upload failure on non-fork runs. The JSON gate is the authoritative check.
+      # A per-skill category keeps each skill's findings as a distinct, self-
+      # healing analysis in the Security tab.
+      - name: Upload SARIF to GitHub Security
+        if: always() && github.event.pull_request.head.repo.fork != true
+        continue-on-error: true
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: results.sarif
+          category: skillspector-${{ matrix.skill }}
+
+      - name: Enforce SAFE recommendation
+        run: |
+          recommendation=$(python -c "import json; print(json.load(open('report.json'))['risk_assessment']['recommendation'])")
+          score=$(python -c "import json; print(json.load(open('report.json'))['risk_assessment']['score'])")
+          echo "${{ matrix.skill }}: recommendation=${recommendation} risk-score=${score}/100"
+          if [ "${recommendation}" != "SAFE" ]; then
+            echo "::error::SkillSpector flagged ${{ matrix.skill }} (recommendation=${recommendation}, risk-score=${score}/100). See report above and the Security tab."
+            exit 1
+          fi
+
+      - name: Upload report artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: skillspector-report-${{ matrix.skill }}
+          path: |
+            report.json
+            results.sarif

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Jentic API Scorecard
 
 [![skills.sh](https://skills.sh/b/jentic/jentic-api-scorecard)](https://skills.sh/jentic/jentic-api-scorecard)
+[![SkillSpector](https://github.com/jentic/jentic-api-scorecard/actions/workflows/skill-security.yml/badge.svg)](https://github.com/jentic/jentic-api-scorecard/actions/workflows/skill-security.yml)
 
 ![Jentic API Scorecard preview](https://github.com/jentic/jentic-api-scorecard/raw/main/assets/scorecard-preview.jpg)
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -148,6 +148,7 @@ jentic-api-scorecard/
 └── .github/workflows/
     ├── ci.yml                                (lint + test on PRs; also callable via workflow_call)
     ├── docker-publish.yml                    (build + push :unstable to GHCR on main; gated on ci.yml)
+    ├── skill-security.yml                    (SkillSpector static scan, matrixed over every skills/* dir; gates each skill on a SAFE recommendation)
     └── release.yml                           (workflow_dispatch — bump via Conventional Commits, build versioned image, npm publish at @latest)
 ```
 


### PR DESCRIPTION
## What

Adds a **SkillSpector** security scan to CI for the published agent skill under `skills/`, with a status badge in the README.

- **New workflow** `.github/workflows/skill-security.yml` — runs [NVIDIA SkillSpector](https://github.com/NVIDIA/SkillSpector)'s static analysis over `skills/jentic-api-scorecard/` on every push/PR to `main`, plus a weekly cron (Tuesdays 04:00 UTC, matching CodeQL / `docker-security.yml`).
  - Uploads SARIF to the **GitHub Security tab** via `github/codeql-action/upload-sarif` — same pattern as `docker-security.yml`.
  - **Gates the build**: fails the job unless `risk_assessment.recommendation == SAFE`.
- **README badge** — workflow-status badge labelled `SkillSpector`.
- **docs/architecture.md §4** — records the new workflow in the layout tree.

## Notes / decisions

- **Pinned to a commit SHA** (`cff7ecc` = v2.1.4). SkillSpector ships no PyPI package and cuts no release tags, so the only reproducible pin is the git commit. An unpinned `main` could flip the gate or its ruleset with no change on our side; bump deliberately in its own PR.
- **`--no-llm` (static only).** The semantic LLM stage needs a provider credential not available in public CI. Verified locally (via a LiteLLM→Bedrock bridge on Claude Opus 4.8) that the full LLM pass also returns `0/100 SAFE` — it adds nothing for a markdown-only skill. The static pass is the gate.
- **Badge wording.** Labelled `SkillSpector` (the tool name) rather than the raw `0/100` score — SkillSpector's score is a *risk* meter where low = good, which reads as the opposite of a grade out of context.

## Verification

Ran the exact scan + gate steps locally against the pinned SHA:

```
SkillSpector: recommendation=SAFE risk-score=0/100
WOULD PASS gate
SARIF valid, results: 0
```