### PR TITLE
fix(action): float major tag so README example tracks releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,18 +93,6 @@ jobs:
             echo "value=$(node -p 'require("./lerna.json").version')"
             echo "sha=$(git rev-parse HEAD)"
           } >> "$GITHUB_OUTPUT"
-      # Maintain a floating major tag (e.g. `v1`) pointing at the freshly
-      # cut release, so consumers can pin `jentic/jentic-api-scorecard@v1`
-      # in their workflows and auto-receive patch/minor releases without a
-      # doc edit (the README examples use this ref). lerna already created
-      # the immutable `vX.Y.Z` tag; we force-move the major alias to it and
-      # force-push. Uses the persisted App-token credentials from checkout.
-      - name: Update floating major tag
-        run: |
-          set -euo pipefail
-          MAJOR="v$(node -p 'require("./lerna.json").version.split(".")[0]')"
-          git tag -f "$MAJOR" "v${{ steps.version.outputs.value }}"
-          git push origin "refs/tags/$MAJOR" --force
 
   # Step 2: build and push the multi-arch GHCR image at the
   # exact tag the CLI will resolve to. Runs BEFORE npm publish so
@@ -219,3 +207,48 @@ jobs:
         with:
           subject-path: ./artifacts/jentic-api-scorecard-cli-${{ needs.release-prepare.outputs.version }}.tgz
           sbom-path: ./artifacts/cli.sbom.spdx.json
+
+  # Step 4: graduate the floating major tag (e.g. `v1`) to the freshly
+  # cut release, so consumers who pin `jentic/jentic-api-scorecard@v1`
+  # in their workflows (the README examples do) auto-receive every
+  # patch/minor without a doc edit. lerna already created the immutable
+  # `vX.Y.Z` tag; we force-move the major alias onto it.
+  #
+  # This runs LAST — only after both the GHCR image (publish-docker) and
+  # the npm tarball (release-publish) are live. The major tag must never
+  # advance past a half-shipped release: were it moved in release-prepare,
+  # a later docker/npm failure would leave `@v1` pointing at a version
+  # consumers can resolve but not run. Gating on both upstream jobs makes
+  # the alias graduate only once the release is fully usable.
+  update-major-tag:
+    name: Update floating major tag
+    needs: [release-prepare, publish-docker, release-publish]
+    runs-on: ubuntu-latest
+    # contents:write to push the tag goes through the App token below,
+    # which is on the `Protect main` ruleset bypass list; GITHUB_TOKEN
+    # needs nothing.
+    permissions: {}
+    steps:
+      - name: Create GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.ARAZZO_BUILDER_APP_ID }}
+          private-key: ${{ secrets.ARAZZO_BUILDER_PRIVATE_KEY }}
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.release-prepare.outputs.sha }}
+          fetch-depth: 0
+          persist-credentials: true
+          token: ${{ steps.app-token.outputs.token }}
+      - name: Move major tag to the released version
+        env:
+          VERSION: ${{ needs.release-prepare.outputs.version }}
+        run: |
+          set -euo pipefail
+          git config user.name "${{ steps.app-token.outputs.app-slug }}[bot]"
+          git config user.email "${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com"
+          MAJOR="v${VERSION%%.*}"
+          git tag -f "$MAJOR" "v${VERSION}"
+          git push origin "refs/tags/$MAJOR" --force

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,6 +93,18 @@ jobs:
             echo "value=$(node -p 'require("./lerna.json").version')"
             echo "sha=$(git rev-parse HEAD)"
           } >> "$GITHUB_OUTPUT"
