### PR TITLE
docs(README): list summary-detail levels for the action

### DIFF
--- a/README.md
+++ b/README.md
@@ -415,7 +415,7 @@ for the full provider matrix (cloud and local Ollama) and the variable reference
 | `severity` | `warning` | Minimum level kept in the SARIF. |
 | `max-findings` | `5000` | Cap on SARIF results, lowest-severity dropped first. |
 | `with-llm` | `false` | Enable LLM-backed analysis. |
-| `summary-detail` | `dimensions` | Depth of the Markdown summary. |
+| `summary-detail` | `dimensions` | Markdown run-summary depth: `summary`, `dimensions`, `signals`, `diagnostics`. |
 | `cli-version` | action's release | CLI version to run (pins the engine image); defaults to the version shipped with the action ref you pinned. |
 
 **Choosing your gates.** Set `min-score` to fail PRs below a readiness bar, and/or `max-errors` /


### PR DESCRIPTION
## Why

A run summary shows the six dimension scores but not the per-signal breakdown that rolls up into them — so `SEC D-` doesn't tell you *which* signal drags it down. That breakdown is already available: the action's `summary-detail` input takes `summary | dimensions | signals | diagnostics`, with `signals` adding the per-signal tables. The inputs table just didn't list the choices.

## What

List the four `summary-detail` levels inline in the README inputs table cell — terse enough to keep the table's one-line-per-row formatting. No behavior change; the knob already ships, and `action.yml`'s input description already enumerates the levels canonically.

## Why not change the default

The action is a thin CLI wrapper and this repo keeps the two aligned, so the run summary stays at `dimensions` (matching the CLI's `--detail` default — the better terminal default). Consumers who want the signal breakdown set `summary-detail: signals`.

Refs #190