### PR TITLE
fix(docker): detect daemon-not-running and show friendly message

### DIFF
--- a/packages/cli/src/docker.ts
+++ b/packages/cli/src/docker.ts
@@ -10,6 +10,14 @@ const DOCKER_MISSING_MESSAGE =
   "error: 'docker' command not found.\n" +
   '  Install Docker: https://docs.docker.com/get-docker/\n';
 
+const DOCKER_NOT_RUNNING_MESSAGE =
+  'error: Docker is installed but the daemon is not running.\n' +
+  '  Start Docker Desktop, or on Linux: sudo systemctl start docker\n';
+
+export function isDaemonDown(stderr: string): boolean {
+  return /Cannot connect to the Docker daemon|the daemon is running/i.test(stderr);
+}
+
 export function imageRef(): string {
   return `${IMAGE_NAME}:${cliVersion}`;
 }
@@ -46,10 +54,12 @@ export function pullImage(ref: string): Promise<PullResult> {
       resolve({ exitCode: ExitCode.GENERIC_ERROR, stderr: err.message });
     });
     child.on('close', (code) => {
-      resolve({
-        exitCode: code ?? ExitCode.GENERIC_ERROR,
-        stderr: Buffer.concat(stderrChunks).toString('utf8'),
-      });
+      const stderr = Buffer.concat(stderrChunks).toString('utf8');
+      if (code !== 0 && isDaemonDown(stderr)) {
+        resolve({ exitCode: ExitCode.DOCKER_MISSING, stderr: DOCKER_NOT_RUNNING_MESSAGE });
+        return;
+      }
+      resolve({ exitCode: code ?? ExitCode.GENERIC_ERROR, stderr });
     });
   });
 }
@@ -178,6 +188,16 @@ export function runDocker(opts: DockerRunOptions): Promise<DockerRunResult> {
       if (signal !== null) {
         const signo = osConstants.signals[signal] ?? 0;
         settle(() => resolve({ exitCode: 128 + signo, stdout, stderr }));
+        return;
+      }
+      if (code !== 0 && isDaemonDown(stderr)) {
+        settle(() =>
+          resolve({
+            exitCode: ExitCode.DOCKER_MISSING,
+            stdout: '',
+            stderr: DOCKER_NOT_RUNNING_MESSAGE,
+          }),
+        );
         return;
       }
       settle(() => resolve({ exitCode: code ?? ExitCode.GENERIC_ERROR, stdout, stderr }));

--- a/packages/cli/src/docker.ts
+++ b/packages/cli/src/docker.ts
@@ -15,7 +15,7 @@ const DOCKER_NOT_RUNNING_MESSAGE =
   '  Start Docker Desktop, or on Linux: sudo systemctl start docker\n';
 
 export function isDaemonDown(stderr: string): boolean {
-  return /Cannot connect to the Docker daemon|the daemon is running/i.test(stderr);
+  return /Cannot connect to the Docker daemon|if the daemon is running/i.test(stderr);
 }
 
 export function imageRef(): string {

--- a/packages/cli/test/docker.test.ts
+++ b/packages/cli/test/docker.test.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 
-import { buildDockerArgs, IMAGE_NAME, pullImage } from '../src/docker.ts';
+import { buildDockerArgs, IMAGE_NAME, isDaemonDown, pullImage } from '../src/docker.ts';
 import { ExitCode } from '../src/exit-codes.ts';
 import { cliVersion } from '../src/version.ts';
 
@@ -97,6 +97,32 @@ describe('buildDockerArgs', function () {
       '--url',
       'https://example.test/spec.yaml',
     ]);
+  });
+});
+
+describe('isDaemonDown', function () {
+  const daemonErrors = [
+    'Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?',
+    'failed to connect to the docker API at unix:///home/user/.docker/run/docker.sock; check if the path is correct and if the daemon is running: dial unix /home/user/.docker/run/docker.sock: connect: no such file or directory',
+    'Cannot connect to the Docker daemon at tcp://docker:2375. Is the Docker daemon running?',
+  ];
+
+  for (const stderr of daemonErrors) {
+    it(`detects daemon-down in: ${stderr.slice(0, 60)}…`, function () {
+      expect(isDaemonDown(stderr)).to.equal(true);
+    });
+  }
+
+  it('returns false for a normal pull failure', function () {
+    expect(isDaemonDown('Error response from daemon: manifest unknown')).to.equal(false);
+  });
+
+  it('returns false for an ENOENT message', function () {
+    expect(isDaemonDown("error: 'docker' command not found.")).to.equal(false);
+  });
+
+  it('returns false for an empty string', function () {
+    expect(isDaemonDown('')).to.equal(false);
   });
 });
 


### PR DESCRIPTION
## Problem

When Docker is installed but the daemon is stopped (e.g. Docker Desktop was quit on macOS), the CLI exits with a cryptic message:

```
error: failed to pull image ghcr.io/jentic/jentic-api-scorecard:1.9.0
failed to connect to the docker API at unix:///…/docker.sock; check if the path is correct and if the daemon is running: …
```

The binary is found (no ENOENT), so the CLI falls through to its generic path and dumps the raw daemon stderr — misleading framing that sounds like a registry/auth problem.

## Fix

Add `isDaemonDown(stderr)` — a pure function that matches the daemon-down signature (`Cannot connect to the Docker daemon` / `the daemon is running`) in both `pullImage()` and `runDocker()`. When detected, map to `DOCKER_MISSING` (exit 4 — already documented as "daemon unreachable") and surface a clear, actionable message:

```
error: Docker is installed but the daemon is not running.
  Start Docker Desktop, or on Linux: sudo systemctl start docker
```

`score.ts` already handles `DOCKER_MISSING` by writing the friendly stderr directly (from the previous PR #192), so no changes needed there.

No new exit code — the README and SKILL.md already document exit 4 as "Docker not installed or daemon unreachable".

## Testing

- Added unit tests for `isDaemonDown()` covering the macOS/Linux common message, the exact error from the issue report (#224), and false-positive guards.
- `npm test -w @jentic/api-scorecard-cli`: 221/221 passing.
- `npm run lint` and `npm run build:typescript -w @jentic/api-scorecard-cli`: clean.

Refs #224