+      # Maintain a floating major tag (e.g. `v1`) pointing at the freshly
+      # cut release, so consumers can pin `jentic/jentic-api-scorecard@v1`
+      # in their workflows and auto-receive patch/minor releases without a
+      # doc edit (the README examples use this ref). lerna already created
+      # the immutable `vX.Y.Z` tag; we force-move the major alias to it and
+      # force-push. Uses the persisted App-token credentials from checkout.
+      - name: Update floating major tag
+        run: |
+          set -euo pipefail
+          MAJOR="v$(node -p 'require("./lerna.json").version.split(".")[0]')"
+          git tag -f "$MAJOR" "v${{ steps.version.outputs.value }}"
+          git push origin "refs/tags/$MAJOR" --force
 
   # Step 2: build and push the multi-arch GHCR image at the
   # exact tag the CLI will resolve to. Runs BEFORE npm publish so

--- a/README.md
+++ b/README.md
@@ -370,7 +370,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: jentic/jentic-api-scorecard@v1.8.0 # pin a released version (or a commit SHA)
+      - uses: jentic/jentic-api-scorecard@v1 # floating major tag (or pin a full version / commit SHA)
         with:
           input: ./openapi.yaml
           api-key: ${{ secrets.JENTIC_API_KEY }}
@@ -392,7 +392,7 @@ jobs:
       LLM_LIGHT_MODEL: gpt-4o-mini
     steps:
       - uses: actions/checkout@v4
-      - uses: jentic/jentic-api-scorecard@v1.8.0
+      - uses: jentic/jentic-api-scorecard@v1
         with:
           input: ./openapi.yaml
           api-key: ${{ secrets.JENTIC_API_KEY }}

--- a/README.md
+++ b/README.md
@@ -428,11 +428,13 @@ gate, so quieting the Security tab to errors-only won't let a warning-heavy spec
 **Outputs land even on a failing build.** When a gate fails, you still get the SARIF findings, the
 HTML artifact, and the Markdown summary — a failing PR is exactly when you want to see them.
 
-**Pin a concrete version.** Always reference the action by a released tag (or commit SHA), never a
-rolling alias — there is no `@v1`. A new release can ship a new scoring engine, and the same
-document can score differently across engine versions; pinning is what keeps a gated build
-reproducible, so a green PR doesn't turn red because a release moved under it. Bump the pin
-deliberately when you're ready to adopt a new engine.
+**Choose your pin deliberately.** The `@v1` major tag (used in the examples above) floats to the
+newest `v1.x.x` on every release, so you auto-receive fixes without a workflow edit and stay within
+one major — no breaking changes. The trade-off: a release can ship a new scoring engine, and the
+same document can score differently across engine versions, so a green PR can turn red when `@v1`
+moves under it. If you gate on a hard threshold and need that build reproducible, pin a full version
+(`@v1.8.3`) or a commit SHA instead, and bump it deliberately when you're ready to adopt a new
+engine.
 
 **On fork PRs**, GitHub gives the workflow a read-only token, so the Security-tab upload can't run;
 the action skips it with a notice and still publishes the HTML artifact and Markdown summary.


### PR DESCRIPTION
## What

- README GitHub Action examples now reference `jentic/jentic-api-scorecard@v1` (floating major tag) instead of the hardcoded `@v1.8.0`, which went stale the moment `v1.8.1` shipped.
- `release.yml` now force-moves the `v<major>` tag to each freshly cut release, so `@v1` always resolves to the newest `v1.x.x`.

## Why

The pinned `@v1.8.0` example drifts out of sync on every release. A floating major tag (the `actions/checkout@v4` idiom — see line 372 right above) keeps the example evergreen across patch/minor releases while staying *pinned* third-party code (not `@main`), so supply-chain posture and SARIF attestation are unaffected. Only a major bump (`v2`) would need a manual doc edit — which is exactly when consumers should read the changelog anyway.

Because `cli-version` defaults to the action's own `packages/cli/package.json`, `@v1` also auto-advances the pinned engine image with no doc edit.

## Notes

- No `v1` tag existed before; the new release step creates and force-updates it. The first `v1` tag lands on the next release after this merges.
- The major-tag step lives in `release-prepare`, reusing the persisted App-token checkout credentials that already push the version bump.