### PR TITLE
ci(publish-to-docs): simplify auth by removing origin reset

### DIFF
--- a/scripts/publish-to-docs.sh
+++ b/scripts/publish-to-docs.sh
@@ -110,10 +110,7 @@ cd "${WORK_DIR}"
 git clone --depth 1 "https://x-access-token:${GH_TOKEN}@github.com/jentic/jentic-docs.git" jentic-docs
 cd jentic-docs
 
-# Reset origin to a token-free URL; inject credentials via http.extraheader (not persisted to .git/config on disk)
-git remote set-url origin "https://github.com/jentic/jentic-docs.git"
-git config http.extraheader "AUTHORIZATION: bearer ${GH_TOKEN}"
-
+# Token is scoped to this job's temp dir (removed by trap cleanup EXIT).
 git config user.name "github-actions[bot]"
 git config user.email "github-actions[bot]@users.noreply.github.com"
 


### PR DESCRIPTION
 - Fixes fatal: could not read Username for 'https://github.com' error on git push
 - The previous approach reset origin to a token-free URL then relied on http.extraheader for auth, but git's credential prompt still fires on a 401 with no TTY available in CI
- Fix: keep the token in the clone URL for the lifetime of the job — the clone lives in a mktemp -d removed by trap cleanup EXIT, so exposure is limited to the job