### PR TITLE
docs(spec): scaffold phase 18 — markdown formatter

### DIFF
--- a/specs/2026-06-15-markdown-formatter/plan.md
+++ b/specs/2026-06-15-markdown-formatter/plan.md
@@ -13,7 +13,7 @@
 6. Render the API-stats line (operations / schemas / tags / security schemes) from `apiMetadata` when present, as a short bullet or inline list.
 7. Render the signals section at `--detail signals` and above: per dimension (from `details[].dimensions[].signals[]`), a sub-heading and a table of signal Name / Score (as `%`, since signal scores are `[0,1]`) / Description. Skip dimensions with no signals.
 8. Render the diagnostics section at `--detail diagnostics`: a severity tally then a table (or grouped lists) of findings — code, severity label, message. Escape literal `|` in messages (`\|`) so cells don't break the table. Tolerate zero diagnostics (render a "0 diagnostics" line).
-9. Add a small `escapeCell(s: string): string` helper for pipe/newline escaping in table cells.
+9. Add a small `escapeCell(s: string): string` helper for table cells: escape literal `|` to `\|`, and collapse any literal newline (`\n`/`\r`) to a space so a multi-line message can't break the GFM row.
 
 ## Group 3 — Wire into dispatch
 
@@ -25,7 +25,7 @@
 12. Create `packages/cli/test/formatters/markdown.test.ts` asserting against `packages/cli/test/fixtures/scorecard.sample.json` (mirror `pretty.test.ts` / `json.test.ts` structure): headline contains the rounded score, upper-cased level, and grade; the dimension table has a GFM header row plus one row per `summary.dimensions[]` entry (6 in the fixture) with the expected kinds (`FC`, `DXJ`, `ARAX`, `AU`, `SEC`, `AID`).
 13. Add `--detail` projection cases: `summary` → headline only, no dimension table; `dimensions` → dimension table present, no signals/diagnostics sections; `signals` → signals section present; `diagnostics` → diagnostics section present. Feed each through `filterByDetail(fixture, level)` as the sibling formatter tests do.
 14. Add a robustness case: a minimal `ScorecardResult` (only `summary.{score,level,grade}`) renders a headline without throwing and emits no empty tables.
-15. Add a pipe-escaping case: a diagnostic message containing `|` renders as `\|` inside the table cell (construct a small fixture inline or reuse a fixture diagnostic if one contains a pipe).
+15. Add a cell-escaping case: build a small inline `ScorecardResult` whose diagnostic message contains both a literal `|` and a `\n` (no fixture diagnostic contains a pipe, so the input must be constructed), and assert the rendered cell shows `\|` and a space (no raw pipe, no row break).
 
 ## Group 5 — Docs and lifecycle
 

