### PR TITLE
docs(spec): scaffold phase 25 - export sub-components from react

### DIFF
--- a/specs/2026-09-08-export-summarycard-dimensioncard-react/plan.md
+++ b/specs/2026-09-08-export-summarycard-dimensioncard-react/plan.md
@@ -1,0 +1,69 @@
+# Phase 25 Plan — Export SummaryCard and DimensionCard from `./react` Entry
+
+## Group 1 — Extract ApiMetadataCard
+
+1. Create `packages/formatter-html/src/app/components/ApiMetadataCard.tsx`:
+   - Move the `StatItem` helper function from `SummaryCard.tsx` into this new file (private, not exported).
+   - Define and export `ApiMetadataCardProps { apiMetadata: ApiMetadata }`.
+   - The component renders the stats bar: five `StatItem` rows for `operationCount`, `schemaCount`, `tagCount`, `securitySchemeCount`, and `securitySchemeTypes?.length`. Match the existing layout and Tailwind classes exactly.
+2. In `packages/formatter-html/src/app/components/SummaryCard.tsx`:
+   - Remove the inline `StatItem` helper and the stats bar JSX (now in `ApiMetadataCard`).
+   - Import `ApiMetadataCard` from `./ApiMetadataCard.tsx`.
+   - Add `showApiMetadata?: boolean` to `SummaryCardProps` (optional, no default in the interface — the component default is `true`).
+   - Replace the stats bar section with `{showApiMetadata !== false && <ApiMetadataCard apiMetadata={apiMetadata} />}`.
+
+## Group 2 — Export Prop Interfaces and Re-export from react.ts
+
+3. In `packages/formatter-html/src/app/components/SummaryCard.tsx`: ensure `interface SummaryCardProps` is `export interface SummaryCardProps` (make it exported).
+4. In `packages/formatter-html/src/app/components/DimensionCard.tsx` (line 7): change `interface DimensionCardProps` to `export interface DimensionCardProps`.
+5. In `packages/formatter-html/src/app/components/DiagnosticsSection.tsx` (line 44): change `interface DiagnosticsSectionProps` to `export interface DiagnosticsSectionProps`.
+6. In `packages/formatter-html/src/app/components/CircularProgress.tsx` (line 3): change `interface CircularProgressProps` to `export interface CircularProgressProps`.
+7. In `packages/formatter-html/src/app/components/GradeBadge.tsx` (line 10): change `interface GradeBadgeProps` to `export interface GradeBadgeProps`.
+8. In `packages/formatter-html/src/app/react.ts`: add component re-exports following the existing `export { default as Scorecard }` pattern:
+   ```
+   export { default as SummaryCard } from './components/SummaryCard.tsx';
+   export { default as DimensionCard } from './components/DimensionCard.tsx';
+   export { default as DiagnosticsSection } from './components/DiagnosticsSection.tsx';
+   export { default as CircularProgress } from './components/CircularProgress.tsx';
+   export { default as GradeBadge } from './components/GradeBadge.tsx';
+   export { default as ApiMetadataCard } from './components/ApiMetadataCard.tsx';
+   ```
+9. In `packages/formatter-html/src/app/react.ts`: add type re-exports:
+   ```
+   export type { SummaryCardProps } from './components/SummaryCard.tsx';
+   export type { DimensionCardProps } from './components/DimensionCard.tsx';
+   export type { DiagnosticsSectionProps } from './components/DiagnosticsSection.tsx';
+   export type { CircularProgressProps } from './components/CircularProgress.tsx';
+   export type { GradeBadgeProps } from './components/GradeBadge.tsx';
+   export type { ApiMetadataCardProps } from './components/ApiMetadataCard.tsx';
+   ```
+10. In `packages/formatter-html/src/app/react.ts`: update the comment about unexported building blocks to reflect that these six components are now public API; note that `SignalCard`, `CircularProgress`'s color helpers, `DiagnosticItem`, `FilterButton`, and signal-metadata panels remain unexported.
+
+## Group 3 — SSR Smoke Tests
+
+11. Create `packages/formatter-html/test/components.test.tsx` with mocha test cases using `renderToStaticMarkup` + `createElement` (following the pattern in `app.test.tsx`). Import each component from `../src/app/react.ts` (the public entry) to validate the re-export chain. Assert the rendered string is non-empty and does not contain the literal text `undefined`:
+    - `SummaryCard` with minimal valid props: `apiMetadata: { name: 'Test', operationCount: 0, schemaCount: 0, tagCount: 0, securitySchemeCount: 0 }`, `summary: { score: 50, level: 'ai-aware', grade: 'B' }`.
+    - `SummaryCard` with `showApiMetadata: false` — assert the rendered HTML does not contain the text `OPERATIONS` (the stat label).
+    - `DimensionCard` with minimal props: `dimension: { kind: 'FC', name: 'Foundational', score: 70, grade: 'A-' }`.
+    - `DiagnosticsSection` with a minimal diagnostics array: `[{ code: 'C001', message: 'test', severity: 1, source: 'spectral' }]`.
+    - `CircularProgress` with `score: 75`.
+    - `GradeBadge` with `grade: 'B+'`.
+    - `ApiMetadataCard` with minimal `apiMetadata`: `{ name: 'Test', operationCount: 3, schemaCount: 5, tagCount: 2, securitySchemeCount: 1 }` — assert the rendered HTML contains `OPERATIONS`.
+
+## Group 4 — Docs and Lifecycle
+
+12. Update `packages/formatter-html/README.md`: document all six exported components and their prop interfaces in the "React components" section. Include the `showApiMetadata` prop on `SummaryCard`, and note that `ApiMetadataCard` can be used independently to place the API stats anywhere in a custom layout.
+13. Update `.claude/CLAUDE.md` in the `packages/formatter-html/` bullet: change the sentence about building blocks staying unexported to name `SummaryCard`, `DimensionCard`, `DiagnosticsSection`, `CircularProgress`, `GradeBadge`, and `ApiMetadataCard` as the public `./react` surface; note that `SignalCard` and below remain unexported.
+14. Append ` ✅` (a single space followed by U+2705) to the `## Phase 25 — Export SummaryCard and DimensionCard from \`./react\` Entry` heading in `specs/roadmap.md`. Leave the rest of the block untouched.
+
+## Group 5 — Verify
+
+15. `npm run build:react -w @jentic/api-scorecard-formatter-html` exits 0.
+16. `grep 'SummaryCard' packages/formatter-html/dist/react/react.d.ts` exits 0.
+17. `grep 'ApiMetadataCard' packages/formatter-html/dist/react/react.d.ts` exits 0.
+18. `grep 'CircularProgress' packages/formatter-html/dist/react/react.d.ts` exits 0.
+19. `grep 'GradeBadge' packages/formatter-html/dist/react/react.d.ts` exits 0.
+20. `grep -E 'SignalCard|DiagnosticItem|FilterButton' packages/formatter-html/src/app/react.ts` exits non-zero (no matches).
+21. `npm test -w @jentic/api-scorecard-formatter-html` exits 0 — all existing and new SSR smoke tests pass.
+22. `npm run lint -w @jentic/api-scorecard-formatter-html` exits 0.
+23. `grep -F " ✅" specs/roadmap.md | grep -F "Phase 25"` exits 0.

