### PR TITLE
fix(README): render header badges inline on marketplace

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Jentic API Scorecard
 
-[![skills.sh](https://skills.sh/b/jentic/jentic-api-scorecard)](https://skills.sh/jentic/jentic-api-scorecard)
-[![SkillSpector](https://github.com/jentic/jentic-api-scorecard/actions/workflows/skill-security.yml/badge.svg)](https://github.com/jentic/jentic-api-scorecard/actions/workflows/skill-security.yml)
+[![skills.sh](https://skills.sh/b/jentic/jentic-api-scorecard)](https://skills.sh/jentic/jentic-api-scorecard) [![SkillSpector](https://github.com/jentic/jentic-api-scorecard/actions/workflows/skill-security.yml/badge.svg)](https://github.com/jentic/jentic-api-scorecard/actions/workflows/skill-security.yml)
 
 ![Jentic API Scorecard preview](https://github.com/jentic/jentic-api-scorecard/raw/main/assets/scorecard-preview.jpg)
 


### PR DESCRIPTION
## What

Join the two header badges (skills.sh, SkillSpector) onto a single physical line so they render **inline** instead of stacked.

## Why

The Marketplace listing renderer treats each source line break as a hard break, so the two badges — previously on separate lines — stacked vertically on https://github.com/marketplace/actions/jentic-api-scorecard. Putting both on one line separated by a space renders them side-by-side on both GitHub's README view and the Marketplace listing.

## Notes

- Markdown-only; no content or link changes.