### PR TITLE
docs(README): clarify plugin@marketplace install grammar

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,10 @@ doubles as a plugin marketplace:
 /plugin install api-scorecard@jentic-api-scorecard
 ```
 
+The `install` argument is `<plugin>@<marketplace>`: the marketplace is always
+`jentic-api-scorecard`, and the part before the `@` is the plugin name — `api-scorecard`
+here, or `api-improve` for the [improve skill](#jentic-api-improve).
+
 Once installed, the skill loads automatically when you ask Claude to score an OpenAPI document —
 no explicit invocation needed:
 
@@ -350,6 +354,9 @@ The improve skill is a **separate plugin** in this repository's marketplace:
 /plugin marketplace add jentic/jentic-api-scorecard
 /plugin install api-improve@jentic-api-scorecard
 ```
+
+The marketplace half is the same `jentic-api-scorecard` as the [scoring
+skill](#jentic-api-scorecard) — only the plugin name changes, to `api-improve`.
 
 Installing the plugin also registers the companion `jentic-api-improve` subagent (used
 for multi-iteration improvement loops). Once installed, ask Claude to improve a spec:

--- a/docs/publish-config.json
+++ b/docs/publish-config.json
@@ -34,7 +34,7 @@
       "title": "API Scorecard \u2013 Agent Skill (Scoring)",
       "intro": "The `jentic-api-scorecard` **agent skill** teaches AI coding agents how to use the scoring CLI correctly \u2014 installing it, scoring files and URLs, producing JSON/HTML reports, wiring it into CI, and interpreting exit codes. Install it through whichever path fits your agent.\n\n---",
       "sections": [
-        { "heading": "jentic-api-scorecard", "level": 3, "headingShift": -1 }
+        { "heading": "jentic-api-scorecard", "level": 3, "headingShift": -1, "contentReplacements": [{ "from": "(#jentic-api-improve)", "to": "(./api-improve-skill.md#jentic-api-improve)" }] }
       ],
       "relatedLinks": [
         { "text": "CLI Reference", "href": "./api-scorecard.md" },


### PR DESCRIPTION
## What

Adds a one-sentence clarification beside each Claude Code `/plugin install` snippet in `README.md`, explaining that the argument is `<plugin>@<marketplace>`: the marketplace is always `jentic-api-scorecard`, and only the plugin name changes (`api-scorecard` vs `api-improve`).

## Why

A user hit `Marketplace "jentic-api-improve" not found` after running `/plugin install api-scorecard@jentic-api-improve` — the two halves were swapped. The repo/marketplace name (`jentic-api-scorecard`) is reused as one skill's stem, which invites the mix-up. The `api-improve` plugin itself is correctly wired; this is purely a docs clarification to prevent the confusion recurring. No code or plugin-catalog change.

## Notes

- Both snippets are mirrored to docs.jentic.com via `scripts/extract-docs.js`. The new cross-reference `[improve skill](#jentic-api-improve)` on the scorecard page would be a dead same-page anchor once extracted (that heading lives on a separate page), so `docs/publish-config.json` gains a `contentReplacements` rewrite to `./api-improve-skill.md#jentic-api-improve` — mirroring the pattern the improve page already uses for its `#jentic-api-scorecard` link.
- Verified with `npm run docs:extract`: both regenerated skill pages carry the new sentence and the cross-page anchors resolve.
- Docs-only change; no test suites apply per `.claude/rules/testing.md`. Does not touch the `## CLI reference` section, so `cli-readme-sync.md` is not triggered.