--- a/specs/2026-09-08-export-summarycard-dimensioncard-react/requirements.md
+++ b/specs/2026-09-08-export-summarycard-dimensioncard-react/requirements.md
@@ -1,0 +1,57 @@
+# Phase 25 Requirements — Export SummaryCard and DimensionCard from `./react` Entry
+
+## Scope
+
+This phase widens the `./react` entry of `@jentic/api-scorecard-formatter-html` to export six React components — `SummaryCard`, `DimensionCard`, `DiagnosticsSection`, `CircularProgress`, `GradeBadge`, and a new `ApiMetadataCard` — plus a prop interface for each. The work has two complementary parts.
+
+**Part 1 — New component: `ApiMetadataCard`.** The stats bar currently embedded in `SummaryCard` (the Operations / Schemas / Tags / Security Schemes / Security Types count row) is extracted into its own exported `ApiMetadataCard` component. `SummaryCard` then uses `ApiMetadataCard` internally. A new `showApiMetadata` prop on `SummaryCard` (default `true`) controls whether the card is rendered. Consumers can suppress the stats row on the integrated `SummaryCard`, or import `ApiMetadataCard` directly and place it anywhere in their layout.
+
+**Part 2 — Re-export from `react.ts`.** All six components and their prop interfaces are added to the `./react` public entry. `CircularProgress` and `GradeBadge` are pure UI primitives — `CircularProgress` takes a `score: number` and draws a color-coded SVG gauge; `GradeBadge` takes a `grade: string` and renders a colored pill — so they are safe to export as low-risk building blocks for custom summary displays.
+
+## Out of Scope
+
+- Components below this set remain unexported: `SignalCard`, `DiagnosticItem`, `FilterButton`, individual signal-metadata panels, and `scoreColors.ts` / its color-utility functions. Concrete consumer demand is the gate for future additions.
+- No changes to `tsconfig.react.json` — it already covers `src/app/components/**/*`.
+- No changes to the `"."` (CLI / `format()`) entry — `src/index.ts` is untouched.
+- No changes to `package.json` exports map — all new exports are accessible through the existing `./react` entry.
+- No version bump — managed by lerna at release time.
+
+## Decisions
+
+### `ApiMetadataCard` is a new file, not an inline refactor
+
+The stats bar is extracted to `packages/formatter-html/src/app/components/ApiMetadataCard.tsx`. The private `StatItem` helper moves with it and stays private to that file. `SummaryCard` imports `ApiMetadataCard` from the new file. This gives consumers a named import they can use independently, and keeps `SummaryCard` focused on layout orchestration.
+
+### `showApiMetadata` defaults to `true` for backward compatibility
+
+`SummaryCard`'s existing behavior (always showing the stats bar) is preserved for all current consumers. Setting `showApiMetadata: false` hides `ApiMetadataCard`. The prop name mirrors the existing `apiMetadata` prop name, making the toggle discoverable.
+
+### `DiagnosticsSection` is included alongside `SummaryCard` and `DimensionCard`
+
+The three components together constitute the complete top-level visible structure of a scorecard. Exporting all three gives consumers full freedom to compose custom layouts.
+
+### `CircularProgress` and `GradeBadge` are exported as primitives
+
+Both have stable, minimal props (`score: number` and `grade: string` respectively). The color logic is internal — consumers get correct JAIRF color-coding automatically.
+
+### Prop interface names are locked
+
+`SummaryCardProps`, `DimensionCardProps`, `DiagnosticsSectionProps`, `CircularProgressProps`, `GradeBadgeProps`, `ApiMetadataCardProps`. These match the interface declarations in each source file.
+
+### Consumer test is required
+
+Beyond green CI and grep checks, a manual consumer import test verifying all six components are importable from the built `dist/react/react.js` is required before merge.
+
+## Constraints
+
+- **Adding exports is non-breaking; removing is not** (`react.ts` design principle, `specs/tech-stack.md`). All six components become permanent public API on merge.
+- **`SummaryCard` API change must be backward-compatible.** The new `showApiMetadata` prop is optional with default `true`. Existing callers that do not pass it see no behavioral change.
+- **Two isolated TS worlds** (`specs/tech-stack.md`, `CLAUDE.md`). Only the `tsconfig.react.json` world (`src/app/`) is touched.
+- **React/react-dom stay optional peerDependencies.** No new runtime dependencies.
+- **No mocks in tests** (`specs/tech-stack.md`). SSR smoke tests use real `renderToStaticMarkup` against real component imports.
+
+## Context
+
+Phase 14 shipped the `./react` entry with `Scorecard` as the sole exported component. Phase 24 added the `detail` prop and established the pattern for widening the entry incrementally. Phase 25 makes the building blocks directly accessible: consumers can now compose custom scorecards using the top-level structural components (`SummaryCard`, `DimensionCard`, `DiagnosticsSection`), control the stats bar's visibility or placement via `ApiMetadataCard` / `showApiMetadata`, and build novel score displays using the score-gauge and grade-badge primitives.
+
+The `ApiMetadataCard` extraction is an internal refactor of `SummaryCard` that happens to produce an exported component. It does not change `SummaryCard`'s rendered output by default. See `docs/architecture.md` §4 for the dual-entry layout and the rationale for keeping `"."` and `"./react"` as isolated build targets.

