### PR TITLE
fix(action): meet marketplace description cap and brand color

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,13 +1,12 @@
 name: 'Jentic API Scorecard'
 description: >-
-  Score an OpenAPI document against the Jentic API AI Readiness Framework (JAIRF),
-  gate the build on the score, upload SARIF findings to the Security tab, attach
-  the HTML scorecard as an artifact, and render a Markdown summary on the run.
+  Score an OpenAPI doc against the Jentic API AI Readiness Framework; gate CI and
+  publish SARIF + an HTML scorecard.
 author: 'Jentic'
 
 branding:
   icon: 'check-circle'
-  color: 'purple'
+  color: 'green'
 
 inputs:
   input:


### PR DESCRIPTION
## What

Two `action.yml` metadata fixes so the action passes GitHub Marketplace listing validation:

- **`description`** trimmed from ~270 → 114 chars. The Marketplace rejects descriptions over 125 chars (`Description must be less than 125 characters.`); the listing draft was failing on this.
- **`branding.color`** changed `purple` → `green` to match Jentic brand (the org logo's mark is a muted teal-green on a dark slate backdrop).

## Why

Required to publish the composite action to the GitHub Marketplace. `branding.color` only accepts one of nine named values (no custom hex), so `green` is the closest allowed match to the brand mark; the Jentic logo itself surfaces on the listing via the org avatar, not `action.yml`.

## Notes

- No behavior change — `action.yml` inputs/outputs/steps are untouched.
- The Marketplace creator logo is already the Jentic logo (jentic org avatar); the `branding` block is only the fallback tile glyph/color.