--- a/specs/2026-06-15-markdown-formatter/plan.md
+++ b/specs/2026-06-15-markdown-formatter/plan.md
@@ -1,0 +1,43 @@
+# Phase 18 Plan — Markdown formatter (`--format markdown`)
+
+## Group 1 — Register the format
+
+1. Add `MARKDOWN: 'markdown'` to the `Format` `as const` record in `packages/cli/src/format.ts` and append `Format.MARKDOWN` to the `FORMATS` array. The `-f, --format` choices in `index.ts` extend automatically from `FORMATS`.
+2. Confirm no `validateScoreOptions` change is needed: Markdown is plain text, safe to a TTY (the formatter never refuses stdout). Leave `validate.ts` untouched.
+
+## Group 2 — Implement the formatter
+
+3. Create `packages/cli/src/formatters/markdown.ts` exporting `formatMarkdown(result: ScorecardResult, options: { detail?: DetailLevel } = {}): string`, mirroring `formatPretty`'s signature and `--detail` gating but emitting GFM (no `chalk` import, no ANSI).
+4. Render the headline: an H1 title, then score (rounded integer `/ 100`), level (upper-cased), and grade — e.g. `Score **66** / 100 — AI-AWARE (B)`. Include the engine/framework version line and `apiMetadata.name`/version when present, as `pretty` does.
+5. Render the dimension table at `--detail dimensions` and above: a GFM pipe table with columns Kind / Name / Score / Grade from `summary.dimensions[]` (rounded integer scores). Omit the table when `summary.dimensions` is absent/empty.
+6. Render the API-stats line (operations / schemas / tags / security schemes) from `apiMetadata` when present, as a short bullet or inline list.
+7. Render the signals section at `--detail signals` and above: per dimension (from `details[].dimensions[].signals[]`), a sub-heading and a table of signal Name / Score (as `%`, since signal scores are `[0,1]`) / Description. Skip dimensions with no signals.
+8. Render the diagnostics section at `--detail diagnostics`: a severity tally then a table (or grouped lists) of findings — code, severity label, message. Escape literal `|` in messages (`\|`) so cells don't break the table. Tolerate zero diagnostics (render a "0 diagnostics" line).
+9. Add a small `escapeCell(s: string): string` helper for pipe/newline escaping in table cells.
+
+## Group 3 — Wire into dispatch
+
+10. In `packages/cli/src/commands/score.ts`, import `formatMarkdown` and extend the format-dispatch chain so `format === Format.MARKDOWN` calls `formatMarkdown(filtered, { detail })` (Markdown consumes the `--detail`-filtered result, exactly like `pretty`).
+11. Confirm `-o` output works for Markdown: `writeReport` strips ANSI only for `pretty`; Markdown carries no ANSI, so it passes through verbatim. Add no special-casing.
+
+## Group 4 — Tests
+
+12. Create `packages/cli/test/formatters/markdown.test.ts` asserting against `packages/cli/test/fixtures/scorecard.sample.json` (mirror `pretty.test.ts` / `json.test.ts` structure): headline contains the rounded score, upper-cased level, and grade; the dimension table has a GFM header row plus one row per `summary.dimensions[]` entry (6 in the fixture) with the expected kinds (`FC`, `DXJ`, `ARAX`, `AU`, `SEC`, `AID`).
+13. Add `--detail` projection cases: `summary` → headline only, no dimension table; `dimensions` → dimension table present, no signals/diagnostics sections; `signals` → signals section present; `diagnostics` → diagnostics section present. Feed each through `filterByDetail(fixture, level)` as the sibling formatter tests do.
+14. Add a robustness case: a minimal `ScorecardResult` (only `summary.{score,level,grade}`) renders a headline without throwing and emits no empty tables.
+15. Add a pipe-escaping case: a diagnostic message containing `|` renders as `\|` inside the table cell (construct a small fixture inline or reuse a fixture diagnostic if one contains a pipe).
+
+## Group 5 — Docs and lifecycle
+
+16. Update `README.md`: add `markdown` to the `## CLI reference` `--format` choices and add a short `--format markdown` subsection (sibling to the existing `--format json` / `--format html` subsections) showing a `$GITHUB_STEP_SUMMARY` / PR-comment usage example.
+17. Update `skills/jentic-api-scorecard/SKILL.md`: add `markdown` to the `-f, --format <fmt>` row's allowed values (currently `pretty`, `json`, `html`), per `.claude/rules/cli-readme-sync.md`.
+18. Append ` ✅` (a single space followed by the U+2705 checkmark) to the `## Phase 18 — Markdown formatter (\`--format markdown\`)` heading in `specs/roadmap.md`, leaving the rest of the block untouched.
+
+## Group 6 — Verify
+
+19. `npm run lint -w @jentic/api-scorecard-cli` exits 0 (ESLint + Prettier clean on `markdown.ts` and touched files).
+20. `npm run build:typescript -w @jentic/api-scorecard-cli` exits 0 (`tsc` type-checks the new formatter and the dispatch/format-record changes).
+21. `npm test -w @jentic/api-scorecard-cli` exits 0, including the new `markdown.test.ts` (headline, dimension table, `--detail` projection, robustness, pipe-escaping).
+22. `node packages/cli/bin/jentic-api-scorecard.mjs score https://raw.githubusercontent.com/jentic/jentic-public-apis/refs/heads/main/apis/openapi/swagger-api/petstore/1.0.27/openapi.json --format markdown` exits 0 and prints valid GFM (an H1 headline and a `|`-delimited dimension table). (Requires the local image at the matching tag — `npm run build:image` if absent.)
+23. Spot-check the rendered Markdown: paste the §22 output (or `--detail diagnostics` output) into a GitHub Markdown preview (or a `$GITHUB_STEP_SUMMARY` in a scratch workflow) and confirm the table and headings render — no raw `|` pipes leaking, no broken rows.
+24. `grep -F "## Phase 18 — Markdown formatter (\`--format markdown\`) ✅" specs/roadmap.md` exits 0 (lifecycle marker present with the load-bearing leading space).

