### PR TITLE
docs(skills): consolidate skills info and structure for docs-site

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,10 @@ An OpenAPI document that passes validation isn't necessarily one an AI agent can
 one thing; semantic clarity, safety, and discoverability are another. The **Jentic API Scorecard**
 scores your OpenAPI document against the
 [Jentic API AI Readiness Framework (JAIRF)](https://github.com/jentic/api-ai-readiness-framework)
-across six dimensions and returns a single grade — so you know exactly where to improve.
+across six dimensions and returns a single grade — so you know exactly where to improve. Pair it
+with the companion **api-improve** agent skill to apply those improvements automatically:
+non-breaking edits, a reusable
+[OpenAPI Overlay](https://spec.openapis.org/overlay/v1.1.0.html), and a before/after changelog.
 
 ## Table of contents
 
@@ -23,14 +26,9 @@ across six dimensions and returns a single grade — so you know exactly where t
 - [HTML report](#html-report)
 - [LLM analysis](#llm-analysis)
 - [Anonymous vs keyed access](#anonymous-vs-keyed-access)
-- [Agent Skills](#agent-skills)
-  - [Claude Code](#claude-code)
-  - [Vercel `skills` CLI](#vercel-skills-cli)
-  - [TanStack Intent](#tanstack-intent)
-- [The api-improve skill](#the-api-improve-skill)
-  - [Claude Code](#claude-code-1)
-  - [Vercel `skills` CLI](#vercel-skills-cli-1)
-  - [TanStack Intent](#tanstack-intent-1)
+- [Skills](#skills)
+  - [jentic-api-scorecard](#jentic-api-scorecard)
+  - [jentic-api-improve](#jentic-api-improve)
 - [CLI reference](#cli-reference)
   - [Commands](#commands)
   - [`score`](#score)
@@ -248,14 +246,24 @@ as the per-key usage / rate-limit accounting hit. **Each free key gets 100 scori
 resetting at the start of each calendar month. Once that quota is exhausted the CLI exits with
 code `7` and prints the `Retry-After` value along with a link to upgrade your plan.
 
-## Agent Skills
+## Skills
 
-This repository ships a versioned [agent skill](https://github.com/jentic/jentic-api-scorecard/blob/main/skills/jentic-api-scorecard/SKILL.md)
+This repository ships two complementary agent skills — install either or both through
+whichever path fits your agent.
+
+| Skill | Purpose |
+|---|---|
+| `jentic-api-scorecard` | Teaches coding agents to use the scoring CLI: scoring files and URLs, producing JSON/HTML, wiring into CI, and interpreting exit codes. |
+| `jentic-api-improve` | Closes the loop: applies non-breaking improvements to a spec automatically, producing an improved spec, an OpenAPI Overlay, and a before/after changelog. |
+
+### jentic-api-scorecard
+
+A versioned [agent skill](https://github.com/jentic/jentic-api-scorecard/blob/main/skills/jentic-api-scorecard/SKILL.md)
 that teaches AI coding agents how to use the CLI correctly — installing it, scoring
 files and URLs, producing JSON/HTML, wiring it into CI, enabling LLM analysis, and
-interpreting exit codes. Install it through whichever path fits your agent.
+interpreting exit codes.
 
-### Claude Code
+#### Claude Code
 
 [Claude Code](https://docs.claude.com/en/docs/claude-code/overview) users install it
 as a [plugin](https://docs.claude.com/en/docs/claude-code/plugins) — this repository
@@ -277,7 +285,7 @@ no explicit invocation needed:
 To force it into context regardless of phrasing, invoke it explicitly with
 `/api-scorecard:jentic-api-scorecard`.
 
-### Vercel `skills` CLI
+#### Vercel `skills` CLI
 
 Install it straight from this repository with the
 [`skills` CLI](https://github.com/vercel-labs/skills):
@@ -288,13 +296,13 @@ npx skills add jentic/jentic-api-scorecard --skill jentic-api-scorecard
 
 It's also listed in the [skills.sh directory](https://skills.sh/jentic/jentic-api-scorecard).
 
-### TanStack Intent
+#### TanStack Intent
 
 The `@jentic/api-scorecard-cli` npm package also ships this skill inside its published
 tarball, so it's discoverable by [TanStack Intent](https://tanstack.com/intent) for
 projects that already depend on the CLI and want version-aligned agent guidance.
 
-## The api-improve skill
+### jentic-api-improve
 
 Scoring tells you _what_ to fix; the `jentic-api-improve` skill closes the loop and
 _fixes_ it. Point an AI coding agent at an OpenAPI document and it runs a baseline
@@ -317,9 +325,9 @@ pipx install check-jsonschema         # overlay schema validation
 ```
 
 Install the skill through whichever path fits your agent — the same three channels as
-the [scoring skill](#agent-skills):
+the [scoring skill](#jentic-api-scorecard):
 
-### Claude Code
+#### Claude Code
 
 The improve skill is a **separate plugin** in this repository's marketplace:
 
@@ -336,13 +344,13 @@ for multi-iteration improvement loops). Once installed, ask Claude to improve a 
 > Raise the JAIRF score of my API and give me an overlay
 ```
 
-### Vercel `skills` CLI
+#### Vercel `skills` CLI
 
 ```bash
 npx skills add jentic/jentic-api-scorecard --skill jentic-api-improve
 ```
 
-### TanStack Intent
+#### TanStack Intent
 
 The `@jentic/api-scorecard-cli` npm package ships this skill (and the companion agent
 definition) inside its published tarball, so it's discoverable by

--- a/docs/publish-config.json
+++ b/docs/publish-config.json
@@ -20,8 +20,8 @@
       ],
       "relatedLinks": [
         { "text": "API Scoring \u2013 Getting Started", "href": "../getting-started/api-scoring.md" },
-        { "text": "Agent Skill", "href": "./api-scorecard-skill.md" },
-        { "text": "Agent Improve Skill", "href": "./api-improve-skill.md" },
+        { "text": "Agent Skill (Scoring)", "href": "./api-scorecard-skill.md" },
+        { "text": "Agent Skill (Improvements)", "href": "./api-improve-skill.md" },
         { "text": "GitHub Action", "href": "./api-scorecard-action.md" },
         { "text": "Enterprise Readiness", "href": "./api-scorecard-enterprise.md" },
         { "text": "JAIRF Overview", "href": "../reference/api-readiness-framework/overview.md" },
@@ -31,14 +31,14 @@
     {
       "id": "agent-skill",
       "output": "docs/cli/api-scorecard-skill.md",
-      "title": "API Scorecard \u2013 Agent Skill",
-      "intro": "The Jentic API Scorecard ships a versioned **agent skill** that teaches AI coding agents how to use the CLI correctly. Install it through whichever path fits your agent.\n\n---",
+      "title": "API Scorecard \u2013 Agent Skill (Scoring)",
+      "intro": "The `jentic-api-scorecard` **agent skill** teaches AI coding agents how to use the scoring CLI correctly \u2014 installing it, scoring files and URLs, producing JSON/HTML reports, wiring it into CI, and interpreting exit codes. Install it through whichever path fits your agent.\n\n---",
       "sections": [
-        { "heading": "Agent Skills" }
+        { "heading": "jentic-api-scorecard", "level": 3, "headingShift": -1 }
       ],
       "relatedLinks": [
         { "text": "CLI Reference", "href": "./api-scorecard.md" },
-        { "text": "Agent Improve Skill", "href": "./api-improve-skill.md" },
+        { "text": "Agent Skill (Improvements)", "href": "./api-improve-skill.md" },
         { "text": "GitHub Action", "href": "./api-scorecard-action.md" },
         { "text": "API Scoring \u2013 Getting Started", "href": "../getting-started/api-scoring.md" },
         { "text": "Skill definition (SKILL.md)", "href": "https://github.com/jentic/jentic-api-scorecard/blob/main/skills/jentic-api-scorecard/SKILL.md" }
@@ -47,16 +47,17 @@
     {
       "id": "agent-improve-skill",
       "output": "docs/cli/api-improve-skill.md",
-      "title": "API Scorecard \u2013 Improve Skill",
-      "intro": "The Jentic API Scorecard ships a second **agent skill**, `jentic-api-improve`, that closes the loop on scoring: it raises an OpenAPI document's JAIRF score with non-breaking improvements and produces an improved spec, a reusable OpenAPI Overlay, and a before/after changelog. Install it through whichever path fits your agent.\n\n---",
+      "title": "API Scorecard \u2013 Agent Skill (Improvements)",
+      "intro": "The `jentic-api-improve` **agent skill** closes the loop on scoring: it raises an OpenAPI document\u2019s JAIRF score with non-breaking improvements and produces an improved spec, a reusable OpenAPI Overlay, and a before/after changelog. Install it through whichever path fits your agent.\n\n---",
       "sections": [
-        { "heading": "The api-improve skill" }
+        { "heading": "jentic-api-improve", "level": 3, "headingShift": -1 }
       ],
       "relatedLinks": [
         { "text": "CLI Reference", "href": "./api-scorecard.md" },
-        { "text": "Agent Skill", "href": "./api-scorecard-skill.md" },
+        { "text": "Agent Skill (Scoring)", "href": "./api-scorecard-skill.md" },
         { "text": "GitHub Action", "href": "./api-scorecard-action.md" },
         { "text": "API Scoring \u2013 Getting Started", "href": "../getting-started/api-scoring.md" },
+        { "text": "API Improvements \u2013 Getting Started", "href": "../getting-started/api-improvements.md" },
         { "text": "Skill definition (SKILL.md)", "href": "https://github.com/jentic/jentic-api-scorecard/blob/main/skills/jentic-api-improve/SKILL.md" }
       ]
     },
@@ -70,8 +71,8 @@
       ],
       "relatedLinks": [
         { "text": "CLI Reference", "href": "./api-scorecard.md" },
-        { "text": "Agent Skill", "href": "./api-scorecard-skill.md" },
-        { "text": "Agent Improve Skill", "href": "./api-improve-skill.md" },
+        { "text": "Agent Skill (Scoring)", "href": "./api-scorecard-skill.md" },
+        { "text": "Agent Skill (Improvements)", "href": "./api-improve-skill.md" },
         { "text": "API Scoring \u2013 Getting Started", "href": "../getting-started/api-scoring.md" },
         { "text": "LLM Signals guide", "href": "https://github.com/jentic/jentic-api-scorecard/blob/main/docs/llm-signals.md" },
         { "text": "jentic/jentic-api-scorecard \u2013 source and full documentation", "href": "https://github.com/jentic/jentic-api-scorecard" }

--- a/scripts/extract-docs.js
+++ b/scripts/extract-docs.js
@@ -51,6 +51,21 @@ if (!fs.existsSync(sourcePath)) {
 }
 const sourceLines = fs.readFileSync(sourcePath, 'utf8').split('\n');
 
+// ── Heading level shift ──────────────────────────────────────────────────────
+// Shifts all ATX headings in an array of lines by `shift` levels.
+// Positive shift makes headings deeper (## → ####); negative makes them shallower.
+// Levels are clamped to [1, 6].
+
+function shiftHeadings(lines, shift) {
+  if (!shift) return lines;
+  return lines.map(line => {
+    const match = line.match(/^(#{1,6}) (.+)$/);
+    if (!match) return line;
+    const newLevel = Math.min(6, Math.max(1, match[1].length + shift));
+    return '#'.repeat(newLevel) + ' ' + match[2];
+  });
+}
+
 // ── GitHub callout → MkDocs admonition ──────────────────────────────────────
 // GitHub renders `> [!TYPE]\n> content` as styled callouts; MkDocs does not.
 // This function converts them to MkDocs `!!! type\n    content` admonitions.
@@ -80,9 +95,9 @@ function convertCallouts(lines) {
   return out;
 }
 
-// ── Parse source into H2 sections ───────────────────────────────────────────
-// Each section spans from `## Heading` up to (but not including) the next `## Heading`.
-// Sub-headings (H3, H4, …) are captured as part of their parent H2 section.
+// ── Parse source into H2 and H3 sections ────────────────────────────────────
+// H2 sections span from `## Heading` to the next `## Heading` (H3+ are included).
+// H3 sections span from `### Heading` to the next `## Heading` or `### Heading`.
 
 function normalise(heading) {
   return heading.toLowerCase().replace(/`/g, '').trim();
@@ -90,20 +105,35 @@ function normalise(heading) {
 
 /** @type {Map<string, { original: string; lines: string[] }>} */
 const sections = new Map();
+/** @type {Map<string, { original: string; lines: string[] }>} */
+const h3Sections = new Map();
 let current = null;
+let currentH3 = null;
 
 for (const line of sourceLines) {
   const h2 = line.match(/^## (.+)$/);
+  const h3 = line.match(/^### (.+)$/);
   if (h2) {
     current = { original: h2[1].trim(), lines: [] };
     sections.set(normalise(current.original), current);
+    currentH3 = null;
+  } else if (h3) {
+    // H3 heading line is added to the parent H2 section (for full-section extraction)
+    if (current !== null) {
+      current.lines.push(line);
+    }
+    currentH3 = { original: h3[1].trim(), lines: [] };
+    h3Sections.set(normalise(currentH3.original), currentH3);
   } else if (current !== null) {
     current.lines.push(line);
+    if (currentH3 !== null) {
+      currentH3.lines.push(line);
+    }
   }
 }
 
 // Trim trailing blank lines from each section
-for (const section of sections.values()) {
+for (const section of [...sections.values(), ...h3Sections.values()]) {
   while (section.lines.length > 0 && section.lines.at(-1).trim() === '') {
     section.lines.pop();
   }
@@ -136,11 +166,14 @@ for (const page of config.pages) {
   for (const entry of page.sections) {
     const heading = typeof entry === 'string' ? entry : entry.heading;
     const rename = typeof entry === 'object' && entry.rename ? entry.rename : null;
+    const level = typeof entry === 'object' && entry.level === 3 ? 3 : 2;
+    const headingShift = typeof entry === 'object' && entry.headingShift != null ? entry.headingShift : 0;
 
-    const section = sections.get(normalise(heading));
+    const sectionMap = level === 3 ? h3Sections : sections;
+    const section = sectionMap.get(normalise(heading));
     if (!section) {
       console.error(
-        `❌  [${page.id}] Section not found in ${config.source ?? 'README.md'}: "${heading}"`,
+        `❌  [${page.id}] H${level} section not found in ${config.source ?? 'README.md'}: "${heading}"`,
       );
       hasErrors = true;
       continue;
@@ -151,7 +184,7 @@ for (const page of config.pages) {
       out.push('');
       out.push(entry.prefix);
     }
-    out.push(...convertCallouts(section.lines));
+    out.push(...convertCallouts(shiftHeadings(section.lines, headingShift)));
     if (entry.suffix) {
       out.push('');
       out.push(entry.suffix);


### PR DESCRIPTION
- Merges the standalone `## Agent Skills` and `## The api-improve skill` README sections into a single `## Skills` section with `### jentic-api-scorecard` and `### jentic-api-improve` subsections and a comparison table; updates the intro to surface both capabilities upfront.
- Extends `scripts/extract-docs.js` to extract H3-level sections and apply a heading-level shift, so the restructured README continues to feed correctly shaped docs pages.
- Updates `docs/publish-config.json`: disambiguated titles (`Agent Skill (Scoring)` /`Agent Skill (Improvements)`), tightened intros that name each skill explicitly, and consistent reference link text throughout all five pages.