--- a/specs/2026-09-08-export-summarycard-dimensioncard-react/validation.md
+++ b/specs/2026-09-08-export-summarycard-dimensioncard-react/validation.md
@@ -1,0 +1,143 @@
+# Phase 25 Validation — Export SummaryCard and DimensionCard from `./react` Entry
+
+## Definition of Done
+
+All of the following must be true before this branch is merged.
+
+### 1. `ApiMetadataCard` is a new file with an exported props interface
+
+`packages/formatter-html/src/app/components/ApiMetadataCard.tsx` must exist and contain `export interface ApiMetadataCardProps` with an `apiMetadata: ApiMetadata` field. Structural check — read the file.
+
+### 2. `SummaryCard` accepts `showApiMetadata` and hides the stats bar when false
+
+```bash
+grep 'showApiMetadata' packages/formatter-html/src/app/components/SummaryCard.tsx
+grep 'ApiMetadataCard' packages/formatter-html/src/app/components/SummaryCard.tsx
+```
+
+Both must exit 0. Confirm `SummaryCard` no longer contains an inline `StatItem` function (that helper moved to `ApiMetadataCard.tsx`).
+
+### 3. All six prop interfaces are exported from their source files
+
+```bash
+grep 'export interface SummaryCardProps' packages/formatter-html/src/app/components/SummaryCard.tsx
+grep 'export interface DimensionCardProps' packages/formatter-html/src/app/components/DimensionCard.tsx
+grep 'export interface DiagnosticsSectionProps' packages/formatter-html/src/app/components/DiagnosticsSection.tsx
+grep 'export interface CircularProgressProps' packages/formatter-html/src/app/components/CircularProgress.tsx
+grep 'export interface GradeBadgeProps' packages/formatter-html/src/app/components/GradeBadge.tsx
+grep 'export interface ApiMetadataCardProps' packages/formatter-html/src/app/components/ApiMetadataCard.tsx
+```
+
+All six must exit 0.
+
+### 4. `react.ts` exports all six components and their prop interfaces
+
+Structural check — read `packages/formatter-html/src/app/react.ts` and confirm it contains:
+- Six `export { default as … }` lines for the new components
+- Six `export type { …Props }` lines for their interfaces
+- No removal of the existing `Scorecard`, `DetailLevel`, `DETAIL_LEVELS`, `DEFAULT_DETAIL`, or type-model re-exports
+
+### 5. Build succeeds and all new symbols appear in `dist/react/react.d.ts`
+
+```bash
+npm run build:react -w @jentic/api-scorecard-formatter-html
+grep 'SummaryCard' packages/formatter-html/dist/react/react.d.ts
+grep 'DimensionCard' packages/formatter-html/dist/react/react.d.ts
+grep 'DiagnosticsSection' packages/formatter-html/dist/react/react.d.ts
+grep 'CircularProgress' packages/formatter-html/dist/react/react.d.ts
+grep 'GradeBadge' packages/formatter-html/dist/react/react.d.ts
+grep 'ApiMetadataCard' packages/formatter-html/dist/react/react.d.ts
+```
+
+`build:react` exits 0; all six `grep` commands exit 0.
+
+### 6. Sub-components remain unexported
+
+```bash
+grep -E 'SignalCard|DiagnosticItem|FilterButton|StatItem' packages/formatter-html/src/app/react.ts
+```
+
+Must exit non-zero (no matches).
+
+### 7. `SummaryCard showApiMetadata: false` hides the stats bar
+
+SSR smoke test in `components.test.tsx` renders `SummaryCard` with `showApiMetadata: false` and asserts the output does not contain the string `OPERATIONS`. This confirms the `ApiMetadataCard` is conditionally mounted, not hidden via CSS.
+
+### 8. All SSR smoke tests pass
+
+```bash
+npm test -w @jentic/api-scorecard-formatter-html
+```
+
+Exits 0. `packages/formatter-html/test/components.test.tsx` must exist and include passing tests for: `SummaryCard` (default and `showApiMetadata: false`), `DimensionCard`, `DiagnosticsSection`, `CircularProgress`, `GradeBadge`, and `ApiMetadataCard`. Each test renders with minimal props via `renderToStaticMarkup` and asserts a non-empty, `undefined`-free string.
+
+### 9. Existing tests still pass
+
+```bash
+npm test -w @jentic/api-scorecard-formatter-html
+```
+
+Exits 0. All pre-existing tests in `app.test.tsx`, `signals.test.tsx`, and `format.test.ts` pass without modification. In particular, the `SummaryCard` extraction must not break the `Scorecard` detail-prop tests in `app.test.tsx` (which render `Scorecard` wrapping `SummaryCard`).
+
+### 10. Lint passes
+
+```bash
+npm run lint -w @jentic/api-scorecard-formatter-html
+```
+
+Exits 0 across all modified and new files.
+
+### 11. `tsconfig.react.json` is unchanged
+
+```bash
+git diff packages/formatter-html/tsconfig.react.json
+```
+
+Must produce no output — the existing `include` already covers `src/app/components/**/*`.
+
+### 12. README documents all six components
+
+`packages/formatter-html/README.md` must mention `SummaryCard` (including `showApiMetadata` prop), `DimensionCard`, `DiagnosticsSection`, `CircularProgress`, `GradeBadge`, and `ApiMetadataCard` as available imports from `@jentic/api-scorecard-formatter-html/react`. Structural check — read the relevant section.
+
+### 13. CLAUDE.md reflects the new export surface
+
+`.claude/CLAUDE.md` must name the six exported components as the `./react` public surface and note that `SignalCard` and below remain unexported. Structural check — read the relevant paragraph.
+
+### 14. Manual consumer import test
+
+After running `npm run build -w @jentic/api-scorecard-formatter-html`, run from the repo root:
+
+```bash
+node --input-type=module <<'EOF'
+import {
+  SummaryCard, DimensionCard, DiagnosticsSection,
+  CircularProgress, GradeBadge, ApiMetadataCard,
+} from './packages/formatter-html/dist/react/react.js';
+if (typeof SummaryCard !== 'function') throw new Error('SummaryCard');
+if (typeof DimensionCard !== 'function') throw new Error('DimensionCard');
+if (typeof DiagnosticsSection !== 'function') throw new Error('DiagnosticsSection');
+if (typeof CircularProgress !== 'function') throw new Error('CircularProgress');
+if (typeof GradeBadge !== 'function') throw new Error('GradeBadge');
+if (typeof ApiMetadataCard !== 'function') throw new Error('ApiMetadataCard');
+console.log('consumer import: OK');
+EOF
+```
+
+Must print `consumer import: OK` and exit 0.
+
+### 15. Roadmap ✅ marker is present
+
+```bash
+grep -F " ✅" specs/roadmap.md | grep -F "Phase 25"
+```
+
+Must exit 0.
+
+## Not Required
+
+- Python tests — no Python code is touched.
+- E2E tests — the CLI `--format html` path uses the `"."` entry's `format()` function, which is unchanged.
+- Docker image build — no container changes.
+- `package.json` exports map changes — no new subpath entries needed.
+- Breaking-change analysis — all changes are additive; `SummaryCard`'s new prop is optional with a backward-compatible default.
+- Browser / interactive testing of `DiagnosticsSection` filter state — the SSR smoke test covers initial render only; interactive state is internal implementation detail.