--- a/specs/2026-06-15-markdown-formatter/requirements.md
+++ b/specs/2026-06-15-markdown-formatter/requirements.md
@@ -1,0 +1,57 @@
+# Phase 18 Requirements — Markdown formatter (`--format markdown`)
+
+## Scope
+
+Add `markdown` as a value of the CLI's `-f, --format` flag. When selected, the CLI emits a GitHub-flavored Markdown (GFM) projection of the scorecard: a headline (score / level / grade), a dimension table, an optional per-signal section, and an optional diagnostics section. The output is plain text suitable for `$GITHUB_STEP_SUMMARY`, PR comments, and status checks — no ANSI color, no terminal-only formatting.
+
+The Markdown formatter is the Markdown analogue of the existing `pretty` formatter: it renders the same scorecard sections from the same engine-result fields, gated by the same `--detail` levels, but as rendered GFM (headings, tables, lists) instead of ANSI-colored terminal text. It is a pure function of the engine result JSON, so a downstream consumer (the Phase 19 GitHub Action) can derive it from a captured `report.json` with no re-scoring.
+
+## Out of Scope
+
+- The GitHub Action that consumes this formatter (Phase 19). This phase ships only the `--format markdown` CLI capability.
+- Posting Markdown to PR comments or the GitHub Checks API — that is the Action's job; the CLI only produces the string.
+- A `./markdown` subpath export from the CLI package. The Action renders Markdown by invoking `score … --format markdown` (the formatter need not be importable). If a future consumer needs the function directly, exporting it is a non-breaking follow-up.
+- Any change to `pretty`, `json`, or `html` output, or to the `--detail` filter semantics.
+- Emoji / shields.io badges / collapsible `<details>` chrome. Keep the first cut to clean GFM headings, tables, and lists; richer presentation can follow if the Action wants it.
+
+## Decisions
+
+### Full parity with `pretty`, gated by `--detail`
+
+The Markdown formatter renders every section `pretty` renders, gated by the same `--detail` levels: the headline always; the dimension table at `dimensions` and above; a per-signal section at `signals` and above; a diagnostics section at `diagnostics`. This makes `--format markdown --detail diagnostics` a complete run summary — the shape the GitHub Action wants for `$GITHUB_STEP_SUMMARY`. The alternative (headline + dimensions only) was rejected because a `--detail diagnostics` invocation would then silently drop findings from the summary.
+
+### Markdown is a sibling formatter inside the CLI package
+
+`markdown.ts` lives in `packages/cli/src/formatters/` next to `pretty.ts` / `json.ts`, exported as `formatMarkdown(result, options)`. It is plain string-building (no new dependency — unlike `html`, which needs the bundled React package), so it stays in the CLI rather than becoming a separate package. It mirrors `formatPretty`'s signature and `--detail` handling.
+
+### TTY-safe; no `validateScoreOptions` refusal
+
+Unlike `html` (a full document) and `sarif` (machine output), Markdown is human-readable plain text, so it is safe to print to an interactive terminal. `--format markdown` adds no entry to `validateScoreOptions`. With `-o`, the Markdown is written verbatim — no `stripAnsi` is needed because the formatter emits no ANSI codes (it must not import `chalk`).
+
+### GFM tables, escaping pipes
+
+The dimension table (and any signal/diagnostic tables) use GFM pipe-table syntax. Cell content that can contain a literal `|` (e.g. diagnostic messages) is escaped (`\|`) so a stray pipe does not break the table. Scores render as integers (rounded, matching `pretty`); signal scores — which are `[0, 1]` in the engine — render as percentages, consistent with `pretty`.
+
+### Independent of SARIF (Phase 17)
+
+This phase only adds `markdown` to the `Format` union and a new formatter file; it does not depend on Phase 17's `sarif` value existing. The two phases extend `Format` independently. (`Format` is currently `pretty | json | html`; whichever of `sarif` / `markdown` lands first adds its value, the other adds its own.)
+
+## Constraints
+
+- **Result JSON is engine-verbatim; formatters are read-only projections** (`specs/tech-stack.md`; `docs/architecture.md` §7). The Markdown formatter reads `summary`, `summary.dimensions[]`, `details[].dimensions[].signals[]`, and `diagnostics[]` without renaming, restructuring, or mutating them.
+- **Tolerate unknown / missing keys** (`docs/architecture.md` §7; engine signals are alpha and may drift). The formatter must render a valid (if sparse) document when optional sections are absent — e.g. a minimal result with only `summary.{score,level,grade}` produces a headline and nothing else, never a crash.
+- **Signal scores are `[0, 1]`, dimension/overall scores are `[0, 100]`** (`docs/architecture.md` §7). The formatter must not multiply one by 100 and forget the other — match `pretty`'s convention (signals → `%`, dimensions/overall → integer out of 100).
+- **`--detail` filter is applied upstream** in `commands/score.ts` via `filterByDetail` before the formatter runs (`docs/architecture.md` §7). The formatter consumes the already-filtered result and renders whatever depth is present; it does not re-filter.
+- **CLI surface changes require README + SKILL sync** (`.claude/rules/cli-readme-sync.md`). Adding `markdown` to `--format` updates `README.md` `## CLI reference` and `skills/jentic-api-scorecard/SKILL.md`'s flag table in the same commit.
+- **TypeScript style** (`.claude/rules/typescript-code-style.md`): `.ts` import suffixes, extend the existing `Format` `as const` record, strict-mode types, no mocking in tests.
+
+## Context
+
+This formatter was parked in Later Phases pending "concrete CI-integrator demand." The Phase 19 GitHub Action is that demand: `$GITHUB_STEP_SUMMARY` renders Markdown, not ANSI-colored `pretty` output, so a rich inline run summary needs a real Markdown projection rather than stripped-`pretty` text in a code fence (which would be a monospace blob with no rendered tables).
+
+It serves the **CI integrators** secondary persona in `specs/mission.md`: a human-readable, paste-able report for PRs and status checks, complementing the machine-readable `--format json`. Sequencing it before Phase 19 keeps each phase small — the formatter is a reviewable concern of its own, and the Action depends on it.
+
+## Stakeholder Notes
+
+- **CI integrators** — want an at-a-glance scorecard rendered on the run/PR without downloading anything. Satisfied by `--format markdown` feeding `$GITHUB_STEP_SUMMARY`.
+- **OpenAPI spec authors** — paste a Markdown scorecard into a PR description or issue. Satisfied by the GFM headline + dimension table.

