### PR TITLE
fix(action): show source origin in SARIF location for URL inputs

### DIFF
--- a/action/postprocess.mjs
+++ b/action/postprocess.mjs
@@ -85,26 +85,28 @@ function filterSarifBySeverity(doc, minLevel) {
   return { ...doc, runs };
 }
 
-// SARIF artifact URI for the scored input. A local path is used as-is (relative,
-// leading "./" stripped); a URL collapses to its basename, since Code Scanning
-// attaches a result to a repo-relative path and a full URL is not one. Falls back
-// to "openapi" when the input is a URL with no usable path segment or is unset.
+// Repo-relative SARIF artifact URI for the scored input: a local path as-is, or a
+// URL reduced to `host/path` (an absolute URI mismatches the `file://` checkout
+// root and Code Scanning rejects the whole upload — issue #200). A `host:port`
+// (e.g. localhost:3000/...) would itself parse as a `scheme:`, so when the result
+// starts with a scheme-like prefix it is forced relative with a leading `./`.
 function sarifArtifactUri(input) {
   const value = String(input ?? '').trim();
   if (value === '') {
     return 'openapi';
   }
   if (/^https?:\/\//i.test(value)) {
-    // Take the basename of the URL path only — never the host, so a path-less URL
-    // (https://example.com/) falls back rather than yielding "example.com".
-    let pathname;
+    let url;
     try {
-      pathname = new URL(value).pathname;
+      url = new URL(value);
     } catch {
       return 'openapi';
     }
-    const tail = pathname.replace(/\/+$/, '').split('/').pop();
-    return tail && tail !== '' ? tail : 'openapi';
+    const relative = (url.host + url.pathname).replace(/\/+$/, '');
+    if (relative === '') {
+      return 'openapi';
+    }
+    return /^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(relative) ? `./${relative}` : relative;
   }
   return value.replace(/^\.\//, '');
 }

--- a/packages/cli/test/action/postprocess.test.ts
+++ b/packages/cli/test/action/postprocess.test.ts
@@ -121,6 +121,57 @@ describe('postprocess helper (black-box)', function () {
     });
   });
 
+  describe('SARIF artifact URI', function () {
+    // Code Scanning renders source only for a path committed to the repo, so a
+    // local input stays a repo-relative path. A URL spec is not in the repo, so it
+    // becomes a scheme-less host/path relative URI — never the absolute URL, whose
+    // https scheme mismatches the file:// checkout root and makes Code Scanning
+    // reject the whole upload. A bare basename (the old behavior) produced a
+    // phantom repo path; host/path shows the real origin instead (issue #200).
+    function firstUri(run: RunResult): string | undefined {
+      return allResults(run.sarif)[0]?.locations?.[0]?.physicalLocation?.artifactLocation.uri;
+    }
+
+    // RFC 3986 scheme prefix: an absolute URI mismatches the file:// checkout root
+    // and Code Scanning rejects the whole upload, so the artifact URI must never
+    // parse as having one.
+    const SCHEME_PREFIX = /^[a-zA-Z][a-zA-Z0-9+.-]*:/;
+
+    it('uses a scheme-less host/path relative URI for a URL input', function () {
+      const url =
+        'https://raw.githubusercontent.com/jentic/jentic-public-apis/refs/heads/main/apis/openapi/swagger-api/petstore/1.0.27/openapi.json';
+      const expected =
+        'raw.githubusercontent.com/jentic/jentic-public-apis/refs/heads/main/apis/openapi/swagger-api/petstore/1.0.27/openapi.json';
+      const run = runPostprocess({ INPUT: url, SEVERITY: 'note' });
+      for (const result of allResults(run.sarif)) {
+        const uri = result.locations?.[0]?.physicalLocation?.artifactLocation.uri;
+        expect(uri).to.equal(expected);
+        expect(uri).to.not.match(SCHEME_PREFIX);
+      }
+    });
+
+    it('forces ./ on a port-bearing URL so host:port is not read as a scheme', function () {
+      // localhost:3000/... would otherwise parse as scheme "localhost:" — an
+      // absolute URI that fails the checkout-root scheme match.
+      const run = runPostprocess({
+        INPUT: 'https://localhost:3000/openapi.json',
+        SEVERITY: 'note',
+      });
+      expect(firstUri(run)).to.equal('./localhost:3000/openapi.json');
+      expect(firstUri(run)).to.not.match(SCHEME_PREFIX);
+    });
+
+    it('keeps a repo-relative path for a local input, stripping a leading ./', function () {
+      expect(firstUri(runPostprocess({ INPUT: './api/openapi.yaml', SEVERITY: 'note' }))).to.equal(
+        'api/openapi.yaml',
+      );
+    });
+
+    it('falls back to "openapi" when the input is unset', function () {
+      expect(firstUri(runPostprocess({ SEVERITY: 'note' }))).to.equal('openapi');
+    });
+  });
+
   describe('gate decision (via GITHUB_OUTPUT)', function () {
     // The fixture scores 66.52 with 2 error-level (severity 1) and 8 warning-level
     // (severity 2) diagnostics.


### PR DESCRIPTION
## Problem

The GitHub Action uploads SARIF to the Security tab. For a **URL** input, `action/postprocess.mjs` collapsed the URL to its basename (`openapi.json`) and stamped it as the SARIF `physicalLocation`. Code Scanning attaches results to repo-relative paths, so every alert pointed at a **phantom `openapi.json`** that doesn't exist in the consumer's repo (see the alert in #200, which scores a hosted petstore URL).

## What I tried first (and why it failed)

Using the **full URL** as the artifact URI. A real Actions run on the test repo proved GitHub rejects the *entire* upload:

```
Code Scanning could not process the submitted SARIF file:
SARIF URI scheme "https" did not match the checkout URI scheme "file"
```

An `https` artifact URI mismatches the `file://` checkout source root → whole-file rejection. Worse than the status quo.

## Fix

Strip the scheme and keep **`host/path` as a scheme-less relative URI**:

`https://raw.githubusercontent.com/.../petstore/1.0.27/openapi.json`
→ `raw.githubusercontent.com/jentic/.../petstore/1.0.27/openapi.json`

A relative URI ingests like any path (no scheme mismatch) while displaying the real origin of the scored document instead of a phantom repo file. Local-file inputs are unchanged — they keep their repo-relative path and render source.

## Verification (real Actions run)

Pointed `char0n/jentic-api-scorecard-test` at this commit:

- ✅ No rejection annotation; SARIF ingested (`spectral-validator` 50, `redocly-validator` 16, `default-validator` 1 results).
- ✅ New alerts carry `raw.githubusercontent.com/.../openapi.json` instead of `openapi.json`.
- ✅ Gate still passed (score 68.62).

(Test repo workflow reverted to its released SHA afterward.)

## Scope note

This is the **file path** fix. Per-finding line mapping (every finding still points at line 1) remains tracked in #191 — independent and unchanged here.

Closes #200