--- a/specs/roadmap.md
+++ b/specs/roadmap.md
@@ -371,6 +371,18 @@ prop that defaults to `diagnostics` (backward-compatible, renders everything pre
 `summary | dimensions | signals | diagnostics` to progressively restrict output. `DetailLevel` is
 added to `packages/formatter-html/src/app/` and re-exported from the `./react` entry. Refs #341.
 
+## Phase 25 — Export SummaryCard and DimensionCard from `./react` Entry
+
+**Goal:** Export `SummaryCard`, `DimensionCard`, and their prop interfaces from the `./react` entry so consumers can compose custom layouts without re-implementing rendering.
+**Depends on:** none (self-contained — builds on Phase 14's `./react` entry and Phase 24's detail prop, both already shipped)
+**Priority:** Medium–High
+
+- Export `SummaryCard`, `DimensionCard`, and their prop interfaces (`SummaryCardProps`, `DimensionCardProps`) from `packages/formatter-html/src/app/react.ts`.
+- Confirm both components are included in the transpiled `dist/react/` output (verify `tsconfig.react.json` covers the new exports; no changes expected but must be checked).
+- Add SSR smoke tests in `packages/formatter-html/test/` confirming `SummaryCard` and `DimensionCard` render without crashing when consumed as direct imports with minimal props.
+- Keep all components below `SummaryCard`/`DimensionCard` (`SignalCard`, `CircularProgress`, `GradeBadge`, individual metadata panels, etc.) unexported — concrete consumer demand is the gate for future additions.
+- Update `README.md` and `.claude/CLAUDE.md` to document the expanded `./react` public surface.
+
 ## Later Phases (Not Yet Planned)
 
 - `--min-score N` as a first-class CLI flag for CI gating — `score --min-score 70` exits non-zero (proposed exit code `9 — score below threshold`; codes `7`/`8` are taken by `RATE_LIMITED`/`LLM_FAILURE`) when `summary.score < N`. This is the *CLI-flag* form; Phase 19's GitHub Action already gates on the score in its wrapper (reading `summary.score` from `--format json`), so the flag is only needed for non-Action integrators. Deferred until such demand surfaces; integrators can already gate manually with `jq` on the JSON output. Recipe to document when this lands: `score --min-score 70 --format json -o report.json && upload report.json`.


### PR DESCRIPTION
Spec scaffold for **Phase 25: Export SummaryCard and DimensionCard from `./react` Entry** from `specs/roadmap.md`.

This PR adds **spec files only** - no code changes. Implementation follows in a separate PR once this spec is approved.

### Scope

This phase widens the `./react` entry of `@jentic/api-scorecard-formatter-html` to export six React components: `SummaryCard`, `DimensionCard`, `DiagnosticsSection`, `CircularProgress`, `GradeBadge`, and a new `ApiMetadataCard`. The stats bar currently embedded in `SummaryCard` (operations / schemas / tags / security scheme counts) is extracted into `ApiMetadataCard`, which `SummaryCard` then uses internally. A new `showApiMetadata` prop on `SummaryCard` (default `true`, backward-compatible) controls whether the card renders. Consumers can suppress it or place `ApiMetadataCard` anywhere independently.
### Out of Scope
 - `SignalCard`, `DiagnosticItem`, `FilterButton`, signal-metadata panels, and `scoreColors.ts` remain unexported
 - No changes to the `"."` (CLI) entry, `tsconfig.react.json`, or `package.json` exports map

### Key decisions
 - **`ApiMetadataCard` is a new standalone component** - extracted from `SummaryCard`'s stats bar; `StatItem` helper stays private inside it - **`showApiMetadata` defaults to `true`** - preserves existing `SummaryCard` behavior for all current callers
 - **`DiagnosticsSection`, `CircularProgress`, `GradeBadge` included** - full top-level structural set plus pure UI primitives
 - **Prop interface names locked** - `SummaryCardProps`, `DimensionCardProps`, `DiagnosticsSectionProps`, `CircularProgressProps`, `GradeBadgeProps`, `ApiMetadataCardProps`
 - **Consumer import test required** before merge (manual + automated SSR smoke tests)

## Files

 - `specs/2026-09-08-export-summarycard-dimensioncard-react/requirements.md`
 - `specs/2026-09-08-export-summarycard-dimensioncard-react/plan.md`
 - `specs/2026-09-08-export-summarycard-dimensioncard-react/validation.md`

## Review guidance

Reviewers should verify:
 - The phase goal is captured faithfully (see `specs/roadmap.md` Phase 25)
 - The `ApiMetadataCard` extraction approach and `showApiMetadata` default are correct
 - Plan task groups are appropriately granular and cover all the moving parts
 - Validation gates are realistic (especially the consumer import test and `showApiMetadata: false` smoke test)

Refs: `specs/roadmap.md` Phase 25; #342