### PR TITLE
fix(sarif/pretty/gate): strip path suffix, light-terminal bar, rate-limit warning

### DIFF
--- a/docker/src/jentic_scorecard_runner/gate.py
+++ b/docker/src/jentic_scorecard_runner/gate.py
@@ -28,6 +28,7 @@ from jentic_scorecard_runner.usage import (
 _ALLOWLIST_PATTERN = re.compile(
     r"^https://raw\.githubusercontent\.com/jentic/jentic-public-apis/refs/heads/main/apis/openapi/"
 )
+_LOW_REMAINING_THRESHOLD = 10
 
 
 def check_gate(url: str | None) -> ExitCode:
@@ -60,7 +61,14 @@ def check_gate(url: str | None) -> ExitCode:
     result = check_usage(key)
 
     match result:
-        case UsageAllowed():
+        case UsageAllowed() as allowed:
+            if allowed.remaining is not None and allowed.remaining <= _LOW_REMAINING_THRESHOLD:
+                limit_part = f" of {allowed.limit}" if allowed.limit is not None else ""
+                print(
+                    f"warning: {allowed.remaining}{limit_part} scoring(s) remaining for your Jentic API key.\n"
+                    "  Top up at https://app.jentic.com/scorecard?tab=api-keys to avoid interruption.",
+                    file=sys.stderr,
+                )
             return ExitCode.SUCCESS
         case UsageRateLimited(detail=detail, retry_after=retry_after):
             message = f"error: rate limit reached for your Jentic API key.\n  {detail}"

--- a/docker/src/jentic_scorecard_runner/usage.py
+++ b/docker/src/jentic_scorecard_runner/usage.py
@@ -27,7 +27,8 @@ _USER_AGENT = "jentic-api-scorecard-runner"
 
 @dataclass(frozen=True)
 class UsageAllowed:
-    pass
+    remaining: int | None = None
+    limit: int | None = None
 
 
 @dataclass(frozen=True)
@@ -70,7 +71,9 @@ def check_usage(key: str) -> UsageResult:
 
     status = response.status_code
     if 200 <= status < 300:
-        return UsageAllowed()
+        remaining = _parse_int_header(response, "X-RateLimit-Remaining")
+        limit = _parse_int_header(response, "X-RateLimit-Limit")
+        return UsageAllowed(remaining=remaining, limit=limit)
 
     if status == 429:
         detail = _problem_detail(response) or "Server provided no detail."
@@ -82,6 +85,16 @@ def check_usage(key: str) -> UsageResult:
         return UsageInvalidKey(detail=detail)
 
     return UsageUnverifiable(reason=f"HTTP {status}")
+
+
+def _parse_int_header(response: requests.Response, name: str) -> int | None:
+    value = response.headers.get(name)
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except ValueError:
+        return None
 
 
 def _problem_detail(response: requests.Response) -> str | None:

--- a/docker/tests/test_gate.py
+++ b/docker/tests/test_gate.py
@@ -186,6 +186,66 @@ class TestRealKeyValidation:
         assert check_gate(url=None) == ExitCode.AUTH_INVALID_KEY
 
 
+class TestLowRemainingWarning:
+    """Warning emitted when X-RateLimit-Remaining is at or below threshold."""
+
+    def test_warning_emitted_at_threshold(self, base_url, monkeypatch, capsys):
+        base_url.expect_request(_USAGE_PATH, method="POST").respond_with_data(
+            "", status=204, headers={"X-RateLimit-Remaining": "10", "X-RateLimit-Limit": "100"}
+        )
+        monkeypatch.setenv("JENTIC_API_KEY", "real-key")
+        assert check_gate(url=None) == ExitCode.SUCCESS
+        err = capsys.readouterr().err
+        assert "10 of 100 scoring(s) remaining" in err
+
+    def test_warning_emitted_below_threshold(self, base_url, monkeypatch, capsys):
+        base_url.expect_request(_USAGE_PATH, method="POST").respond_with_data(
+            "", status=204, headers={"X-RateLimit-Remaining": "3", "X-RateLimit-Limit": "100"}
+        )
+        monkeypatch.setenv("JENTIC_API_KEY", "real-key")
+        assert check_gate(url=None) == ExitCode.SUCCESS
+        err = capsys.readouterr().err
+        assert "3 of 100 scoring(s) remaining" in err
+
+    def test_warning_omits_limit_when_header_absent(self, base_url, monkeypatch, capsys):
+        base_url.expect_request(_USAGE_PATH, method="POST").respond_with_data(
+            "", status=204, headers={"X-RateLimit-Remaining": "5"}
+        )
+        monkeypatch.setenv("JENTIC_API_KEY", "real-key")
+        assert check_gate(url=None) == ExitCode.SUCCESS
+        err = capsys.readouterr().err
+        assert "5 scoring(s) remaining" in err
+        assert "of" not in err
+
+    def test_no_warning_above_threshold(self, base_url, monkeypatch, capsys):
+        base_url.expect_request(_USAGE_PATH, method="POST").respond_with_data(
+            "", status=204, headers={"X-RateLimit-Remaining": "11", "X-RateLimit-Limit": "100"}
+        )
+        monkeypatch.setenv("JENTIC_API_KEY", "real-key")
+        assert check_gate(url=None) == ExitCode.SUCCESS
+        assert capsys.readouterr().err == ""
+
+    def test_no_warning_when_headers_absent(self, base_url, monkeypatch, capsys):
+        base_url.expect_request(_USAGE_PATH, method="POST").respond_with_data("", status=204)
+        monkeypatch.setenv("JENTIC_API_KEY", "real-key")
+        assert check_gate(url=None) == ExitCode.SUCCESS
+        assert capsys.readouterr().err == ""
+
+    def test_no_warning_for_allowlisted_url(self, monkeypatch, capsys):
+        url = "https://raw.githubusercontent.com/jentic/jentic-public-apis/refs/heads/main/apis/openapi/petstore/openapi.yaml"
+        monkeypatch.setenv("JENTIC_API_KEY", "real-key")
+        assert check_gate(url=url) == ExitCode.SUCCESS
+        assert capsys.readouterr().err == ""
+
+    def test_malformed_remaining_header_ignored(self, base_url, monkeypatch, capsys):
+        base_url.expect_request(_USAGE_PATH, method="POST").respond_with_data(
+            "", status=204, headers={"X-RateLimit-Remaining": "not-a-number"}
+        )
+        monkeypatch.setenv("JENTIC_API_KEY", "real-key")
+        assert check_gate(url=None) == ExitCode.SUCCESS
+        assert capsys.readouterr().err == ""
+
+
 class TestFailOpen:
     def test_5xx_fails_open_with_warning(self, base_url, monkeypatch, capsys):
         base_url.expect_request(_USAGE_PATH, method="POST").respond_with_data("boom", status=503)

--- a/packages/cli/src/formatters/pretty.ts
+++ b/packages/cli/src/formatters/pretty.ts
@@ -32,7 +32,9 @@ const BAR_WIDTH = 20;
 function scoreBar(score: number): string {
   const filled = Math.round((score / 100) * BAR_WIDTH);
   const empty = BAR_WIDTH - filled;
-  return chalk.white('▄'.repeat(filled)) + chalk.blackBright('▄'.repeat(empty));
+  // chalk.inverse swaps fg/bg so the filled blocks are visible on both dark and
+  // light terminal backgrounds; chalk.dim keeps the empty segment subdued.
+  return chalk.inverse('▄'.repeat(filled)) + chalk.dim('▄'.repeat(empty));
 }
 
 // Signal scores are [0, 1] with no engine-emitted grade, so we band by raw

--- a/packages/cli/src/formatters/sarif.ts
+++ b/packages/cli/src/formatters/sarif.ts
@@ -91,10 +91,21 @@ function locationsFor(diagnostic: Diagnostic): SarifLocation[] | undefined {
   return location !== undefined ? [location] : undefined;
 }
 
+// Strips the engine-baked " [path: <dotted.path>]" suffix from a SARIF message.
+// Before PR #218 added physical locations, this suffix was the only usable location
+// hint in the Security tab. Now that each finding carries a real physicalLocation,
+// the suffix is redundant noise. Only the SARIF projection strips it; --format json
+// leaves the engine message verbatim per the architecture invariant.
+const PATH_SUFFIX_RE = / \[path: [^\]]+\]$/;
+
+export function stripPathSuffix(message: string): string {
+  return message.replace(PATH_SUFFIX_RE, '');
+}
+
 function toSarifResult(diagnostic: Diagnostic): SarifResult {
   const result: SarifResult = {
     level: severityToLevel(diagnostic.severity),
-    message: { text: diagnostic.message },
+    message: { text: stripPathSuffix(diagnostic.message) },
   };
   if (diagnostic.code !== undefined) {
     result.ruleId = diagnostic.code;

--- a/packages/cli/test/formatters/sarif.test.ts
+++ b/packages/cli/test/formatters/sarif.test.ts
@@ -4,7 +4,7 @@ import { fileURLToPath } from 'node:url';
 import { Ajv, type ValidateFunction } from 'ajv';
 import { expect } from 'chai';
 
-import { formatSarif, toJsonPointer } from '../../src/formatters/sarif.ts';
+import { formatSarif, stripPathSuffix, toJsonPointer } from '../../src/formatters/sarif.ts';
 import { Diagnostic, ScorecardResult } from '../../src/result.ts';
 
 const fixturePath = fileURLToPath(new URL('../fixtures/scorecard.sample.json', import.meta.url));
@@ -208,6 +208,49 @@ describe('formatSarif', function () {
     expect(minimalDoc.runs).to.deep.equal([]);
     const ajv = new Ajv({ strict: false, logger: false });
     expect(ajv.compile(sarifSchema)(minimalDoc)).to.equal(true);
+  });
+});
+
+describe('stripPathSuffix', function () {
+  it('strips a trailing [path: ...] suffix', function () {
+    expect(stripPathSuffix('Servers must be present. [path: openapi]')).to.equal(
+      'Servers must be present.',
+    );
+  });
+
+  it('strips a multi-segment dotted path suffix', function () {
+    expect(
+      stripPathSuffix(
+        'Header `X-Expires-After` should not start with "X-". [path: paths./user/login.get.responses.200.headers.X-Expires-After]',
+      ),
+    ).to.equal('Header `X-Expires-After` should not start with "X-".');
+  });
+
+  it('leaves a message without the suffix unchanged', function () {
+    expect(stripPathSuffix('No path suffix here.')).to.equal('No path suffix here.');
+  });
+
+  it('leaves a message with a bracket that is not the exact pattern unchanged', function () {
+    expect(stripPathSuffix('See [RFC 6901] for details.')).to.equal('See [RFC 6901] for details.');
+  });
+
+  it('the SARIF formatter applies the strip to message.text', function () {
+    const result = {
+      summary: { score: 0, level: 'unknown', grade: 'F' },
+      diagnostics: [
+        {
+          source: 'engine',
+          severity: 2,
+          message: 'Something wrong. [path: paths./foo.get]',
+          code: 'SOMETHING',
+          data: {},
+        },
+      ],
+    } as unknown as ScorecardResult;
+    const doc = JSON.parse(formatSarif(result)) as {
+      runs: { results: { message: { text: string } }[] }[];
+    };
+    expect(doc.runs[0]?.results[0]?.message.text).to.equal('Something wrong.');
   });
 });
 


