### PR TITLE
fix(deps): hoist conventional-commits-filter to fix release pipeline

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@types/mocha": "^10.0.10",
         "@types/node": "^26.0.0",
         "chai": "^6.2.2",
-        "conventional-commits-filter": "^6.0.1",
+        "conventional-commits-filter": "6.0.1",
         "copyfiles": "^2.4.1",
         "eslint": "^9.39.1",
         "eslint-config-prettier": "^10.1.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@types/mocha": "^10.0.10",
         "@types/node": "^26.0.0",
         "chai": "^6.2.2",
+        "conventional-commits-filter": "^6.0.1",
         "copyfiles": "^2.4.1",
         "eslint": "^9.39.1",
         "eslint-config-prettier": "^10.1.8",
@@ -2305,9 +2306,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2322,9 +2320,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2339,9 +2334,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2356,9 +2348,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6282,16 +6271,6 @@
         "node": ">=22"
       }
     },
-    "node_modules/conventional-changelog-writer/node_modules/conventional-commits-filter": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-6.0.1.tgz",
-      "integrity": "sha512-cs+LadpH7Kpw0M3k8wurk+sOVVDAENA0iK4OBOrkL94j5lEVYRJ4j3zd2bhY9qgzyrPqthdcYT3axzRN7AliMg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=22"
-      }
-    },
     "node_modules/conventional-changelog/node_modules/@conventional-changelog/git-client": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@conventional-changelog/git-client/-/git-client-3.1.2.tgz",
@@ -6348,6 +6327,16 @@
       "bin": {
         "conventional-commits-parser": "dist/cli/index.js"
       },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/conventional-commits-filter": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-6.0.1.tgz",
+      "integrity": "sha512-cs+LadpH7Kpw0M3k8wurk+sOVVDAENA0iK4OBOrkL94j5lEVYRJ4j3zd2bhY9qgzyrPqthdcYT3axzRN7AliMg==",
+      "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=22"
       }
@@ -6430,16 +6419,6 @@
       },
       "funding": {
         "url": "https://ko-fi.com/dangreen"
-      }
-    },
-    "node_modules/conventional-recommended-bump/node_modules/conventional-commits-filter": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-6.0.1.tgz",
-      "integrity": "sha512-cs+LadpH7Kpw0M3k8wurk+sOVVDAENA0iK4OBOrkL94j5lEVYRJ4j3zd2bhY9qgzyrPqthdcYT3axzRN7AliMg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=22"
       }
     },
     "node_modules/conventional-recommended-bump/node_modules/conventional-commits-parser": {
@@ -9790,16 +9769,6 @@
       },
       "engines": {
         "node": "^22.13.0 || ^24.0.0 || ^26.0.0"
-      }
-    },
-    "node_modules/lerna/node_modules/conventional-commits-filter": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-6.0.1.tgz",
-      "integrity": "sha512-cs+LadpH7Kpw0M3k8wurk+sOVVDAENA0iK4OBOrkL94j5lEVYRJ4j3zd2bhY9qgzyrPqthdcYT3axzRN7AliMg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=22"
       }
     },
     "node_modules/lerna/node_modules/conventional-commits-parser": {

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "@types/mocha": "^10.0.10",
     "@types/node": "^26.0.0",
     "chai": "^6.2.2",
+    "conventional-commits-filter": "^6.0.1",
     "copyfiles": "^2.4.1",
     "eslint": "^9.39.1",
     "eslint-config-prettier": "^10.1.8",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "overrides": {
     "@conventional-changelog/git-client": {
-      "conventional-commits-filter": "^3.0.0"
+      "conventional-commits-filter": "6.0.1"
     }
   },
   "devDependencies": {
@@ -44,7 +44,7 @@
     "@types/mocha": "^10.0.10",
     "@types/node": "^26.0.0",
     "chai": "^6.2.2",
-    "conventional-commits-filter": "^6.0.1",
+    "conventional-commits-filter": "6.0.1",
     "copyfiles": "^2.4.1",
     "eslint": "^9.39.1",
     "eslint-config-prettier": "^10.1.8",


### PR DESCRIPTION
conventional-changelog@8.1.0 nests @conventional-changelog/git-client@3.1.2 which imports conventional-commits-filter, but omits it from its own deps. npm ci in CI installs the lock file subtree strictly, leaving the package unresolvable. Adding it at root hoists it to node_modules/ so any nested consumer can find it.

Breakage introduced by a Dependabot lock file regeneration that upgraded conventional-changelog to 8.1.0.
