### PR TITLE
docs(spec): scaffold phase 23 — improve change-scope modes

### DIFF
--- a/specs/2026-07-14-jentic-api-improve-change-scope-modes/plan.md
+++ b/specs/2026-07-14-jentic-api-improve-change-scope-modes/plan.md
@@ -1,0 +1,37 @@
+# Phase 23 Plan — jentic-api-improve Change-Scope Modes
+
+## Group 1 — Skill core: mode switch + oasdiff in `SKILL.md`
+
+1. Declare the `mode` option in `skills/jentic-api-improve/SKILL.md`: extend the `argument-hint` frontmatter (line 10) and the Overview input handling (line ~18) to accept a named `mode` with values `non-breaking` (default), `summary-description`, `full`; state explicitly that an omitted mode behaves exactly as today.
+2. Add `Bash(oasdiff *)` to the `allowed-tools` frontmatter (line 11) and to both `settings.local.json` pre-approval snippets (lines ~51-53 and ~72-74); add the `oasdiff` install command to the `compatibility` frontmatter line (line 9).
+3. Add a `### oasdiff (breaking-change detection)` subsection under `## CLI Tools` (following the per-tool template at lines 174-208): install channel (Go install / Homebrew / release binary / `docker run tufin/oasdiff`), the canonical single-command invocation (`oasdiff breaking <base> <revision> --format json -o <file>`, base = read-only `$0`, revision = placed improved spec), and its exit-code contract (non-zero / non-empty breaking list = break found).
+4. Define the per-mode behavior in the `## Improvements are non-breaking` / `## Constraints` sections (lines 294-322, 626-643): `summary-description` restricts edits to `description_suggestion`/`summary_suggestion` from `POOR_OPERATION_SEMANTICS` diagnostics only; `non-breaking` keeps the current strictly-additive MUST-NOT list; `full` relaxes the MUST-NOT list to permit breaking edits but is still bound by the no-dimension-regression guard.
+5. Wire `summary-description`'s hard LLM requirement into the exit-8 handling (lines 218, 292): in this mode a scorecard LLM-failure (exit 8) stops the run with a report and does NOT offer the up-front `--with-llm` drop.
+6. Set the iteration policy per mode at the loop cap (line 536): `non-breaking`/`summary-description` keep the max-2-then-ask cap; `full` runs more iterations by default (state the concrete higher cap and the same "ask the user before exceeding" behavior).
+7. Add the `oasdiff breaking` check to the post-placement verify sequence (alongside verify step G, lines 441-447 / 562): run after final placement comparing `$0` original vs the placed improved spec; report the verdict in all modes; fail the run in `non-breaking`/`summary-description` on a detected break; report-only in `full`.
+8. Confirm the no-dimension-regression guard (step 7, line 547) is stated as applying in all three modes including `full`, and that `full`'s breaking edits are only shipped when no dimension drops below baseline.
+9. Add a `Change-scope mode:` field to the subagent brief template (lines 493-522) so the selected mode threads to the spawned subagent, and update the placeholder-fill instructions (lines 746-758) accordingly.
+
+## Group 2 — Mirror into the agent + add `references/oasdiff.md`
+
+10. Mirror every Group 1 behavioral rule into `agents/jentic-api-improve.md`: add `Bash(oasdiff *)` to `allowed-tools` (line 6), the per-mode constraint relaxation/restriction (`## Constraints`, lines 123-129), the per-mode iteration cap (line 42), and the `oasdiff` check in the final-placement verify step (line 68). Keep the skill as the single source for Forbidden Shell Idioms (agent lines 15-17) — do not duplicate that list.
+11. Create `skills/jentic-api-improve/references/oasdiff.md` modeled on `references/jentic-apitools-cli.md`: install, the `oasdiff breaking` invocation, machine-readable output shape, and an exit-code → per-mode reaction table (fail in `non-breaking`/`summary-description`, report in `full`).
+12. Update `skills/jentic-api-improve/references/jentic-api-scorecard.md` only if the `summary-description` "fail if LLM unavailable" rule needs restating against the scorecard exit-code table (line ~106) — otherwise leave untouched.
+
+## Group 3 — Documentation sync
+
+13. Update the README `### jentic-api-improve` section (lines 305-360): document the three modes and the default, add `oasdiff` to the prerequisite install block (lines 320-325), and refresh the one-line skills-table row (line 257) and TOC anchor (line 31) if wording changes. Keep the H3 heading text `jentic-api-improve` unchanged so `docs/publish-config.json` extraction still resolves.
+14. Update `docs/architecture.md` §4: correct the references-tree description (line 141) from "six-file" to "seven-file" and list `oasdiff` among the improve skill's orchestrated tools; note the `mode` switch in the improve-skill layout prose (lines 139-143).
+15. Update `.claude/CLAUDE.md` (the `skills/` bullet, line ~16): change the improve skill's "six-file `references/` tree" to seven files, add `oasdiff` to its orchestrated-tooling list, and mention the three modes.
+16. Update the `api-improve` plugin description in `.claude-plugin/marketplace.json` (line ~18) so it no longer implies improvements are exclusively non-breaking (acknowledge `full` mode's opt-in breaking changes).
+17. Add a one-line note to `docs/improve-cost-benchmark.md` that `full` mode's extra iterations increase score-quota spend beyond the benchmarked two-iteration loop.
+18. Append ` ✅` (a single space followed by the U+2705 checkmark) to the `## Phase 23 — jentic-api-improve Change-Scope Modes` heading in `specs/roadmap.md`, leaving the rest of the block untouched, per the lifecycle rule.
+
+## Group 4 — Verify
+
+19. `git diff --name-only main...HEAD` lists only files under `skills/jentic-api-improve/`, `agents/jentic-api-improve.md`, `README.md`, `docs/architecture.md`, `docs/improve-cost-benchmark.md`, `.claude/CLAUDE.md`, `.claude-plugin/marketplace.json`, and `specs/2026-07-14-jentic-api-improve-change-scope-modes/` — no `docker/` or `packages/` code changed.
+20. `python -m pip install "git+https://github.com/NVIDIA/SkillSpector.git@cff7ecc4f2881d9e23ea4bb801a6353e1dbe39e6"` then `skillspector scan skills/jentic-api-improve/ --no-llm --format json --output /tmp/report.json` and `python -c "import json;print(json.load(open('/tmp/report.json'))['risk_assessment']['recommendation'])"` prints `SAFE`.
+21. `npm run docs:extract:dry-run` exits 0 (README `### jentic-api-improve` heading still resolves against `docs/publish-config.json`).
+22. `grep -F "## Phase 23 — jentic-api-improve Change-Scope Modes ✅" specs/roadmap.md` exits 0 (roadmap-completion marker present).
+23. Doc-consistency check: the three mode names, the default (`non-breaking`), and the `oasdiff` prerequisite appear consistently in `SKILL.md`, `agents/jentic-api-improve.md`, `README.md`, `docs/architecture.md`, and `.claude/CLAUDE.md` (no file omits a mode or names one differently).
+24. Behavioral matrix (manual, per `validation.md`): drive the skill against a fixture spec once per mode and confirm — `summary-description` applies only summary/description edits and stops if LLM is unavailable; `non-breaking` stays additive and fails on a detected break; `full` runs more iterations, may make breaking edits, and reports (does not fail) on a break — with the no-dimension-regression guard holding in every mode.

--- a/specs/2026-07-14-jentic-api-improve-change-scope-modes/requirements.md
+++ b/specs/2026-07-14-jentic-api-improve-change-scope-modes/requirements.md
@@ -1,0 +1,56 @@
+# Phase 23 Requirements — jentic-api-improve Change-Scope Modes
+
+## Scope
+
+This phase adds a change-scope `mode` selector to the already-shipped `jentic-api-improve` skill (and its companion subagent) so a user can bound how far the skill is allowed to alter an OpenAPI document. Three modes ship: `summary-description` (apply only the LLM-sourced `summary`/`description` suggestions the scorecard surfaces), `non-breaking` (the current strictly-additive behavior — the default), and `full` (more iterations and a broader set of signals, permitting breaking edits, but only where no JAIRF dimension regresses below baseline). The work is entirely inside the markdown skill and agent plus their `references/` tree and the surrounding documentation — no `docker/` or `packages/` code changes.
+
+Alongside the modes, every run gains an `oasdiff`-based breaking-change detection step that compares the original input against the final improved spec. The detection always runs and always reports its result. In `non-breaking` and `summary-description` modes a detected breaking change fails the run; in `full` mode it is reported but does not fail (breaking edits are expected there, bounded by the no-regression guard). `oasdiff` becomes a new user-installed orchestrated tool, documented the same way the skill already documents `jentic-openapi-tools`, `check-jsonschema`, and `jentic-apitools`.
+
+## Out of Scope
+
+- No changes to the scorecard CLI (`packages/cli/`) or the Python runner (`docker/`). The mode switch lives only in the markdown skill/agent; `docs/architecture.md` §5–§9 (CLI flags, auth, engine) are unaffected.
+- No bundling or auto-installing of `oasdiff`. It is a user-installed prerequisite, invoked when present — consistent with the skill's "orchestrate user-installed tooling, never vendor it" model.
+- No new automated test suite for the skill. Markdown skills have no unit tests; the automated gate stays SkillSpector, and mode/oasdiff behavior is validated manually (see `validation.md`).
+- No change to the two-plugin `marketplace.json` structure, the tarball `prepack`/`postpack` packaging, or the `docs/publish-config.json` page mapping beyond keeping their text accurate (the `api-improve` plugin description is refreshed to acknowledge `full` mode).
+- No relaxation of the `non-breaking` default or the `summary-description` guarantees — `full` is strictly opt-in.
+
+## Decisions
+
+### Full mode is aggressive but score-safe
+
+`full` mode performs more iterations by default and pursues a broader set of improvement signals than `non-breaking`, and it is permitted to make breaking contract changes — but the existing "no dimension may drop below baseline" pre-ship guard (`SKILL.md` step 7, introduced in commit `b301395`) still applies in every mode. A breaking edit is therefore only shipped when it does not regress any JAIRF dimension; a breaking edit that drops a dimension is rejected exactly as an additive regression is today. This preserves most of the skill's safety while widening the edit surface, and it keeps a single guard rule across all three modes rather than forking the guard logic per mode. `oasdiff` runs report-only in `full` (breaking changes are expected and surfaced, not fatal).
+
+### summary-description mode requires LLM and applies only summary/description suggestions
+
+In `summary-description` mode the skill applies only the `description_suggestion` / `summary_suggestion` fields carried by the scorecard's `POOR_OPERATION_SEMANTICS` diagnostics, which exist only when the score runs with `--with-llm`. This mode therefore hard-requires an available LLM in the score CLI: if the scorecard returns the LLM-failure exit code (8), the run stops and reports rather than falling back to a no-LLM pass. This is a mode-specific hardening of the skill's existing exit-8 handling (today a stop-and-report with an optional up-front `--with-llm` drop); in this mode the drop is not offered, because the mode is defined entirely by LLM-sourced suggestions.
+
+### mode is a named option, default non-breaking
+
+`mode` is surfaced as a named option (parsed from the invocation / prompt), not a third positional argument, because the skill already uses `$0` (input) and `$1` (output dir) positionally and a third positional would collide with the output-dir slot semantics. When unspecified, `mode` defaults to `non-breaking` so existing invocations behave exactly as before. The exact surface (named flag vs. prompt-instruction convention) is settled in `plan.md`; the requirement is only that the default is non-breaking and that an omitted mode is indistinguishable from today's behavior.
+
+### oasdiff is a user-installed Go binary
+
+`oasdiff` (github.com/oasdiff/oasdiff) is a Go binary, unlike every current prerequisite which installs via `pipx`/`npx`. Its install channel (Go install, Homebrew, release binary, or `docker run tufin/oasdiff`) is documented in the skill's `compatibility` line, the `## CLI Tools` section, a new `references/oasdiff.md`, and the README prerequisite block. A new `Bash(oasdiff *)` entry is added to `allowed-tools` in both the skill and the agent (and to the two `settings.local.json` pre-approval snippets), and the invocation obeys the skill's Forbidden Shell Idioms (single allowlisted command, machine-readable output via a flag/redirect, no pipes or compound shell).
+
+## Constraints
+
+Load-bearing invariants this phase must preserve (from `specs/mission.md`, `specs/tech-stack.md`, `docs/architecture.md`, and the current skill):
+
+- **Skills are markdown-only; they orchestrate user-installed tooling and never vendor or auto-install it** — `oasdiff` must follow the existing user-installed-prerequisite pattern (`docs/architecture.md` §4; `.claude/CLAUDE.md`).
+- **`skills/` is the single canonical source consumed by three distribution paths** (TanStack Intent, Vercel `skills`, Claude Code marketplace) — every edit lands in the one tree; the tarball `prepack`/`postpack` glob auto-includes new `references/` files, so no packaging edit is needed.
+- **SkillSpector `SAFE` gate must keep passing** — `skill-security.yml` globs `skills/*`, runs SkillSpector pinned at commit `cff7ecc` (v2.1.4), and fails unless `risk_assessment.recommendation == "SAFE"`. New shell in `SKILL.md` can flip the verdict, so the `oasdiff` invocation must respect the Forbidden Shell Idioms.
+- **The default must stay non-breaking; the Overlay is documented as the non-breaking delta** — `full` mode is an explicit opt-in and must not weaken the `non-breaking`/`summary-description` guarantees.
+- **The original input `$0` is read-only for the whole run** — `oasdiff` compares the read-only original against the placed improved spec; it must not mutate `$0`.
+- **The no-regression guard ("no dimension may drop below baseline; ship the best clean iteration")** — retained in all three modes, including `full` (this is what makes `full` "score-safe").
+- **Skill and agent are mirrored** — every loop/constraint rule exists verbatim in both `SKILL.md` and `agents/jentic-api-improve.md`; mode and oasdiff logic must land in both to avoid drift.
+
+## Context
+
+Phase 21 ported the `jentic-api-improve` skill into this repo as public OSS; Phase 22 benchmarked it across models and specs. Both established the skill as the second public consumer of the scorecard CLI and hardened its no-regression guard. This phase refines that shipped skill: today it runs exactly one behavior (strictly-additive, non-breaking, max two iterations), and users have no way to say "only touch summaries and descriptions" or "go further, I accept breaking changes." The mode switch gives users that control, and `oasdiff` gives every run an explicit, tool-verified breaking-change verdict rather than relying on the skill's self-imposed additive discipline alone.
+
+The relevant design surface is `docs/architecture.md` §4 (the `skills/`/`agents/` layout, the two-plugin marketplace model, and the tarball packaging note) and the improve-skill README section (`### jentic-api-improve`), which the `docs/publish-config.json` `agent-improve-skill` page extracts into the docs site. `docs/improve-cost-benchmark.md` (Phase 22) assumes the standard two-iteration loop; `full` mode's extra iterations warrant a note there, since they multiply score-quota spend.
+
+## Stakeholder Notes
+
+- **OpenAPI spec authors/maintainers (primary persona)** — gain explicit control over how invasive the skill is: a light "polish the prose" pass (`summary-description`), the safe default (`non-breaking`), or an aggressive pass they knowingly accept breaking changes from (`full`), with an `oasdiff` verdict on every run.
+- **CI integrators (secondary)** — the per-mode failure semantics (fail on break in `non-breaking`/`summary-description`) make the skill safe to wire into a gated pipeline where only non-breaking improvements may land automatically.

--- a/specs/2026-07-14-jentic-api-improve-change-scope-modes/validation.md
+++ b/specs/2026-07-14-jentic-api-improve-change-scope-modes/validation.md
@@ -1,0 +1,65 @@
+# Phase 23 Validation — jentic-api-improve Change-Scope Modes
+
+## Definition of Done
+
+All of the following must be true before this branch is merged.
+
+### 1. SkillSpector SAFE verdict
+
+```
+python -m pip install "git+https://github.com/NVIDIA/SkillSpector.git@cff7ecc4f2881d9e23ea4bb801a6353e1dbe39e6"
+skillspector scan skills/jentic-api-improve/ --no-llm --format json --output /tmp/report.json
+python -c "import json; print(json.load(open('/tmp/report.json'))['risk_assessment']['recommendation'])"
+```
+
+Prints `SAFE`. This mirrors the CI gate in `.github/workflows/skill-security.yml` (pinned commit `cff7ecc`, v2.1.4), which fails unless `risk_assessment.recommendation == "SAFE"`. The `skill-security.yml` job for `jentic-api-improve` must be green on the PR.
+
+### 2. Docs extraction dry-run passes
+
+```
+npm run docs:extract:dry-run
+```
+
+Exits 0. Confirms the README `### jentic-api-improve` H3 heading still resolves against the `agent-improve-skill` page in `docs/publish-config.json` (extraction `process.exit(1)`s on a heading miss). If the README section was renamed, `docs/publish-config.json` must be updated in lockstep so this still exits 0.
+
+### 3. Roadmap-completion marker present
+
+```
+grep -F "## Phase 23 — jentic-api-improve Change-Scope Modes ✅" specs/roadmap.md
+```
+
+Exits 0. The `## Phase 23 — …` heading ends with ` ✅` (single space + U+2705) and the rest of the block is unchanged.
+
+### 4. No code trees touched
+
+```
+git diff --name-only main...HEAD
+```
+
+Every path is under `skills/jentic-api-improve/`, `agents/jentic-api-improve.md`, `README.md`, `docs/architecture.md`, `docs/improve-cost-benchmark.md`, `.claude/CLAUDE.md`, `.claude-plugin/marketplace.json`, or `specs/2026-07-14-jentic-api-improve-change-scope-modes/`. No file under `docker/` or `packages/` appears.
+
+### 5. Mode surface documented consistently
+
+The three mode names (`summary-description`, `non-breaking`, `full`), the default (`non-breaking`), and the `oasdiff` prerequisite appear consistently across `skills/jentic-api-improve/SKILL.md`, `agents/jentic-api-improve.md`, `README.md`, `docs/architecture.md`, and `.claude/CLAUDE.md`. No file omits a mode, names one differently, or contradicts the per-mode `oasdiff` fail/report behavior. `docs/architecture.md` and `.claude/CLAUDE.md` describe the references tree as seven files (was six) and list `oasdiff` among the orchestrated tools.
+
+### 6. oasdiff invocation obeys the Forbidden Shell Idioms
+
+The `oasdiff` invocation in `SKILL.md` (and any in the agent) is a single allowlisted `Bash(oasdiff *)` command writing machine-readable output via a flag/redirect — no `$(...)`, no compound `&&`/`;`/`|`, no heredoc — and `Bash(oasdiff *)` is present in `allowed-tools` in both `SKILL.md` and `agents/jentic-api-improve.md` and in both `settings.local.json` pre-approval snippets.
+
+### 7. Behavioral matrix across the three modes (manual)
+
+Drive the skill against a fixture spec (e.g. `packages/cli/test/fixtures/sample.yaml`) once per mode with `oasdiff` available (install via `go install github.com/oasdiff/oasdiff@latest` or `docker run --rm -v "$PWD:/specs" tufin/oasdiff breaking /specs/before.yaml /specs/after.yaml`). Confirm:
+
+- `summary-description`: only `summary`/`description` fields are added/changed; the run stops and reports if the score CLI has no LLM (scorecard exit 8); a detected breaking change fails the run.
+- `non-breaking` (default): edits stay strictly additive; a detected breaking change fails the run.
+- `full`: more iterations run; breaking edits may appear; `oasdiff` reports the break but the run does not fail on it; the no-dimension-regression guard still holds (no JAIRF dimension below baseline in the shipped iteration).
+
+Evidence (the improved specs, the `oasdiff` verdicts, and the per-mode pass/fail outcome) is attached to the PR. This is a required reviewer walkthrough, not a CI gate — the skill is agent-driven markdown and cannot be exercised by an automated suite.
+
+## Not Required
+
+- No unit / integration / e2e test suite for the skill — no pytest (`docker/tests/`) or mocha (`packages/cli/test/`, `packages/formatter-html/test/`) test touches `skills/` or the improve skill, and `.claude/rules/testing.md` exempts `docs/`/`.claude/`-only changes from test suites.
+- No `cli-readme-sync.md` obligation — that rule is scoped to `packages/cli/src/*.ts`; this phase changes no CLI source and the improve skill has no README flag/mode table to mirror. Doc consistency is the manual check in item 5.
+- No CI job for `oasdiff` — break detection is a runtime behavior of the agent-driven skill; item 7 is the manual verification.
+- No packaging edits — the `prepack`/`postpack` `copyfiles` globs and `marketplace.json` directory references auto-include the new `references/oasdiff.md`; only text accuracy (item 5, plugin description) is checked.
+- No changes to the scorecard CLI, the Docker runner, exit codes, or `docs/architecture.md` §5–§9.


### PR DESCRIPTION
## Summary

Spec scaffold for **Phase 23: jentic-api-improve Change-Scope Modes** from `specs/roadmap.md`.

This PR adds **spec files only** — no code changes. Implementation follows in a separate PR once this spec is approved.

### Scope

Adds a change-scope `mode` selector to the `jentic-api-improve` skill and its companion subagent: `summary-description` (apply only the LLM-sourced summary/description suggestions the scorecard surfaces), `non-breaking` (the current strictly-additive default), and `full` (more iterations and broader signals, permitting breaking edits but only where no JAIRF dimension regresses below baseline). Every run gains an `oasdiff`-based breaking-change detection step that always reports its verdict, fails the run in `non-breaking`/`summary-description`, and is report-only in `full`. The work is entirely inside the markdown skill/agent, their `references/` tree, and surrounding docs — no `docker/` or `packages/` code changes.

### Out of Scope

- No changes to the scorecard CLI (`packages/cli/`) or the Python runner (`docker/`).
- No bundling or auto-installing of `oasdiff` — it is a user-installed prerequisite.
- No new automated test suite for the skill (SkillSpector stays the automated gate; mode/oasdiff behavior is validated manually).
- No relaxation of the `non-breaking` default or `summary-description` guarantees — `full` is strictly opt-in.

### Key decisions

- **Full mode is aggressive but score-safe** — permits breaking edits but the no-dimension-regression guard still applies in every mode, so a break that drops a dimension is rejected.
- **summary-description requires LLM** — applies only `description_suggestion`/`summary_suggestion` from `POOR_OPERATION_SEMANTICS`; hard-stops on scorecard exit 8 (no `--with-llm` drop offered).
- **mode is a named option, default non-breaking** — not a third positional (`$0`/`$1` are input/output-dir); an omitted mode is indistinguishable from today.
- **oasdiff is a user-installed Go binary** — documented install channels; `Bash(oasdiff *)` added to `allowed-tools` in skill + agent; invocation obeys the Forbidden Shell Idioms.

## Files

- `specs/2026-07-14-jentic-api-improve-change-scope-modes/requirements.md`
- `specs/2026-07-14-jentic-api-improve-change-scope-modes/plan.md`
- `specs/2026-07-14-jentic-api-improve-change-scope-modes/validation.md`

## Review guidance

Reviewers should verify:
- The phase goal is captured faithfully (see `specs/roadmap.md` Phase 23).
- Scope, constraints, and decisions match intent — in particular the `full`-mode "aggressive but score-safe" bound and the `summary-description` hard-LLM requirement.
- The plan's four task groups (SKILL.md core → agent + `references/oasdiff.md` → docs sync → Verify) are appropriately granular and each has a concrete verification step.
- The validation gates are realistic — SkillSpector SAFE + `docs:extract:dry-run` + doc-consistency are the automated/mechanical gates; the three-mode behavioral matrix (item 7) is a required manual reviewer walkthrough.

Refs: `specs/roadmap.md` Phase 23; #303.