--- a/specs/2026-06-15-markdown-formatter/requirements.md
+++ b/specs/2026-06-15-markdown-formatter/requirements.md
@@ -30,7 +30,7 @@ Unlike `html` (a full document) and `sarif` (machine output), Markdown is human-
 
 ### GFM tables, escaping pipes
 
-The dimension table (and any signal/diagnostic tables) use GFM pipe-table syntax. Cell content that can contain a literal `|` (e.g. diagnostic messages) is escaped (`\|`) so a stray pipe does not break the table. Scores render as integers (rounded, matching `pretty`); signal scores — which are `[0, 1]` in the engine — render as percentages, consistent with `pretty`.
+The dimension table (and any signal/diagnostic tables) use GFM pipe-table syntax. Cell content that can contain a literal `|` (e.g. diagnostic messages) is escaped (`\|`), and literal newlines are collapsed to a space, so neither a stray pipe nor a multi-line message breaks a table row. Scores render as integers (rounded, matching `pretty`); signal scores — which are `[0, 1]` in the engine — render as percentages, consistent with `pretty`.
 
 ### Independent of SARIF (Phase 17)
 

--- a/specs/2026-06-15-markdown-formatter/validation.md
+++ b/specs/2026-06-15-markdown-formatter/validation.md
@@ -31,7 +31,7 @@ Exits 0. `test/formatters/markdown.test.ts` asserts, against `test/fixtures/scor
 - the dimension table has a GFM header row plus one row per `summary.dimensions[]` entry (6 rows), with kinds `FC`, `DXJ`, `ARAX`, `AU`, `SEC`, `AID`;
 - `--detail` projection: `summary` → headline only (no dimension table); `dimensions` → dimension table, no signals/diagnostics sections; `signals` → signals section present; `diagnostics` → diagnostics section present;
 - a minimal `ScorecardResult` (only `summary.{score,level,grade}`) renders a headline without throwing and emits no empty tables;
-- a diagnostic message containing a literal `|` is escaped to `\|` in its table cell.
+- an inline-constructed diagnostic message containing a literal `|` and a `\n` renders with `\|` and the newline collapsed to a space (no raw pipe, no broken row) — the fixture has no pipe-bearing message, so this case builds its own input.
 
 ### 4. Markdown output is valid GFM end-to-end against a real score
 

--- a/specs/2026-06-15-markdown-formatter/validation.md
+++ b/specs/2026-06-15-markdown-formatter/validation.md
@@ -1,0 +1,68 @@
+# Phase 18 Validation — Markdown formatter (`--format markdown`)
+
+## Definition of Done
+
+All of the following must be true before this branch is merged.
+
+### 1. Lint is clean
+
+```
+npm run lint -w @jentic/api-scorecard-cli
+```
+
+Exits 0. ESLint + Prettier pass on the new `formatters/markdown.ts` and every other touched `.ts` file.
+
+### 2. TypeScript type-checks
+
+```
+npm run build:typescript -w @jentic/api-scorecard-cli
+```
+
+Exits 0. `tsc` compiles the new formatter, the extended `Format` record, and the dispatch change in `commands/score.ts` with no errors.
+
+### 3. Unit tests pass, including the new Markdown suite
+
+```
+npm test -w @jentic/api-scorecard-cli
+```
+
+Exits 0. `test/formatters/markdown.test.ts` asserts, against `test/fixtures/scorecard.sample.json`:
+- the headline contains the rounded overall score, the upper-cased level, and the grade;
+- the dimension table has a GFM header row plus one row per `summary.dimensions[]` entry (6 rows), with kinds `FC`, `DXJ`, `ARAX`, `AU`, `SEC`, `AID`;
+- `--detail` projection: `summary` → headline only (no dimension table); `dimensions` → dimension table, no signals/diagnostics sections; `signals` → signals section present; `diagnostics` → diagnostics section present;
+- a minimal `ScorecardResult` (only `summary.{score,level,grade}`) renders a headline without throwing and emits no empty tables;
+- a diagnostic message containing a literal `|` is escaped to `\|` in its table cell.
+
+### 4. Markdown output is valid GFM end-to-end against a real score
+
+```
+node packages/cli/bin/jentic-api-scorecard.mjs score \
+  https://raw.githubusercontent.com/jentic/jentic-public-apis/refs/heads/main/apis/openapi/swagger-api/petstore/1.0.27/openapi.json \
+  --format markdown
+```
+
+Exits 0 and prints Markdown to stdout: an H1 headline line, a score/level/grade line, and a GFM pipe table for dimensions (header row, separator row, one row per dimension). No ANSI escape codes in the output. (Requires the local image at the matching `cli-version` tag; run `npm run build:image` first if it is absent.)
+
+### 5. Rendered-Markdown spot check
+
+Paste the §4 output (and a `--format markdown --detail diagnostics` run) into a GitHub Markdown preview — e.g. a draft PR comment, or echo it into `$GITHUB_STEP_SUMMARY` in a scratch workflow. The dimension table and any signal/diagnostic tables render as real tables (no leaking raw `|`, no broken rows), headings render as headings, and the document reads cleanly.
+
+### 6. README and SKILL reflect the new format
+
+`README.md` `## CLI reference` lists `markdown` among the `--format` choices and includes a short `--format markdown` usage subsection. `skills/jentic-api-scorecard/SKILL.md`'s `-f, --format <fmt>` row lists `markdown` alongside `pretty`, `json`, `html`. Both updated in the same commit as the code, per `.claude/rules/cli-readme-sync.md`.
+
+### 7. Roadmap lifecycle marker
+
+```
+grep -F "## Phase 18 — Markdown formatter (\`--format markdown\`) ✅" specs/roadmap.md
+```
+
+Exits 0. The Phase 18 heading carries the ` ✅` suffix (space + U+2705) and the rest of the block is unchanged.
+
+## Not Required
+
+- No GitHub Action, workflow file, or `$GITHUB_STEP_SUMMARY` wiring — that is Phase 19.
+- No `./markdown` subpath export from the CLI package — the Action invokes `--format markdown`; importable access is a non-breaking future follow-up.
+- No emoji, shields.io badges, or collapsible `<details>` chrome — first cut is plain GFM.
+- No Python (`docker/`) changes and no new exit codes — host-side formatter only, so `docker/tests/` need not run.
+- No e2e suite change required beyond the manual end-to-end checks above, unless the dispatch edit in `commands/score.ts` is found to affect an existing e2e assertion.


