### PR TITLE
docs(spec): scaffold phase 22 — benchmark improve cost

### DIFF
--- a/specs/2026-07-05-benchmark-improve-cost/plan.md
+++ b/specs/2026-07-05-benchmark-improve-cost/plan.md
@@ -1,0 +1,46 @@
+# Phase 22 Plan — Benchmark jentic-api-improve Token Usage and Cost
+
+All new code lives under `scripts/` (Node ESM, zero-dependency, matching `scripts/extract-docs.js`). Nothing under `packages/`, `docker/`, or the CLI/container changes. Groups are ordered risky-bits-first: the two net-new pieces (the token-counting proxy, then the matrix harness) come before the deterministic data→doc rendering, so the uncertain parts are proven early.
+
+## Group 1 — Token-counting OpenAI-compatible proxy
+
+1. Create `scripts/token-proxy.mjs`: a Node `http.createServer` endpoint exposing `POST /v1/chat/completions` (OpenAI-compatible) that forwards each request to a real upstream provider (base URL + key from env, e.g. `PROXY_UPSTREAM_URL` / `PROXY_UPSTREAM_KEY`), returns the upstream response verbatim, and accumulates `usage.prompt_tokens` / `usage.completion_tokens` per request. Expose the running tally via an in-process accessor (the harness imports the proxy as a module) and/or a `GET /__usage` endpoint for out-of-process reads. Match `extract-docs.js` style: `#!/usr/bin/env node` shebang, ESM imports, `process.argv` for `--port`, `❌`/`✅`/`process.exit(1)` conventions.
+2. Handle streaming vs non-streaming responses (the engine may request either); tally tokens from the final `usage` block, and if the upstream omits `usage` on a streamed response, record that cell's engine tokens as `null` (unknown) rather than 0, so a missing count is never silently read as free.
+3. Add a self-check path exercised by `--dry-run` (Group 5 / Verify): the proxy can start, accept a canned request against a stub upstream, tally a known token count, and shut down — no real upstream call. Keep this stub inside the harness's dry-run wiring, not shipped as the default upstream.
+
+## Group 2 — Benchmark harness: matrix driver
+
+4. Create `scripts/bench-improve.js` (the harness entry): read a pinned config (models × spec set) — either inline or from a sibling `scripts/bench-improve.config.json` — where each spec records its OAK raw-`githubusercontent.com` URL and baseline JAIRF score. Seed the config with the confirmed anchor spec (`.../apis/openapi/swagger-api/petstore/1.0.27/openapi.json`) plus 2–3 more OAK specs selected during implementation to span low/mid/high baseline score; record each URL + baseline score in the config.
+5. For each matrix cell (agent-model × spec): start the token-counting proxy (Group 1) on a free port; set the engine `--with-llm` env to the local-provider recipe pointed at the proxy (`LLM_PROVIDER=OPENAI`, `LIGHT_LLM_PROVIDER=OPENAI`, `OPENAI_API_URL=http://localhost:<port>/v1/chat/completions`, `OPENAI_API_KEY=<non-empty>`, `LLM_LIGHT_MODEL=<fixed engine model>`) held fixed across all cells; and invoke the skill headlessly via `claude -p "<invoke the jentic-api-improve skill on <specURL> <outDir>>" --model <agent-model> --output-format json` (use `--permission-mode bypassPermissions` for unattended runs per the skill's autonomy note). Ensure `JENTIC_API_KEY` is present for the in-loop re-scores on the local working copy.
+6. After each cell: read the coding agent's own `usage` + `total_cost_usd` from the `claude -p` JSON output; read the engine token tally from the proxy; read the skill's own output artifacts (the improved spec's changelog / score before-after) for the score delta and iterations run. Handle the skill's terminal exit conditions defensively — treat both exit 1 (host-side "no LLM provider") and exit 8 (in-container LLM failure) as a recorded cell error, and stop-and-record on quota (7), Docker (4), and auth (2/3) rather than silently producing a zero-cost cell.
+7. Add a `--dry-run` flag: iterate the full matrix and exercise all plumbing (proxy start/stop, env assembly, command construction) against the stub upstream from task 3, printing each planned cell, without invoking `claude -p` or any real model or `score` call; exit 0.
+
+## Group 3 — Results data file
+
+8. Define and emit a machine-readable per-cell results data file (JSON, e.g. `scripts/bench-improve.results.json` or a `--output` path): one record per cell with `{ model, spec: {url, baseline_score}, agent: {input_tokens, output_tokens, cost_usd}, engine: {input_tokens, output_tokens}, iterations_run, score_before, score_after, cli_version, run_date, error? }`. Split token counts by surface (engine vs agent) explicitly. Stamp `cli_version` (read from `packages/cli/package.json`) and `run_date` into the file header/metadata.
+9. Commit a small **sample** results data file (`scripts/bench-improve.sample.json`) with representative but clearly-labelled illustrative numbers, so the deterministic doc-render check (Group 4 / Verify) has a fixture to run against without any measurement.
+
+## Group 4 — Deterministic data→doc generator
+
+10. Add a `--render-only --data <file>` mode to `scripts/bench-improve.js` (or a sibling pure function it calls) that reads a results data file and produces `docs/improve-cost-benchmark.md`: a results table across models × specs with token and cost totals broken down by surface (engine vs agent), the pinned spec set (URL + baseline score), model-selection guidance/takeaways, and a header stamping the measured `cli_version` + run date. This step performs no measurement and calls no model — it is a pure function of the data file.
+11. Ensure `--render-only` can target a temp `--output-dir` (like `extract-docs.js`'s preview mode) so the generated doc can be diffed against the committed one without writing into the repo.
+
+## Group 5 — Manual measurement run + committed doc
+
+12. Document the manual run recipe in a comment header in `scripts/bench-improve.js` and briefly in the doc: prerequisites (Docker running, `JENTIC_API_KEY`, `claude` CLI authenticated, `PROXY_UPSTREAM_*` set), the `bench:improve` invocation, and the ~3-quota-units-per-cell budget warning.
+13. Perform one real measurement run across the pinned matrix (manual; spends real quota + LLM budget), write the real results data file, and generate the committed `docs/improve-cost-benchmark.md` from it via the Group 4 renderer. If a full matrix run is impractical at implementation time, record a documented partial run and clearly mark unmeasured cells — never fabricate numbers.
+
+## Group 6 — Wiring, docs, and roadmap lifecycle
+
+14. Add a `bench:improve` script entry to the root `package.json` `scripts` block, beside the existing `docs:*` entries (e.g. `"bench:improve": "node scripts/bench-improve.js"`); add a `bench:improve:dry-run` if a distinct dry-run entry is useful.
+15. Cross-reference the new benchmark from `docs/llm-signals.md` (the existing `--with-llm` provider/recipe doc) if a natural pointer fits; do not restructure that doc. Confirm no README `## CLI reference` sync is needed (CLI surface unchanged, per `.claude/rules/cli-readme-sync.md`) and no `specs/tech-stack.md` update is triggered (no new load-bearing dependency, per `.claude/rules/update-tech-stack-on-deps.md`).
+16. Append ` ✅` (a single space followed by the U+2705 checkmark) to the `## Phase 22 — Benchmark jentic-api-improve Token Usage and Cost` heading in `specs/roadmap.md`, leaving the rest of the block untouched.
+
+## Group 7 — Verify
+
+17. `npx eslint scripts/bench-improve.js scripts/token-proxy.mjs` and `npx prettier --check scripts/bench-improve.js scripts/token-proxy.mjs` both exit 0 (explicit — `npm run lint` does NOT cover `scripts/*.js`; `eslint.config.js` ignores `**/*.js`).
+18. `node -e "JSON.parse(require('fs').readFileSync('scripts/bench-improve.sample.json','utf8'))"` exits 0 (sample data file is valid JSON); same check passes for the real results data file if committed.
+19. Deterministic doc render matches the committed doc: `node scripts/bench-improve.js --render-only --data scripts/bench-improve.sample.json --output-dir /tmp/bench-check` produces a markdown file whose content matches what the committed `docs/improve-cost-benchmark.md` would be for that data (diff-clean against a render of the *same* data file) — proving the generator is a pure, reproducible function of its input.
+20. `node scripts/bench-improve.js --dry-run` exits 0, prints every planned model×spec cell, and makes no real `claude -p`, model, or `score` call (verifiable: no network to a real provider, no scorecard quota consumed).
+21. `docs/improve-cost-benchmark.md` exists and contains a results table with per-surface (engine vs agent) token/cost columns and the pinned spec set with baseline scores.
+22. `grep -F "## Phase 22 — Benchmark jentic-api-improve Token Usage and Cost ✅" specs/roadmap.md` exits 0 (lifecycle marker present with the load-bearing leading space).

--- a/specs/2026-07-05-benchmark-improve-cost/requirements.md
+++ b/specs/2026-07-05-benchmark-improve-cost/requirements.md
@@ -1,0 +1,54 @@
+# Phase 22 Requirements — Benchmark jentic-api-improve Token Usage and Cost
+
+## Scope
+
+Add a reproducible, developer-run benchmark that measures how many tokens — and how much money — a full run of the `jentic-api-improve` skill consumes, so a prospective user can pick a model and anticipate cost before adopting the skill. A run of the skill spends LLM budget on two independent surfaces: the coding agent's own reasoning as it drives the standard two-iteration improvement loop, and the scoring engine's `--with-llm` semantic analysis on each `score` call (one baseline plus up to two in-loop re-scores). The benchmark measures both, separately, across a matrix of coding-agent models × input OpenAPI specs of varying size and starting quality.
+
+Concretely this phase delivers: a Node ESM harness under `scripts/` (matching `scripts/extract-docs.js` conventions) that drives the skill end-to-end per matrix cell and records per-surface token counts and cost; a small net-new local token-counting OpenAI-compatible proxy the scoring engine is pointed at (the only way to capture engine-side tokens — see Decisions); a machine-readable per-cell results data file; and a generated `docs/improve-cost-benchmark.md` with a results table broken down by surface plus model-selection guidance. The real measurement is a manual, non-CI-gated run (it spends real scorecard quota and real LLM budget, and LLM outputs are stochastic); the deterministic parts — the harness's lint cleanliness, the data file's JSON validity, and the data-file→doc rendering — are verifiable without any spend.
+
+## Out of Scope
+
+- **CI gating of the real measurement.** No CI job runs the model×spec matrix — it costs real money and quota and its outputs are stochastic, so it cannot be a deterministic gate. Only the deterministic surfaces (lint, JSON validity, doc rendering, dry-run plumbing) are checkable.
+- **Any change to the CLI, the container, the runner, or the scoring engine.** The harness only *drives* the already-shipped `@jentic/api-scorecard-cli` and the `jentic-api-improve` skill; it adds no measurement instrumentation to the product itself (that would violate the no-telemetry stance — see Constraints).
+- **A new dependency solely to parse args or run the proxy.** The harness matches `extract-docs.js`'s zero-dependency style (manual `process.argv` parsing, Node's built-in `http`/`fetch`). If a genuinely load-bearing library becomes necessary, that is a decision to surface, not a default.
+- **Benchmarking the scoring CLI on its own** (without the improve skill) or portfolio/multi-spec scoring — those are separate concerns.
+- **Making `fable` an engine `--with-llm` option.** `fable` is a Claude Code coding-agent model alias; it belongs only on the agent axis, never on the fixed engine provider (see Decisions).
+
+## Decisions
+
+### Measure two surfaces separately, with distinct signals
+A skill run's LLM cost splits into the coding agent's own reasoning tokens and the scoring engine's `--with-llm` tokens; the benchmark reports them as separate columns because they scale differently (the engine batches operations and caps its work regardless of spec size, while the agent's reasoning grows with the loop and the model). The agent surface is captured first-party from Claude Code headless mode (`claude -p … --output-format json`), reading the session's `usage` and `total_cost_usd` fields — authoritative, no estimation. The engine surface is captured by the proxy described next.
+
+### The scoring engine's tokens require a local token-counting proxy (the scorecard JSON does not expose them)
+Research confirmed the scorecard result JSON has no `usage`/`token`/`cost` field anywhere (top-level keys are `metadata`, `apiMetadata`, `summary`, `details`, `diagnostics`; the only `cost`-named field is a JAIRF scoring weight, unrelated to tokens). So the roadmap's open question — "does the scorecard output already surface usage?" — resolves to **no**. The engine surface is therefore measured by pointing the engine's `--with-llm` provider at a small net-new local OpenAI-compatible endpoint (the skill's documented local-provider recipe) that forwards each request to a real upstream and tallies `usage.prompt_tokens` / `usage.completion_tokens`. Loopback endpoints are auto-rewritten to `host.docker.internal` with `--network host` by the CLI's docker layer, so a `localhost` proxy is reachable from inside the container transparently. This is a *forwarding measurement* proxy against a real upstream, not a mock, so it stays faithful to the no-mocking spirit.
+
+### Hold the engine `--with-llm` provider fixed across the model axis
+The matrix varies the **coding-agent** model (haiku / sonnet / opus / fable). The engine's `--with-llm` provider is held to a single fixed configuration across every cell, so the agent-model comparison is not confounded by also varying the engine model. `fable` exists only on the agent axis — it is a Claude Code model alias with no engine-provider meaning.
+
+### Pin the input-spec set (OAK URLs + recorded baseline score)
+The input axis is a small, explicitly pinned set of OpenAPI specs from `jentic-public-apis` (OAK), chosen to span size/complexity and starting quality (low / mid / high baseline JAIRF score). Each spec is recorded by its raw `githubusercontent.com` OAK URL plus its baseline score. The confirmed anchor spec is the swagger-api petstore already used across the repo's tests (`.../apis/openapi/swagger-api/petstore/1.0.27/openapi.json`); the remaining specs are selected from the live OAK catalog during implementation and pinned in the harness config with their URLs and baseline scores. Baseline `score` calls on OAK URLs are quota-free (the gate allowlist bypasses the validator), but the improve loop's in-loop re-scores run against the edited **local working copy**, which is not an OAK URL and therefore costs one scorecard quota unit each and requires `JENTIC_API_KEY` — budget at least three units per cell.
+
+### Split expensive measurement from cheap deterministic rendering
+Following the `extract-docs.js` precedent, the harness separates the expensive, stochastic measurement (which writes a machine-readable data file) from a pure data-file→markdown rendering step. The rendering step is a deterministic function of a committed data file, so `docs/improve-cost-benchmark.md` can be regenerated and diff-checked without any LLM spend, and a `--dry-run` mode exercises the matrix plumbing without calling any model. This is what makes the phase verifiable at all despite the measurement being manual.
+
+## Constraints
+
+Load-bearing invariants this phase must preserve:
+
+- **No telemetry / metrics / analytics in the product** (`specs/tech-stack.md` "Observability"; "What We Are Not Using"). The benchmark is a *dev-time* measurement that writes numbers to a repo data file and doc — it must not add any always-on measurement, logging, or phone-home to the CLI or container. Pointing the engine at a local proxy during a manual benchmark run does not instrument the shipped product.
+- **Outbound calls to Jentic stay capped at the per-invocation key-check** (`specs/tech-stack.md` "Outbound calls to Jentic"; `specs/mission.md`). The harness introduces no new Jentic endpoint; it only runs the shipped CLI, which already makes exactly that one call.
+- **`--with-llm` sends only targeted spec context, not the full spec** (`specs/mission.md`; `skills/jentic-api-improve/SKILL.md`). Using a local proxy keeps the engine's spec context on-host and gives free, exact token counts — the sanctioned privacy-preserving path.
+- **Reproducibility = pin CLI version → image tag → engine pair** (`specs/mission.md`; `specs/tech-stack.md`; `docs/architecture.md` §8). The doc stamps the exact CLI/image version measured (currently `@jentic/api-scorecard-cli` 1.9.3, read from `packages/cli/package.json`) and the run date, so a result is always attributable to a specific engine release.
+- **No mocking in the three test suites** (`.claude/rules/testing.md`). The harness is not one of those suites and lives under `scripts/`, so it is exempt; the token-counting proxy forwards to a real upstream (not a fake), and the harness stays out of `docker/tests/` and `packages/*/test/` and out of `ci.yml`.
+- **`scripts/*.js` is not covered by `npm run lint`** (`eslint.config.js` globally ignores `**/*.js`; the lint script targets only `packages/*` `src test`). So the harness's lint cleanliness must be asserted with an explicit `npx eslint` / `npx prettier --check` invocation, not assumed from the repo-wide lint.
+
+## Context
+
+This phase exists because Phase 21 has shipped the `jentic-api-improve` skill, and `--with-llm` cost is the first question a prospective adopter asks — the skill runs a coding agent through a multi-iteration loop *and* triggers LLM-backed engine analysis on every score, so the total spend is non-obvious and model-dependent. A measured, published cost table turns "how expensive is this?" into a concrete answer and gives model-selection guidance grounded in real numbers rather than guesses.
+
+It is deliberately the repo's first benchmarking work and the first use of Claude Code headless mode (`claude -p`) as a measurement harness, so the plan builds the net-new, riskiest pieces first (the token-counting proxy, then the matrix driver) before the deterministic data→doc rendering. The deliverable `docs/improve-cost-benchmark.md` sits alongside `docs/llm-signals.md`, which already documents the engine's `--with-llm` provider matrix and the local-provider recipe the proxy relies on; the benchmark cross-references it. The harness follows the `scripts/extract-docs.js` model closely: Node ESM, zero dependencies, a `--dry-run` mode, and a root `package.json` `bench:*` script entry beside the existing `docs:*` entries.
+
+## Stakeholder Notes
+
+- **OpenAPI spec authors / prospective skill adopters** — want to know what running the improve skill will cost before committing to it, and which model gives the best cost/quality trade-off. Satisfied by the per-surface cost table and model-selection guidance in `docs/improve-cost-benchmark.md`.
+- **Jentic maintainers** — want a repeatable way to re-measure cost when the engine or skill changes, and a version-stamped record of each measurement. Satisfied by the pinned-version harness and the regeneratable data-file→doc pipeline.

--- a/specs/2026-07-05-benchmark-improve-cost/validation.md
+++ b/specs/2026-07-05-benchmark-improve-cost/validation.md
@@ -1,0 +1,66 @@
+# Phase 22 Validation — Benchmark jentic-api-improve Token Usage and Cost
+
+## Definition of Done
+
+All of the following must be true before this branch is merged. Every check here is deterministic and spends no scorecard quota and no LLM budget — the real model×spec measurement is a manual step (see Not Required), not a merge gate.
+
+### 1. Harness lints and formats clean (explicit)
+
+```
+npx eslint scripts/bench-improve.js scripts/token-proxy.mjs
+npx prettier --check scripts/bench-improve.js scripts/token-proxy.mjs
+```
+
+Both exit 0. This must be run explicitly: `npm run lint` does **not** cover `scripts/*.js` (`eslint.config.js` globally ignores `**/*.js` and the lint script targets only `packages/*` `src test`), so a `scripts/`-only change is invisible to the repo-wide lint.
+
+### 2. Data file is valid JSON
+
+```
+node -e "JSON.parse(require('fs').readFileSync('scripts/bench-improve.sample.json','utf8'))"
+```
+
+Exits 0. The committed sample results data file parses as JSON. If a real results data file is also committed, the same check passes against it.
+
+### 3. Doc generation is a pure, reproducible function of the data file
+
+```
+node scripts/bench-improve.js --render-only --data scripts/bench-improve.sample.json --output-dir /tmp/bench-check
+```
+
+Exits 0 and writes a markdown file under `/tmp/bench-check` (never into the repo). Rendering the **same** data file twice produces byte-identical output, and rendering the committed real data file reproduces the committed `docs/improve-cost-benchmark.md` (diff-clean) — proving the generator performs no measurement and no LLM call, only a deterministic transform of its input.
+
+### 4. Dry-run exercises the full matrix with no spend
+
+```
+node scripts/bench-improve.js --dry-run
+```
+
+Exits 0, prints every planned `model × spec` cell (all four agent models × each pinned spec), and makes **no** real `claude -p` invocation, no real model call, and no `score` call — so it consumes zero scorecard quota. Verifiable from the absence of any outbound provider request and no quota decrement.
+
+### 5. Token-counting proxy tallies correctly against a stub upstream
+
+The `scripts/token-proxy.mjs` self-check (exercised by the dry-run wiring) starts the proxy, sends a canned `POST /v1/chat/completions` whose stub response carries a known `usage` block, and confirms the proxy's running tally equals that known count, then shuts down cleanly — no real upstream contacted. A streamed response with no `usage` block records `null` (unknown), never `0`.
+
+### 6. Data file records both surfaces and provenance
+
+`scripts/bench-improve.sample.json` (and any committed real data file) has, per cell, token counts split into an `engine` surface and an `agent` surface (not a single merged total), the spec's OAK URL and baseline score, `iterations_run`, `score_before`/`score_after`, and a `cli_version` + `run_date` stamp. A cell that errored records the error rather than zero-cost numbers.
+
+### 7. Published doc has the required shape
+
+`docs/improve-cost-benchmark.md` exists and contains: a results table across models × specs with token and cost totals broken down by surface (engine vs agent), the pinned spec set listed with each spec's URL and baseline score, model-selection guidance, and a header stamping the measured `cli_version` and run date.
+
+### 8. Roadmap lifecycle marker
+
+```
+grep -F "## Phase 22 — Benchmark jentic-api-improve Token Usage and Cost ✅" specs/roadmap.md
+```
+
+Exits 0 — the Phase 22 heading carries the ` ✅` suffix (space + U+2705), with the rest of the block unchanged.
+
+## Not Required
+
+- **Running the real model×spec measurement in CI.** It spends real scorecard quota and real LLM budget and its outputs are stochastic, so it cannot be a deterministic gate. The one real run that produces the committed data file and doc is a manual step performed once at implementation time; it is not re-run to merge.
+- **The three test suites** (`docker/tests/` pytest, `packages/cli` and `packages/formatter-html` mocha). This phase changes only `scripts/`, `docs/`, `specs/`, and the root `package.json` `scripts` block — no code any suite covers, so per `.claude/rules/testing.md` "When to run" no suite is required. The harness is intentionally not one of those suites and is not added to `ci.yml`.
+- **A README `## CLI reference` / `SKILL.md` flag-table sync.** The CLI surface is unchanged (`.claude/rules/cli-readme-sync.md` triggers only on `packages/cli/src/{index,detail,format,exit-codes}.ts`).
+- **A `specs/tech-stack.md` update.** The harness adds no load-bearing dependency (Node stdlib + built-in `fetch`, matching `extract-docs.js`); per `.claude/rules/update-tech-stack-on-deps.md` a swappable dev helper does not warrant a constitution entry, and the existing `extract-docs.js` harness set the precedent (it appears in neither `tech-stack.md` nor the README).
+- **Wiring the deterministic checks into CI.** Checks 1–5 could be CI-gated later, but no existing CI job touches `scripts/`; adding one is out of scope here — the checks are run manually / at review time for this phase.


### PR DESCRIPTION
## Summary

Spec scaffold for **Phase 22: Benchmark jentic-api-improve Token Usage and Cost** from `specs/roadmap.md`.

This PR adds **spec files only** — no code changes. Implementation follows in a separate PR once this spec is approved.

### Scope

A developer-run benchmark that measures how many tokens and how much money a full `jentic-api-improve` run consumes, so an adopter can pick a model and anticipate cost. It measures two independent surfaces separately — the coding agent's own reasoning across the skill's standard 2-iteration loop, and the scoring engine's `--with-llm` spend — across a matrix of Claude agent models (haiku/sonnet/opus/fable) × pinned OAK specs of varying size and starting quality. Delivered as a zero-dependency Node ESM harness under `scripts/` (matching `extract-docs.js`), a net-new local token-counting OpenAI-compatible proxy, a machine-readable results data file, and a generated `docs/improve-cost-benchmark.md`. The real measurement is manual (real quota + LLM spend, stochastic); the deterministic parts (lint, JSON validity, data→doc rendering, dry-run) are verifiable.

### Out of Scope

- CI gating of the real measurement (can't spend real money/quota in CI).
- Any change to the CLI, container, runner, or scoring engine.
- A new dependency solely to parse args or run the proxy.
- Making `fable` an engine `--with-llm` option (it's an agent-axis model alias only).

### Key decisions

- Measure two surfaces separately, with distinct signals (agent = `claude -p --output-format json`; engine = local proxy tally).
- The scorecard JSON does **not** expose token usage (confirmed) → a local token-counting proxy is required, not optional.
- Hold the engine `--with-llm` provider fixed across the model axis so the agent-model comparison isn't confounded.
- Pin the input-spec set (OAK URL + recorded baseline score); anchor spec is the repo's known-good swagger-api petstore.
- Split expensive measurement from cheap deterministic rendering (data file → doc), enabling verification without spend.

## Files

- `specs/2026-07-05-benchmark-improve-cost/requirements.md`
- `specs/2026-07-05-benchmark-improve-cost/plan.md`
- `specs/2026-07-05-benchmark-improve-cost/validation.md`

## Review guidance

Reviewers should verify:
- The phase goal is captured faithfully (see `specs/roadmap.md` Phase 22).
- Scope, constraints, and decisions match intent — especially the two-surface measurement, the proxy-required finding, and the fixed-engine-provider decision.
- The plan's risky-bits-first grouping (proxy → harness → data → doc → measurement → lifecycle) is appropriately granular and each group's work is verifiable.
- The validation gates are realistic: deterministic checks are the merge gate; the real model×spec run is manual by necessity.

Refs: `specs/roadmap.md` Phase 22; #284.