### PR TITLE
feat(formatter-html): add per-diagnostic help tooltips

### DIFF
--- a/packages/formatter-html/src/app/components/DiagnosticsList.tsx
+++ b/packages/formatter-html/src/app/components/DiagnosticsList.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 
+import { DIAGNOSTIC_HELP } from '../diagnosticHelp.ts';
 import type { Diagnostic, Provenance } from '../types.ts';
 
 // Severity mapping: 1=Error, 2=Warning, 3=Information, 4=Hint
@@ -184,6 +185,7 @@ function DiagnosticItem({ diagnostic }: DiagnosticItemProps) {
   const [pathsExpanded, setPathsExpanded] = useState(false);
   const { code, message, severity, source, data } = diagnostic;
   const config = SEVERITY_CONFIG[severity as SeverityKey] || SEVERITY_CONFIG[3];
+  const help = DIAGNOSTIC_HELP[code];
 
   const paths = data?.paths && data.paths.length > 0 ? data.paths : null;
   const singlePath = !paths && data?.path && data.path.length > 0 ? formatPath(data.path) : null;
@@ -195,7 +197,17 @@ function DiagnosticItem({ diagnostic }: DiagnosticItemProps) {
   return (
     <div className={`p-2 rounded border ${config.color} text-xs`}>
       <div className="flex items-start justify-between gap-2">
-        <span className="font-mono font-semibold">{code}</span>
+        <span className="flex items-center gap-1">
+          <span className="font-mono font-semibold">{code}</span>
+          {help && (
+            <span className="relative group inline-flex items-center cursor-help">
+              <span className="text-[10px] opacity-40 select-none leading-none">ⓘ</span>
+              <span className="pointer-events-none absolute bottom-full left-1/2 -translate-x-1/2 mb-1.5 w-56 rounded bg-gray-800 px-2 py-1.5 text-[10px] text-white opacity-0 group-hover:opacity-100 transition-opacity z-20 whitespace-normal text-left shadow-lg">
+                {help.description}
+              </span>
+            </span>
+          )}
+        </span>
         <span className="text-[10px] opacity-70">{source}</span>
       </div>
       <p className="mt-1 text-gray-700">{message}</p>

--- a/packages/formatter-html/src/app/components/DiagnosticsSection.tsx
+++ b/packages/formatter-html/src/app/components/DiagnosticsSection.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 
+import { DIAGNOSTIC_HELP } from '../diagnosticHelp.ts';
 import type { Diagnostic } from '../types.ts';
 
 // Severity mapping: 1=Error, 2=Warning, 3=Information, 4=Hint
@@ -182,6 +183,7 @@ interface DiagnosticItemProps {
 function DiagnosticItem({ diagnostic, pathsExpanded, onTogglePaths }: DiagnosticItemProps) {
   const { code, message, severity, source, data } = diagnostic;
   const config = SEVERITY_CONFIG[severity as SeverityKey] || SEVERITY_CONFIG[3];
+  const help = DIAGNOSTIC_HELP[code];
 
   const paths = data?.paths && data.paths.length > 0 ? data.paths : null;
   const singlePath = !paths && data?.path && data.path.length > 0 ? formatPath(data.path) : null;
@@ -193,7 +195,17 @@ function DiagnosticItem({ diagnostic, pathsExpanded, onTogglePaths }: Diagnostic
   return (
     <div className={`p-3 rounded border ${config.color}`}>
       <div className="flex items-start justify-between gap-2">
-        <span className="font-mono font-semibold text-sm">{code}</span>
+        <span className="flex items-center gap-1">
+          <span className="font-mono font-semibold text-sm">{code}</span>
+          {help && (
+            <span className="relative group inline-flex items-center cursor-help">
+              <span className="text-xs opacity-40 select-none leading-none">ⓘ</span>
+              <span className="pointer-events-none absolute bottom-full left-1/2 -translate-x-1/2 mb-1.5 w-60 rounded bg-gray-800 px-2.5 py-2 text-xs text-white opacity-0 group-hover:opacity-100 transition-opacity z-20 whitespace-normal text-left shadow-lg">
+                {help.description}
+              </span>
+            </span>
+          )}
+        </span>
         <span className="text-xs opacity-70">{source}</span>
       </div>
       <p className="mt-1 text-sm text-gray-700">{message}</p>

--- a/packages/formatter-html/src/app/diagnosticHelp.ts
+++ b/packages/formatter-html/src/app/diagnosticHelp.ts
@@ -1,0 +1,131 @@
+export interface DiagnosticHelpEntry {
+  description: string;
+}
+
+// Short descriptions for known diagnostic codes. Keyed by the `code` string emitted
+// in the scorecard JSON. Codes absent from this map render without a tooltip.
+// Pending: full authoritative definitions from jentic/api-ai-readiness-framework#42.
+export const DIAGNOSTIC_HELP: Readonly<Record<string, DiagnosticHelpEntry>> = {
+  // Example coverage — see jentic/api-ai-readiness-framework#42 for full definitions
+  present_examples: {
+    description:
+      'Count of schema elements (properties, parameters, bodies) that carry at least one example value.',
+  },
+  total_examples: {
+    description: 'Total number of individual example values present across the document.',
+  },
+  expected_examples: {
+    description: 'Expected count of examples based on the number of example-bearing elements.',
+  },
+
+  // Description / summary coverage
+  describable_elements: {
+    description: 'Number of operations, schemas, and parameters that accept a description field.',
+  },
+  described_elements: {
+    description: 'Number of elements that have a non-empty description.',
+  },
+  summaries_expected: {
+    description: 'Number of operations expected to carry a summary.',
+  },
+  summaries_present: {
+    description: 'Number of operations that have a non-empty summary.',
+  },
+
+  // Operations
+  total_operations: {
+    description: 'Total number of operations (path × HTTP-method pairs) in the document.',
+  },
+  operations_with_operationId: {
+    description: 'Number of operations that declare an operationId.',
+  },
+  operation_response_coverage: {
+    description: 'Ratio of operations that document at least one response.',
+  },
+  operations_using_RFC9457: {
+    description: 'Fraction of error responses that follow the RFC 9457 Problem Details format.',
+  },
+
+  // $ref resolution
+  resolved_refs: {
+    description: 'Number of $ref references that resolve successfully after bundling.',
+  },
+  relative_refs: {
+    description: 'Number of relative $ref references in the document.',
+  },
+  absolute_http_refs: {
+    description: 'Number of $ref references that use an absolute http/https URL.',
+  },
+  total_refs: {
+    description: 'Total number of $ref references in the document.',
+  },
+
+  // Schema metrics
+  max_schema_depth: {
+    description: 'Maximum nesting depth of schema objects within the document.',
+  },
+  schema_count: {
+    description: 'Total number of schema definitions in the document.',
+  },
+
+  // Tags and security
+  tag_count: {
+    description: 'Total number of tags declared at the document level.',
+  },
+  security_scheme_count: {
+    description: 'Total number of security scheme definitions in components.securitySchemes.',
+  },
+  security_scheme_types: {
+    description: 'Security scheme type names used (e.g. apiKey, oauth2, http).',
+  },
+  security_schemes: {
+    description: 'Whether the document declares at least one security scheme.',
+  },
+
+  // Linting rules
+  operation_id_casing: {
+    description: 'Operation IDs must follow a consistent casing convention (camelCase by default).',
+  },
+  'operation-4xx-response': {
+    description: 'Operations should define at least one 4xx error response.',
+  },
+  RELATIVE_SERVER_URL: {
+    description: 'Server URLs should be absolute; relative URLs may cause resolution issues.',
+  },
+  'no-unused-components': {
+    description:
+      'All components (schemas, parameters, etc.) should be referenced by at least one operation.',
+  },
+  'oas3-unused-component': {
+    description: 'An OAS3 component is declared but not referenced anywhere in the document.',
+  },
+  UNUSED_SECURITY_SCHEME_DEFINED: {
+    description:
+      'A security scheme is defined in components.securitySchemes but not applied in any security requirement.',
+  },
+  'no-errors-without-content': {
+    description: 'Error responses (4xx/5xx) should include a response body schema.',
+  },
+  'no-x-response-headers': {
+    description: 'Response headers prefixed with X- are discouraged; prefer standard header names.',
+  },
+  'hosts-https-only-oas3': {
+    description: 'All server URLs should use https to enforce secure transport.',
+  },
+  'params-must-include-examples': {
+    description: 'Parameters should include at least one example value.',
+  },
+  'security-defined': {
+    description: 'Operations (or the document globally) should declare security requirements.',
+  },
+  'api-health': {
+    description: 'The API should expose a health or liveness endpoint.',
+  },
+  'monite-openapi-number-boundaries': {
+    description: 'Numeric fields should declare minimum and maximum constraints.',
+  },
+  'monite-security-no-secrets-in-path-or-query-parameters': {
+    description:
+      'Sensitive values (passwords, tokens, secrets) must not appear in path or query parameters.',
+  },
+};


### PR DESCRIPTION
Split out of #253 per review feedback — this PR is scoped to the per-diagnostic tooltips only.

## Summary

Adds per-diagnostic help tooltips to the HTML report. A new `DIAGNOSTIC_HELP` lookup table (30+ codes, keyed by diagnostic code) is wired into both `DiagnosticsSection` and `DiagnosticsList`: an (i) icon appears next to each diagnostic code that has a known description; hovering reveals it as a tooltip.

Authoritative definitions are pending JAIRF jentic/api-ai-readiness-framework#42 — this covers the codes found in the petstore fixture in the meantime, and can be extended/corrected once the spec definitions land.

## Test plan

- [x] `npm run lint -w @jentic/api-scorecard-formatter-html`
- [x] `npm run build -w @jentic/api-scorecard-formatter-html`
- [x] `npm test -w @jentic/api-scorecard-formatter-html` — 75 passing
- [ ] HTML report: hover over an (i) icon next to a known diagnostic code → tooltip appears with description
- [ ] HTML report: diagnostic with no entry in `DIAGNOSTIC_HELP` → no (i) icon rendered

Refs #245