### PR DESCRIPTION
## Summary

Spec scaffold for **Phase 18: Markdown formatter (`--format markdown`)** from `specs/roadmap.md`.

This PR adds **spec files only** — no code changes. Implementation follows in a separate PR once this spec is approved.

### Scope
Add `markdown` as a `-f, --format` value emitting a GitHub-flavored Markdown projection of the scorecard — headline (score/level/grade), dimension table, optional signals and diagnostics sections — gated by `--detail` exactly like `pretty`. Plain text (no ANSI), suitable for `$GITHUB_STEP_SUMMARY`, PR comments, and status checks. A pure function of the engine result JSON, so the Phase 19 Action derives it with no re-scoring.

### Out of Scope
- The GitHub Action that consumes it (Phase 19).
- Posting to PR comments / Checks API (Action's job).
- A `./markdown` subpath export (Action invokes `--format markdown`; importable access is a non-breaking future follow-up).
- Emoji / badges / `<details>` chrome — first cut is plain GFM.

### Key decisions
- Full parity with `pretty`, gated by `--detail` (headline → dimensions → signals → diagnostics).
- Sibling formatter inside the CLI package (plain string-building, no new dep).
- TTY-safe — no `validateScoreOptions` refusal; `-o` writes verbatim (no chalk strip).
- GFM pipe tables with `|` escaped in cells; signal scores as `%`, dimension/overall as integer /100.
- Independent of SARIF (Phase 17) — each adds its own `Format` value.

## Files

- `specs/2026-06-15-markdown-formatter/requirements.md`
- `specs/2026-06-15-markdown-formatter/plan.md`
- `specs/2026-06-15-markdown-formatter/validation.md`

## Review guidance

Reviewers should verify:
- The phase goal is captured faithfully (see `specs/roadmap.md` Phase 18).
- Scope, constraints, and decisions match intent — especially full pretty-parity content and the `[0,1]` signal vs `[0,100]` dimension score handling.
- The plan's task groups are appropriately granular and each has a concrete verification step.
- Validation gates are realistic — unit tests plus a rendered-GFM spot check.

Refs: `specs/roadmap.md` Phase 18.