### PR TITLE
chore(harness): hide internal skills from skills.sh discovery

### DIFF
--- a/.claude/skills/review-community/SKILL.md
+++ b/.claude/skills/review-community/SKILL.md
@@ -2,6 +2,8 @@
 name: review-community
 description: Review a pull request authored by someone other than the current GitHub user, applying the team's diplomatic review-comments tone. Use when the PR author's GitHub login differs from the current user's `gh api user` login. For own PRs, use the built-in /review directly. Detects authorship automatically and refuses on self-authored PRs.
 argument-hint: "[pr-number | pr-url] (optional — defaults to the PR for the current branch)"
+metadata:
+  internal: true
 ---
 
 # /review-community — review someone else's PR with the community tone

--- a/.claude/skills/sdd-create-constitution/SKILL.md
+++ b/.claude/skills/sdd-create-constitution/SKILL.md
@@ -2,6 +2,8 @@
 name: sdd-create-constitution
 description: Bootstrap the SDD constitution (specs/mission.md, specs/tech-stack.md, specs/roadmap.md) from current repository evidence. Refuses by default if any of the three files already exists — overwriting requires explicit confirmation via AskUserQuestion. Loads the constitution templates, runs parallel Explore subagents over the code trees that exist (e.g. `docker/`, `packages/`), `docs/`, and top-level config to ground claims in evidence, synthesizes findings, then issues a single grouped AskUserQuestion call (Mission / Tech Stack / Roadmap) before writing the three files. Edits files in place and stops — committing, branching, and opening a PR are user actions.
 argument-hint: "(no arguments)"
+metadata:
+  internal: true
 ---
 
 # /sdd-create-constitution — bootstrap the SDD constitution

--- a/.claude/skills/sdd-distill-lessons/SKILL.md
+++ b/.claude/skills/sdd-distill-lessons/SKILL.md
@@ -2,6 +2,8 @@
 name: sdd-distill-lessons
 description: Distil per-spec retrospectives into specs/lessons.md so future spec authoring absorbs the learning. Reads specs/*/retrospective.md, groups recurring patterns, surfaces candidate lessons and tech-stack.md promotion candidates via AskUserQuestion, writes confirmed additions to specs/lessons.md, then invokes /review against the pending change before stopping.
 argument-hint: "(no arguments)"
+metadata:
+  internal: true
 ---
 
 # /sdd-distill-lessons — distil retrospectives into specs/lessons.md

--- a/.claude/skills/sdd-implement-spec/SKILL.md
+++ b/.claude/skills/sdd-implement-spec/SKILL.md
@@ -2,6 +2,8 @@
 name: sdd-implement-spec
 description: Implement an existing feature spec end-to-end — pick an unprocessed feature spec (one whose `## Phase N — ...` heading in `specs/roadmap.md` does not yet carry the `✅` lifecycle marker), cut a feature branch, walk `plan.md` task groups in order with one primary atomic Conventional-Commits commit per group (plus optional small fix-up commits during verification or pre-push review), run `plan.md`'s Verify group plus every check in `validation.md`, then run a pre-push review pairing the built-in `/review` skill with three parallel deep-review subagents (spec-adherence, code-quality, risk-and-robustness) before pushing and opening the PR. The spec is read-only during implementation; if it is wrong or incomplete, the skill stops and surfaces the gap rather than patching the spec mid-flight. Reports implementation, review, and verification results at the end. When `$ARGUMENTS` is empty, enumerates unprocessed specs via AskUserQuestion.
 argument-hint: "[phase-number | slug-fragment | spec-dir-path] (optional)"
+metadata:
+  internal: true
 ---
 
 # /sdd-implement-spec — implement a feature spec

--- a/.claude/skills/sdd-new-phase/SKILL.md
+++ b/.claude/skills/sdd-new-phase/SKILL.md
@@ -2,6 +2,8 @@
 name: sdd-new-phase
 description: Append a new active phase to specs/roadmap.md. Parses existing phases (active and ✅-completed) to compute the next stable phase number per the lifecycle rule, grounds the proposal against specs/mission.md and specs/tech-stack.md, groups structured questions (goal, dependencies, priority) via AskUserQuestion, then collects a freeform bullet list for the phase body. Edits specs/roadmap.md in place, then invokes the built-in /review skill against the pending change before stopping — committing, pushing, and opening a PR are left to the user. Does not create a feature spec; that is /sdd-new-spec's job.
 argument-hint: "[short title or one-sentence intent] (optional)"
+metadata:
+  internal: true
 ---
 
 # /sdd-new-phase — add a new active phase to the roadmap

--- a/.claude/skills/sdd-new-spec/SKILL.md
+++ b/.claude/skills/sdd-new-spec/SKILL.md
@@ -2,6 +2,8 @@
 name: sdd-new-spec
 description: Scaffold a feature spec for a roadmap phase and open it as a PR for human review. Reads specs/roadmap.md, lets the user pick a phase (or accepts one as argument), runs preflight checks, cuts a feature branch, writes specs/YYYY-MM-DD-<slug>/ (requirements.md, plan.md, validation.md — grounded in specs/mission.md and specs/tech-stack.md), commits, pushes, and opens a PR. Makes zero code changes — the PR is for review of the spec itself; implementation follows in a separate PR once the spec is approved. Groups clarifying questions (one per output file) via AskUserQuestion before any disk write.
 argument-hint: "[phase-number | \"phase title fragment\"] (optional)"
+metadata:
+  internal: true
 ---
 
 # /sdd-new-spec — scaffold a feature spec for a roadmap phase


### PR DESCRIPTION
## Problem

The [skills.sh directory](https://www.skills.sh/jentic/jentic-api-scorecard) lists **two** skills for this repo:

1. `jentic-api-scorecard` — the intended, canonical distributable skill (`skills/jentic-api-scorecard/`).
2. `sdd-implement-spec` — an **internal dev-harness skill** from `.claude/skills/` that should never reach installers.

The Vercel `skills` CLI / skills.sh discover raw `SKILL.md` files and scan `.claude/skills/` as one of their standard container directories — so our harness skills leak into the public directory. This violates the documented invariant in `CLAUDE.md` ("the dev harness under `.claude/` is not referenced and never leaks to installers"). That invariant held for the Claude Code plugin marketplace path (`marketplace.json` explicitly scopes `skills: ["./skills/jentic-api-scorecard"]`) but **not** for the skills.sh path, which ignores `marketplace.json`.

## Fix

Add `metadata.internal: true` to the frontmatter of all six `.claude/skills/` SKILL.md files. Per [vercel-labs/skills](https://github.com/vercel-labs/skills):

> `metadata.internal`: Set to `true` to hide the skill from normal discovery.
> Internal skills are only visible and installable when `INSTALL_INTERNAL_SKILLS=1` is set.

Applied to all six (not just the one currently leaking) so any of them stops leaking the moment it would otherwise be discovered:

- `review-community`
- `sdd-create-constitution`
- `sdd-distill-lessons`
- `sdd-implement-spec`
- `sdd-new-phase`
- `sdd-new-spec`

`metadata.internal` is an unknown field to Claude Code's own skill loader (which reads `name`/`description`/`argument-hint`), so the slash commands are unaffected.

## Note on retroactive removal

This closes the leak **going forward** (no new installs/discovery of internal skills). It does **not** guarantee the existing `sdd-implement-spec` entry vanishes from skills.sh — that directory is install-driven telemetry with no documented opt-out/removal API, so the stale entry may need a separate request to the skills.sh maintainers to de-list.