### PR TITLE
feat(CountBasedMetadata): add notes to example signal panels

### DIFF
--- a/packages/formatter-html/src/app/components/signals/CountBasedMetadata.tsx
+++ b/packages/formatter-html/src/app/components/signals/CountBasedMetadata.tsx
@@ -31,7 +31,7 @@ const COUNT_SIGNAL_CONFIG: Record<string, CountConfig> = {
     denominatorField: 'expected_examples',
     label: 'Examples Present',
     denominatorLabel: 'expected',
-    note: 'Diagnostics list the locations where examples are expected (expected_examples) or already present (present_examples). The two sets overlap when all expected locations already have examples.',
+    note: 'expected_examples marks every element that can hold an example value; present_examples marks the subset that already has at least one. The gap between the two is where density can be improved.',
   },
   example_validity: {
     numeratorField: 'valid_examples',

--- a/packages/formatter-html/src/app/components/signals/CountBasedMetadata.tsx
+++ b/packages/formatter-html/src/app/components/signals/CountBasedMetadata.tsx
@@ -13,6 +13,7 @@ interface CountConfig {
   secondaryLabel?: string;
   secondaryIsBad?: boolean;
   showPercentagePrimary?: boolean;
+  note?: string;
 }
 
 const COUNT_SIGNAL_CONFIG: Record<string, CountConfig> = {
@@ -30,6 +31,7 @@ const COUNT_SIGNAL_CONFIG: Record<string, CountConfig> = {
     denominatorField: 'expected_examples',
     label: 'Examples Present',
     denominatorLabel: 'expected',
+    note: 'Diagnostics list the locations where examples are expected (expected_examples) or already present (present_examples). The two sets overlap when all expected locations already have examples.',
   },
   example_validity: {
     numeratorField: 'valid_examples',
@@ -39,6 +41,7 @@ const COUNT_SIGNAL_CONFIG: Record<string, CountConfig> = {
     secondaryField: 'invalid_examples',
     secondaryLabel: 'Invalid',
     secondaryIsBad: true,
+    note: 'The total above counts individual examples; the diagnostics below list unique locations. When a location has more than one example, it is listed once here but counted multiple times in the total.',
   },
   response_coverage: {
     numeratorField: 'response_coverage_sum',
@@ -46,6 +49,7 @@ const COUNT_SIGNAL_CONFIG: Record<string, CountConfig> = {
     label: 'Response Coverage',
     denominatorLabel: 'operations',
     showPercentagePrimary: true,
+    note: 'Each operation scores 0-1: +0.25 for 2XX, 4XX, 5XX, and default responses',
   },
   description_coverage: {
     numeratorField: 'described_elements',
@@ -127,9 +131,11 @@ export default function CountBasedMetadata({
               </div>
             </div>
           </div>
-          <p className="text-[10px] text-gray-500 bg-gray-50 rounded px-2 py-1.5">
-            Each operation scores 0-1: +0.25 for 2XX, 4XX, 5XX, and default responses
-          </p>
+          {config.note && (
+            <p className="text-[10px] text-gray-500 bg-gray-50 rounded px-2 py-1.5">
+              {config.note}
+            </p>
+          )}
         </div>
       ) : (
         <div className="space-y-2">
@@ -149,6 +155,11 @@ export default function CountBasedMetadata({
               label={config.secondaryLabel}
               isBad={config.secondaryIsBad}
             />
+          )}
+          {config.note && (
+            <p className="text-[10px] text-gray-500 bg-gray-50 rounded px-2 py-1.5">
+              {config.note}
+            </p>
           )}
         </div>
       )}


### PR DESCRIPTION
## Summary

Closes #235

The HTML report shows `present_examples` and `total_examples` diagnostics pointing to the same locations, and the `total_examples` metadata count (e.g. 37) differs from the number of paths shown in the diagnostics (e.g. 27). This is correct engine behavior — diagnostics mark unique **locations**, while the metadata counts individual **example objects** — but was opaque to users.

- Adds an optional `note` field to `CountConfig` in `CountBasedMetadata.tsx`
- Renders the note in both the donut-chart branch (`response_coverage`) and the progress-bar branch (all other count signals), replacing the previous hardcoded string
- For `example_density`: explains that `expected_examples` and `present_examples` diagnostics list overlapping location sets (they converge when all expected locations already have examples)
- For `example_validity`: explains that the total-examples count in the summary can exceed the diagnostic location count when a single location holds multiple examples

## Test plan

- [x] All 75 existing `@jentic/api-scorecard-formatter-html` unit tests pass (`npm test -w @jentic/api-scorecard-formatter-html`)
- [x] `signals.test.tsx` SSR tests for `example_density` and `example_validity` still pass (no `undefined`/`NaN`, expected numerator/denominator values)
- [x] `response_coverage` note text is unchanged (moved from hardcoded JSX to `COUNT_SIGNAL_CONFIG`)