### PR DESCRIPTION
## Summary

- **#220 — SARIF path suffix** (`fix(sarif)`): `message.text` in SARIF output no longer carries the redundant `[path: …]` tail that duplicates what's already in `logicalLocations`. A narrow regex strips only the canonical suffix; other bracket patterns (e.g. `[RFC 6901]`) are untouched. JSON output is unchanged (engine-verbatim). Five new unit tests cover the helper and the formatter-level integration.

- **#105 / #127 — Rate-limit warning** (`feat(gate)`): When `X-RateLimit-Remaining` is ≤ 10, a warning is printed to stderr before scoring proceeds so users can top up before hitting the quota wall. The limit is included in the message when `X-RateLimit-Limit` is also present. Malformed or absent headers are silently ignored (fail-safe). Seven new `TestLowRemainingWarning` tests cover threshold, below-threshold, absent-limit, above-threshold, absent-headers, allowlisted-URL short-circuit, and malformed-header cases.

- **#97 — Score bar on light terminals** (`fix(pretty)`): The score bar used `chalk.white` for the filled segment, which is invisible on a white/light terminal background. Replaced with `chalk.inverse`, which swaps fg/bg so the filled blocks are always a contrast reversal of the terminal's current colors — visible on dark and light backgrounds alike.

## Test plan

- [x] `npm test -w @jentic/api-scorecard-cli` — 220 passing (includes new `stripPathSuffix` tests)
- [x] `cd docker && uv run poe test tests/test_gate.py` — 31 passing (includes new `TestLowRemainingWarning` class)
- [x] `npx tsc --noEmit -p packages/cli/tsconfig.json` — clean
- [x] `cd docker && uv run poe lint` — clean

Closes #220
Refs #105 #127
Refs #97

🤖 Generated with [Claude Code](https://claude.com/claude-code)